### PR TITLE
Fix ASS subtitles, add subtitle customization, reorder URL view

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ with VLC-inspired UI and TV remote-friendly navigation.
 - **VLC-style UI** — dark slate-blue theme matching the cone icon
 - **Full TV remote support** — D-pad navigation, OK/BACK, media keys
   (Play/Pause/Stop/FF/RW), audio + subtitle track picker
+- **External subtitles** — SRT / VTT / ASS·SSA / SAMI sidecar files and
+  embedded MP4/MKV text tracks, painted by the app (AVPlay can't render text
+  subs on this firmware), with **customisable size, font, position and
+  background** under Settings → Subtitle appearance
 - **No native code** — pure HTML/CSS/JS so it runs on any Tizen TV with a
   Public-tier developer cert. No partner-cert or platform-side requirements.
 

--- a/tizen-web-vlc/css/style.css
+++ b/tizen-web-vlc/css/style.css
@@ -195,10 +195,20 @@ button:focus { outline: none; }
 }
 
 .presets {
-    margin-top: 32px;
+    margin-top: 40px;
+    width: 100%;
+    max-width: 1080px;
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
+}
+.presets-label {
+    width: 100%;
+    font-size: 16px;
+    color: var(--fg-dim);
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    margin-bottom: 14px;
 }
 .preset {
     background: var(--bg-card);
@@ -339,13 +349,18 @@ button:focus { outline: none; }
 /* AVPlay subtitle overlay — for embedded text/subtitle tracks selected via
  * the CC menu.  AVPlay fires onsubtitlechange(duration, text, ...) and we
  * paint into this element.  HTML5 <track> handles its own rendering. */
+/* Size + font come from the user's Settings via CSS custom properties set in
+ * SubtitleStyle.apply(); position + background come from the sub-pos-*/sub-bg
+ * classes toggled on this element.  Defaults below match the medium/sans/
+ * bottom/none preset so the overlay looks right even before apply() runs. */
 #subtitle-overlay {
     position: absolute;
     left: 8%; right: 8%;
     bottom: 8%;
     text-align: center;
     color: #fff;
-    font-size: 36px;
+    font-size: var(--sub-size, 36px);
+    font-family: var(--sub-font, 'Segoe UI', 'Helvetica Neue', Helvetica, Arial, sans-serif);
     font-weight: 500;
     line-height: 1.3;
     text-shadow:
@@ -355,8 +370,28 @@ button:focus { outline: none; }
          2px -2px 0 rgba(0,0,0,.85),
         -2px -2px 0 rgba(0,0,0,.85);
     pointer-events: none;
-    white-space: pre-line;
     z-index: 50;            /* above the video plane, below OSDs */
+}
+/* Position presets.  Bottom is the default; middle/top free the opposite
+ * anchor so the block grows in the right direction. */
+#subtitle-overlay.sub-pos-bottom { top: auto; bottom: 8%; transform: none; }
+#subtitle-overlay.sub-pos-top    { bottom: auto; top: 8%; transform: none; }
+#subtitle-overlay.sub-pos-middle { top: 50%; bottom: auto; transform: translateY(-50%); }
+
+/* The cue text lives in a .sub-line span so a translucent box (when enabled)
+ * hugs the text instead of spanning the full 8%-to-8% width. */
+#subtitle-overlay .sub-line {
+    display: inline;
+    white-space: pre-line;
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
+}
+#subtitle-overlay.sub-bg .sub-line {
+    background: rgba(0,0,0,.65);
+    padding: .08em .35em;
+    border-radius: 6px;
+    /* Outline is redundant over a solid box — drop the heavy shadow there. */
+    text-shadow: 0 0 3px rgba(0,0,0,.8);
 }
 
 #view-player {

--- a/tizen-web-vlc/index.html
+++ b/tizen-web-vlc/index.html
@@ -71,21 +71,25 @@
         <input id="url-input" type="text" inputmode="url"
                placeholder="rtsp://… · https://…/playlist.m3u8 · file:///opt/usr/media/…"
                data-focus>
-        <div class="presets">
-            <button class="preset" data-url="http://vjs.zencdn.net/v/oceans.mp4">Oceans (MP4, short)</button>
-            <button class="preset" data-url="https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8">HLS test (Mux)</button>
-            <button class="preset" data-url="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4">Big Buck Bunny (MP4)</button>
-            <button class="preset" data-url="https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_16x9/bipbop_16x9_variant.m3u8">Apple BipBop (HLS, 16:9)</button>
-            <button class="preset" data-url="https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd">DASH test (Akamai)</button>
-            <button class="preset" data-url="rtsp://9627b0bf2a7b.entrypoint.cloud.wowza.com:1935/app-p5260J38/66abe4b9_stream1">My Wowza RTSP</button>
-            <button class="preset" data-url="rtsp://170.93.143.139:554/rtplive/470011e600ef003a004ee33696235daa">FAA RTSP (public)</button>
-        </div>
     </div>
 
     <div class="actions">
         <button class="btn primary" data-action="open-current-url">Play</button>
         <button class="btn ghost"   data-action="fetch-remote-url">📲 Get URL from device</button>
         <button class="btn ghost"   data-action="back-home">Cancel</button>
+    </div>
+
+    <!-- Sample inputs sit below the primary actions so the remote lands on
+         Play first; the chips are a secondary, try-it convenience. -->
+    <div class="presets">
+        <div class="presets-label">Or try a sample stream</div>
+        <button class="preset" data-url="http://vjs.zencdn.net/v/oceans.mp4">Oceans (MP4, short)</button>
+        <button class="preset" data-url="https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8">HLS test (Mux)</button>
+        <button class="preset" data-url="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4">Big Buck Bunny (MP4)</button>
+        <button class="preset" data-url="https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_16x9/bipbop_16x9_variant.m3u8">Apple BipBop (HLS, 16:9)</button>
+        <button class="preset" data-url="https://dash.akamaized.net/akamai/bbb_30fps/bbb_30fps.mpd">DASH test (Akamai)</button>
+        <button class="preset" data-url="rtsp://9627b0bf2a7b.entrypoint.cloud.wowza.com:1935/app-p5260J38/66abe4b9_stream1">My Wowza RTSP</button>
+        <button class="preset" data-url="rtsp://170.93.143.139:554/rtplive/470011e600ef003a004ee33696235daa">FAA RTSP (public)</button>
     </div>
 
     <p class="url-drop-hint">Paste a URL from your phone, tablet or laptop — pair once under <b>Settings</b>.</p>
@@ -196,6 +200,26 @@
             <button class="settings-row" data-action="setting-auto-play">
                 <div class="settings-label">Auto-play next file</div>
                 <div class="settings-value" id="setting-auto-play-value">Off</div>
+            </button>
+        </div>
+
+        <h2 class="settings-section-title">Subtitle appearance</h2>
+        <div class="settings-group">
+            <button class="settings-row" data-action="setting-subtitle-size">
+                <div class="settings-label">Subtitle size</div>
+                <div class="settings-value" id="setting-subtitle-size-value">Medium</div>
+            </button>
+            <button class="settings-row" data-action="setting-subtitle-font">
+                <div class="settings-label">Subtitle font</div>
+                <div class="settings-value" id="setting-subtitle-font-value">Sans-serif</div>
+            </button>
+            <button class="settings-row" data-action="setting-subtitle-position">
+                <div class="settings-label">Subtitle position</div>
+                <div class="settings-value" id="setting-subtitle-position-value">Bottom</div>
+            </button>
+            <button class="settings-row" data-action="setting-subtitle-bg">
+                <div class="settings-label">Subtitle background</div>
+                <div class="settings-value" id="setting-subtitle-bg-value">None</div>
             </button>
         </div>
 

--- a/tizen-web-vlc/js/app.js
+++ b/tizen-web-vlc/js/app.js
@@ -167,7 +167,8 @@
         window.addEventListener('resize', Player.setDisplayRect);
 
         UI.showView('view-home');
-        updateRepeatButton();  // reflect saved repeat preference on OSD
+        updateRepeatButton();        // reflect saved repeat preference on OSD
+        SubtitleStyle.apply();       // push saved subtitle appearance onto the overlay
     }
 
     /* ── Action dispatcher ────────────────────────────────────────── */
@@ -201,6 +202,10 @@
             case 'setting-subtitle-lang': openLangPicker('subtitleLang', 'Preferred subtitle language', LanguageList.forSubtitle()); break;
             case 'setting-repeat-mode':   openRepeatPicker(); break;
             case 'setting-auto-play':     openAutoPlayPicker(); break;
+            case 'setting-subtitle-size':     openSubtitlePicker('subtitleSize',     'Subtitle size',       SubtitleStyle.forSize());     break;
+            case 'setting-subtitle-font':     openSubtitlePicker('subtitleFont',     'Subtitle font',       SubtitleStyle.forFont());     break;
+            case 'setting-subtitle-position': openSubtitlePicker('subtitlePosition', 'Subtitle position',   SubtitleStyle.forPosition()); break;
+            case 'setting-subtitle-bg':       openSubtitlePicker('subtitleBg',       'Subtitle background', SubtitleStyle.forBg());       break;
             case 'close-picker':       closePicker(); break;
         }
     }
@@ -645,6 +650,10 @@
         document.getElementById('setting-subtitle-lang-value').textContent = LanguageList.nameFor(Settings.get('subtitleLang'));
         document.getElementById('setting-repeat-mode-value').textContent   = (Settings.get('repeatMode') === 'one') ? 'Repeat one' : 'Off';
         document.getElementById('setting-auto-play-value').textContent     = Settings.get('autoPlay') ? 'On' : 'Off';
+        document.getElementById('setting-subtitle-size-value').textContent     = SubtitleStyle.nameForSize(Settings.get('subtitleSize'));
+        document.getElementById('setting-subtitle-font-value').textContent     = SubtitleStyle.nameForFont(Settings.get('subtitleFont'));
+        document.getElementById('setting-subtitle-position-value').textContent = SubtitleStyle.nameForPosition(Settings.get('subtitlePosition'));
+        document.getElementById('setting-subtitle-bg-value').textContent       = SubtitleStyle.nameForBg(Settings.get('subtitleBg'));
         // Mirror repeat state to the OSD button if visible
         updateRepeatButton();
     }
@@ -739,6 +748,18 @@
             Settings.set('repeatMode', val);
             refreshSettingsValues();
             UI.toast('Repeat: ' + (val === 'one' ? 'On' : 'Off'));
+        });
+    }
+    /* Subtitle-appearance pickers — share the generic option list, then
+     * re-apply the live style so changes show immediately on the overlay. */
+    function openSubtitlePicker(settingKey, title, options) {
+        pickerSetting = settingKey;
+        var cur = Settings.get(settingKey);
+        openPicker(title, options, cur, function (val) {
+            Settings.set(settingKey, val);
+            SubtitleStyle.apply();
+            refreshSettingsValues();
+            UI.toast(title + ' updated');
         });
     }
     function openAutoPlayPicker() {

--- a/tizen-web-vlc/js/player.js
+++ b/tizen-web-vlc/js/player.js
@@ -94,47 +94,16 @@ var Player = (function () {
         }
     }
 
-    /* Tell AVPlay to load an external subtitle file by path.  Samsung's
-     * own sample (SampleWebApps-PlayerAvplayWithSubtitles) uses this API:
-     * strip 'file://' from the URI, hand AVPlay the raw path,
-     * setSilentSubtitle(false) to make it deliver cues via the
-     * onsubtitlechange callback.
-     *
-     * BUG: on Tizen 5.0 this call triggers a silent seek to ~midway in the
-     * file when invoked AFTER play() has started.  So we only use it BEFORE
-     * play() (avOpen's prepare callback, READY state — no seek).  Every
-     * mid-playback switch goes through applyExternalSubtitleLive() instead,
-     * which renders with the JS time-poller and never moves the playhead. */
+    /* All external subtitles (SRT / VTT / ASS / SSA / SMI) are painted by the
+     * JS time-poller into #subtitle-overlay, never through AVPlay's native
+     * setExternalSubtitlePath.  The native path can't render ASS on this
+     * firmware and carried a mid-file seek bug; the poller handles every
+     * format, never moves the playhead, and lets the user's appearance
+     * settings apply.  currentExternalSub tracks which file is active so the
+     * CC menu can mark it and "Off" can clear it. */
     var currentExternalSub = null;
-    /* Pre-play ONLY: apply an external subtitle through AVPlay's native
-     * setExternalSubtitlePath while AVPlay is still in the READY state (i.e.
-     * from inside the prepareAsync callback, before play()).  In that state
-     * the call is safe.  Invoked mid-playback it triggers a silent seek to
-     * mid-file on Tizen 5.0 — for that case use applyExternalSubtitleLive()
-     * instead, which never moves the playhead.  Returns true on success. */
-    function setAvExternalSubtitle(sub) {
-        if (!sub) return false;
-        if (currentExternalSub === sub) return true;      // already loaded
-        var path = sub.fullPath || sub.uri || '';
-        if (path.indexOf('file://') === 0) {
-            path = path.slice(7);
-            try { path = decodeURIComponent(path); } catch (e) {}
-        }
-        if (!path) return false;
 
-        if (typeof Debug !== 'undefined') Debug.player('setExternalSubtitlePath (pre-play) ' + path);
-        try {
-            av().setExternalSubtitlePath(path);
-        } catch (e) {
-            if (typeof Debug !== 'undefined') Debug.error('setExternalSubtitlePath: ' + (e.message || e));
-            return false;
-        }
-        try { av().setSilentSubtitle(false); } catch (e) {}
-        currentExternalSub = sub;
-        return true;
-    }
-
-    /* Mid-playback external-subtitle switch that does NOT touch playback
+    /* External-subtitle switch that does NOT touch playback
      * state — this is the fix for the sub-switch flicker (issue #4).
      *
      * AVPlay's setExternalSubtitlePath() seeks to mid-file when called during
@@ -206,7 +175,17 @@ var Player = (function () {
             .replace(/&gt;/gi, '>').replace(/&quot;/gi, '"')
             .trim();
         if (!s) { hideSubtitleText(); return; }
-        el.textContent = s;
+        // Paint into a .sub-line span (not the overlay directly) so an
+        // optional translucent background box hugs the text rather than the
+        // full overlay width.  textContent keeps it injection-safe.
+        var line = el.firstChild;
+        if (!line || line.className !== 'sub-line') {
+            el.textContent = '';
+            line = document.createElement('span');
+            line.className = 'sub-line';
+            el.appendChild(line);
+        }
+        line.textContent = s;
         el.classList.remove('hidden');
         clearTimeout(subClearTimer);
 
@@ -253,7 +232,7 @@ var Player = (function () {
                 case 'vtt':                 extCues = parseVttCues(text); break;
                 case 'srt':                 extCues = parseSrtCues(text); break;
                 case 'ass':
-                case 'ssa':                 extCues = parseVttCues(assToVtt(text)); break;
+                case 'ssa':                 extCues = parseAssCues(text); break;
                 case 'smi':
                 case 'sami':                extCues = parseVttCues(smiToVtt(text)); break;
                 default:                    extCues = parseSrtCues(text); break;
@@ -291,28 +270,118 @@ var Player = (function () {
         else         showSubtitleText(extCues[idx].text, 0);   // 0 → no timer
     }
 
+    /* SRT/VTT timecode line, e.g. "00:01:02,500 --> 00:01:05,000" (both ,
+     * and . decimals accepted).  VTT also allows a 2-field "MM:SS.mmm" form
+     * with no hours, so the hours group is optional. */
+    var TIMECODE_RE =
+        /(?:(\d{1,2}):)?(\d{1,2}):(\d{2})[,.](\d{1,3})\s*-->\s*(?:(\d{1,2}):)?(\d{1,2}):(\d{2})[,.](\d{1,3})/;
+
+    function tcToSecs(h, m, s, frac) {
+        // frac is the raw decimal digits — normalise to milliseconds.
+        var f = String(frac || '0');
+        while (f.length < 3) f += '0';
+        f = f.slice(0, 3);
+        return (+h || 0) * 3600 + (+m || 0) * 60 + (+s || 0) + (+f) / 1000;
+    }
+
     function parseSrtCues(srt) {
         var out = [];
-        var blocks = String(srt || '').replace(/\r/g, '').split(/\n\n+/);
+        // Strip a leading UTF-8 BOM and CRs, then split into blank-line-
+        // separated blocks.  We scan each block for the timecode line rather
+        // than assuming it's the first/second line, so an optional numeric
+        // index, a VTT cue identifier, a stray leading blank line, or a NOTE
+        // block don't throw the parse off (the old code dropped the first
+        // cue whenever a blank line led the block).
+        var clean = String(srt || '').replace(/^\uFEFF/, '').replace(/\r/g, '');
+        var blocks = clean.split(/\n\n+/);
         for (var i = 0; i < blocks.length; i++) {
             var lines = blocks[i].split('\n');
-            // Skip optional numeric index
-            var idx = 0;
-            if (/^\d+$/.test(lines[idx])) idx++;
-            var m = /(\d\d):(\d\d):(\d\d)[,.](\d{3})\s*-->\s*(\d\d):(\d\d):(\d\d)[,.](\d{3})/.exec(lines[idx] || '');
-            if (!m) continue;
-            var start = (+m[1]) * 3600 + (+m[2]) * 60 + (+m[3]) + (+m[4]) / 1000;
-            var end   = (+m[5]) * 3600 + (+m[6]) * 60 + (+m[7]) + (+m[8]) / 1000;
-            var text  = lines.slice(idx + 1).join('\n').trim();
-            if (text) out.push({ start: start, end: end, text: text });
+            var tcIdx = -1, m = null;
+            for (var j = 0; j < lines.length; j++) {
+                m = TIMECODE_RE.exec(lines[j]);
+                if (m) { tcIdx = j; break; }
+            }
+            if (tcIdx < 0) continue;
+            var start = tcToSecs(m[1], m[2], m[3], m[4]);
+            var end   = tcToSecs(m[5], m[6], m[7], m[8]);
+            var text  = lines.slice(tcIdx + 1).join('\n').trim();
+            if (text && end > start) out.push({ start: start, end: end, text: text });
         }
         return out;
     }
     function parseVttCues(vtt) {
-        // Strip the WEBVTT header then treat the body like SRT (timecodes use
-        // dot-decimal; the regex in parseSrtCues accepts both . and ,).
-        var body = String(vtt || '').replace(/^WEBVTT[^\n]*\n/, '');
+        // Strip the WEBVTT header line then treat the body like SRT —
+        // parseSrtCues handles the rest (blank lines, cue ids, dot/comma).
+        var body = String(vtt || '').replace(/^\uFEFF/, '').replace(/^WEBVTT[^\n]*\n/, '');
         return parseSrtCues(body);
+    }
+
+    /* ASS / SSA → cues, parsed DIRECTLY into [{start,end,text}] rather than
+     * round-tripping through a VTT string (the old path lost the first cue
+     * and was brittle).  AVPlay's native renderer can't draw ASS on this
+     * firmware, so every ASS subtitle is painted through this poller path.
+     *
+     * Dialogue line:  Dialogue: Layer,Start,End,Style,Name,ML,MR,MV,Effect,Text
+     * Times are H:MM:SS.cc (centiseconds).  Override tags ({\an8} etc.),
+     * \N / \n line breaks and \h hard-spaces are normalised away. */
+    function parseAssCues(ass) {
+        var out = [];
+        var lines = String(ass || '').replace(/^\uFEFF/, '').replace(/\r/g, '').split('\n');
+        var fmt = null;
+        var inEvents = false;
+
+        for (var i = 0; i < lines.length; i++) {
+            var l = lines[i].trim();
+            if (l.charAt(0) === '[' && l.charAt(l.length - 1) === ']') {
+                inEvents = (l.toLowerCase() === '[events]');
+                continue;
+            }
+            if (!inEvents) continue;
+
+            if (l.toLowerCase().indexOf('format:') === 0) {
+                fmt = l.substring(7).split(',').map(function (s) { return s.trim().toLowerCase(); });
+                continue;
+            }
+            if (l.toLowerCase().indexOf('dialogue:') !== 0) continue;
+            if (!fmt) fmt = ['layer','start','end','style','name','marginl','marginr','marginv','effect','text'];
+
+            // Split into fmt.length-1 comma fields; the remainder is the Text
+            // field (which itself may contain commas).
+            var rest = l.substring(9).trim();
+            var parts = [];
+            var idx = 0;
+            for (var k = 0; k < fmt.length - 1; k++) {
+                var comma = rest.indexOf(',', idx);
+                if (comma < 0) break;
+                parts.push(rest.substring(idx, comma));
+                idx = comma + 1;
+            }
+            parts.push(rest.substring(idx));
+
+            var sI = fmt.indexOf('start'), eI = fmt.indexOf('end'), tI = fmt.indexOf('text');
+            if (sI < 0 || eI < 0 || tI < 0) continue;
+
+            var start = assTimeToSecs(parts[sI]);
+            var end   = assTimeToSecs(parts[eI]);
+            if (start == null || end == null || end <= start) continue;
+
+            var text = (parts[tI] || '')
+                .replace(/\{[^}]*\}/g, '')   // {\b1}, {\an8}, drawing tags …
+                .replace(/\\N/gi, '\n')      // hard + soft line breaks
+                .replace(/\\h/gi, ' ')       // hard space
+                .replace(/<[^>]+>/g, '')     // stray HTML
+                .trim();
+            if (text) out.push({ start: start, end: end, text: text });
+        }
+        // ASS dialogue lines aren't required to be in chronological order;
+        // the poller's scan assumes sorted cues, so sort by start.
+        out.sort(function (a, b) { return a.start - b.start; });
+        return out;
+    }
+    function assTimeToSecs(t) {
+        var m = /^\s*(\d+):(\d{1,2}):(\d{1,2})[.,](\d{1,3})\s*$/.exec(String(t || ''));
+        if (!m) return null;
+        return tcToSecs(m[1], m[2], m[3], m[4]);
     }
 
     var avPollTimer = null;
@@ -434,14 +503,20 @@ var Player = (function () {
                     avSetDisplayRect();
                     avSetDisplayMethod();
 
-                    /* Pre-apply preferred external subtitle BEFORE play() —
-                     * calling setExternalSubtitlePath after play() triggers a
-                     * silent seek to mid-file on Tizen 5.0.  Doing it here,
-                     * with AVPlay in the READY state, avoids the bug. */
+                    /* Pre-apply the preferred external subtitle BEFORE play()
+                     * through the JS time-poller, NOT AVPlay's native
+                     * setExternalSubtitlePath.  The native renderer can't draw
+                     * ASS/SSA on this firmware (and carried the mid-file seek
+                     * bug); the poller paints every format into
+                     * #subtitle-overlay, so it both fixes ASS and lets the
+                     * user's size/font/position settings apply.  Keep AVPlay's
+                     * own renderer silent so only our overlay shows.  (The CC
+                     * menu and applyLanguagePreferences use the same path
+                     * mid-playback.) */
                     if (typeof Settings !== 'undefined') {
                         var pref = Settings.get('subtitleLang');
                         var sub  = pickBestExternalSubtitle(pref);
-                        if (sub) setAvExternalSubtitle(sub);
+                        if (sub) applyExternalSubtitleLive(sub);
                     }
 
                     try { av().play(); } catch (e) {}

--- a/tizen-web-vlc/js/settings.js
+++ b/tizen-web-vlc/js/settings.js
@@ -7,24 +7,30 @@
 var Settings = (function () {
     var KEY = 'vlctv_settings_v1';
     var defaults = {
-        audioLang:        '',      // '' = auto (use file's default), or ISO code
-        subtitleLang:     'off',   // 'off' = no subs, '' = auto-pick first, or ISO code
-        repeatMode:       'off',   // 'off' | 'one'
-        autoPlay:         false    // auto-play the next file in the folder when one finishes
+        audioLang:        '',          // '' = auto (use file's default), or ISO code
+        subtitleLang:     'off',       // 'off' = no subs, '' = auto-pick first, or ISO code
+        repeatMode:       'off',       // 'off' | 'one'
+        autoPlay:         false,       // auto-play the next file in the folder when one finishes
+        // ── Subtitle appearance (applied to the painted overlay) ──────────
+        subtitleSize:     'medium',    // 'small' | 'medium' | 'large' | 'xlarge'
+        subtitleFont:     'sans',      // 'sans' | 'serif' | 'mono'
+        subtitlePosition: 'bottom',    // 'bottom' | 'middle' | 'top'
+        subtitleBg:       'none'       // 'none' | 'box'  (translucent box behind text)
     };
     var cache = null;
 
     function load() {
         if (cache) return cache;
+        var stored = {};
         try {
             var raw = localStorage.getItem(KEY);
-            var stored = raw ? JSON.parse(raw) : {};
-            cache = {};
-            for (var k in defaults)
-                cache[k] = (k in stored) ? stored[k] : defaults[k];
-        } catch (e) {
-            cache = { audioLang: '', subtitleLang: 'off', repeatMode: 'off', autoPlay: false };
-        }
+            stored = raw ? JSON.parse(raw) : {};
+        } catch (e) { stored = {}; }
+        // Build from defaults so newly-added keys always have a value, even
+        // when the stored blob predates them.
+        cache = {};
+        for (var k in defaults)
+            cache[k] = (stored && k in stored) ? stored[k] : defaults[k];
         return cache;
     }
     function save() {
@@ -141,5 +147,89 @@ var LanguageList = (function () {
                 if (langs[i].code === code) return langs[i].name;
             return code || 'Auto';
         }
+    };
+})();
+
+
+/* Subtitle-appearance options + their resolved CSS values.  Subtitles are
+ * painted by the app into #subtitle-overlay (AVPlay backend, both embedded
+ * and external cues) and by the browser into video::cue (HTML5 fallback),
+ * so apply() drives both surfaces from the saved Settings. */
+var SubtitleStyle = (function () {
+    var SIZE = [
+        { code: 'small',  name: 'Small',       px: 26 },
+        { code: 'medium', name: 'Medium',      px: 36 },
+        { code: 'large',  name: 'Large',       px: 48 },
+        { code: 'xlarge', name: 'Extra large', px: 60 }
+    ];
+    var FONT = [
+        { code: 'sans',  name: 'Sans-serif', css: "'Segoe UI','Helvetica Neue',Helvetica,Arial,sans-serif" },
+        { code: 'serif', name: 'Serif',      css: "Georgia,'Times New Roman',serif" },
+        { code: 'mono',  name: 'Monospace',  css: "'Consolas','Courier New',monospace" }
+    ];
+    var POSITION = [
+        { code: 'bottom', name: 'Bottom' },
+        { code: 'middle', name: 'Middle' },
+        { code: 'top',    name: 'Top' }
+    ];
+    var BG = [
+        { code: 'none', name: 'None (outline only)' },
+        { code: 'box',  name: 'Translucent box' }
+    ];
+
+    function find(list, code) {
+        for (var i = 0; i < list.length; i++) if (list[i].code === code) return list[i];
+        return list[0];
+    }
+    function nameFor(group, code) { return find(group, code).name; }
+
+    /* Read the four subtitle settings and push them onto the document: CSS
+     * custom properties (consumed by #subtitle-overlay) + a generated
+     * video::cue rule for the HTML5 backend.  Position is overlay-only —
+     * ::cue position is driven by the cue's own line setting, not CSS. */
+    function apply() {
+        if (typeof Settings === 'undefined') return;
+        var size = find(SIZE, Settings.get('subtitleSize'));
+        var font = find(FONT, Settings.get('subtitleFont'));
+        var pos  = find(POSITION, Settings.get('subtitlePosition'));
+        var bg   = Settings.get('subtitleBg');
+
+        var root = document.documentElement;
+        root.style.setProperty('--sub-size', size.px + 'px');
+        root.style.setProperty('--sub-font', font.css);
+
+        var ov = document.getElementById('subtitle-overlay');
+        if (ov) {
+            ov.classList.remove('sub-pos-bottom', 'sub-pos-middle', 'sub-pos-top');
+            ov.classList.add('sub-pos-' + pos.code);
+            ov.classList.toggle('sub-bg', bg === 'box');
+        }
+
+        // HTML5 <track> rendering: inject/update a ::cue rule.
+        var styleEl = document.getElementById('subtitle-cue-style');
+        if (!styleEl) {
+            styleEl = document.createElement('style');
+            styleEl.id = 'subtitle-cue-style';
+            document.head.appendChild(styleEl);
+        }
+        styleEl.textContent =
+            'video::cue{' +
+            'font-size:' + size.px + 'px;' +
+            'font-family:' + font.css + ';' +
+            (bg === 'box' ? 'background:rgba(0,0,0,.65);'
+                          : 'background:transparent;') +
+            '}';
+    }
+
+    return {
+        forSize:     function () { return SIZE; },
+        forFont:     function () { return FONT; },
+        forPosition: function () { return POSITION; },
+        forBg:       function () { return BG; },
+        nameForSize: function (c) { return nameFor(SIZE, c); },
+        nameForFont: function (c) { return nameFor(FONT, c); },
+        nameForPosition: function (c) { return nameFor(POSITION, c); },
+        nameForBg:   function (c) { return nameFor(BG, c); },
+        apply:       apply
     };
 })();


### PR DESCRIPTION
ASS subtitle fixes (js/player.js):
- Route all external subs (incl. preferred-language pre-play) through the JS time-poller / #subtitle-overlay instead of AVPlay's native setExternalSubtitlePath, which can't render ASS/SSA on this firmware.
- Replace the lossy ASS->VTT-string round-trip with a dedicated parseAssCues() that parses ASS directly; sort out-of-order dialogue lines.
- Rewrite parseSrtCues/parseVttCues to scan each block for the timecode line (fixes the silently-dropped first cue) and strip a UTF-8 BOM; accept the no-hours VTT timecode form.

Subtitle customization (Settings -> Subtitle appearance):
- New persisted settings: size, font, position, background.
- SubtitleStyle.apply() drives #subtitle-overlay (CSS vars + position/bg classes) and video::cue for the HTML5 fallback; cue text wrapped in a .sub-line span so the optional box hugs the text.

UX (index.html):
- Move the sample-stream preset chips below the Play/Get URL/Cancel actions.