### PR TITLE
Handle MKV / DTS / TrueHD honestly instead of mislabeling MKV unsuppo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ with VLC-inspired UI and TV remote-friendly navigation.
 ## Tested on
 
 - Samsung UE55RU7020WXXN (2019, Tizen 5.0)
+- Samsung S90C (2023, Tizen 6.5) — MKV plays via AVPlay; DTS/TrueHD audio
+  tracks can't be decoded by the TV (auto-skipped to a supported track when
+  the file has one)
 - Should run on any Tizen TV from 2017 onward with AVPlay support
 
 ## Installation

--- a/tizen-web-vlc/js/app.js
+++ b/tizen-web-vlc/js/app.js
@@ -584,17 +584,26 @@
         // Hint for opaque codec-not-supported errors
         var hint = '';
         var uri = state.playingUri || '';
-        var isMkv = /\.mkv($|\?)/i.test(uri) || /MKV not supported/i.test(msg);
+        // AVPlay-failed-on-MKV is signalled with the "MKV_CODEC:" prefix from
+        // player.js.  The old "MKV not supported" HTML5 message is kept in the
+        // match for safety, but AVPlay DOES support the MKV container on these
+        // TVs — a failure is a codec inside it, most often DTS/TrueHD audio.
+        var isMkv = /^MKV_CODEC:/.test(msg) || /\.mkv($|\?)/i.test(uri) || /MKV not supported/i.test(msg);
 
         if (isMkv) {
-            // Replace the raw error with a clear headline; the hint carries
-            // the actionable detail.
-            msg = 'MKV files aren\'t supported on this TV';
-            hint = 'The TV\'s WebView can\'t decode MKV containers directly. ' +
-                   'Remux to MP4 — no quality loss, takes seconds:\n\n' +
-                   '    ffmpeg -i input.mkv -c copy output.mp4\n\n' +
-                   'If the audio codec is FLAC or DTS, also re-encode audio:\n\n' +
-                   '    ffmpeg -i input.mkv -c:v copy -c:a aac -b:a 192k output.mp4';
+            msg = 'This MKV couldn’t be played';
+            hint = 'The MKV container itself is fine on this TV — the problem is a ' +
+                   'track inside it.  Most often that’s DTS or TrueHD audio, which ' +
+                   'Samsung TVs can’t decode (they only pass those through to an AV ' +
+                   'receiver over HDMI).  Less often it’s AV1 or 10-bit HEVC video.\n\n' +
+                   'Try, in order:\n' +
+                   '  1. Open the CC / track menu and pick another audio track (many ' +
+                   'releases include an AC3 or AAC track alongside the DTS one).\n' +
+                   '  2. Re-encode just the audio (keeps the video untouched, fast even ' +
+                   'on a Raspberry Pi):\n' +
+                   '       ffmpeg -i input.mkv -c:v copy -c:a ac3 -b:a 640k output.mkv\n' +
+                   '  3. If the video also won’t play, remux/transcode the whole file:\n' +
+                   '       ffmpeg -i input.mkv -c:v copy -c:a aac -b:a 192k output.mp4';
         } else if (/unknown error|not supported|invalid|stuck loading|unsupported source/i.test(msg)) {
             hint = 'The file or stream may use a codec or container that this TV can\'t ' +
                    'decode (HEVC 10-bit, AV1, DTS-HD MA, VP9 Profile 2, etc.). ' +
@@ -694,7 +703,9 @@
             codecHtml += '<div class="codec"><span class="name">USB local files</span>' +
                          '<span class="status ok">✓ Via HTML5 video</span></div>';
             codecHtml += '<div class="codec"><span class="name">MKV container</span>' +
-                         '<span class="status maybe">? Remux to MP4</span></div>';
+                         '<span class="status ok">✓ Via AVPlay</span></div>';
+            codecHtml += '<div class="codec"><span class="name">DTS / TrueHD audio</span>' +
+                         '<span class="status no">✗ TV can’t decode</span></div>';
             codecHtml += '</div>';
 
             box.innerHTML = rows.join('') + codecHtml;
@@ -953,35 +964,81 @@
      * HTML5 external subs, lang tag) matches the preferred ISO code and
      * activates it.  Subtitle 'off' explicitly disables.  No-op if the
      * preference is empty (Auto). */
+    /* Pick the audio track to play, balancing two goals:
+     *   1. the user's preferred audio language (Settings → audioLang), and
+     *   2. actually getting sound — Samsung TVs can't decode DTS/TrueHD, so a
+     *      track flagged `unsupported` by Player.getTracks() plays silently.
+     * Priority: preferred-language + decodable  >  any decodable  >  the
+     * preferred-language track even if silent (at least it's the right
+     * language).  Only switches when it improves on the current/default track,
+     * and surfaces a toast so the user understands a silent file. */
+    function chooseAudioTrack(tracks) {
+        var audio = (tracks && tracks.audio) || [];
+        if (!audio.length) return;
+
+        var pref = (Settings.get('audioLang') || '').toLowerCase();
+        function langMatches(t) {
+            if (!pref) return false;
+            var l = (t.lang || '').toLowerCase();
+            var nm = (t.name || '').toLowerCase();
+            return l === pref ||
+                   (l && pref.length === 2 && l.indexOf(pref) === 0) ||
+                   (l && l.length === 2 && pref.indexOf(l) === 0) ||
+                   nm.indexOf(pref) >= 0;
+        }
+        function firstSupported(list) {
+            for (var i = 0; i < list.length; i++) if (!list[i].unsupported) return list[i];
+            return null;
+        }
+
+        var active = null;
+        for (var i = 0; i < audio.length; i++) if (audio[i].active) { active = audio[i]; break; }
+
+        var target = null;
+        if (pref) {
+            var matchSupported = null, matchAny = null;
+            for (var j = 0; j < audio.length; j++) {
+                if (!langMatches(audio[j])) continue;
+                if (!matchAny) matchAny = audio[j];
+                if (!audio[j].unsupported && !matchSupported) matchSupported = audio[j];
+            }
+            if (matchSupported)      target = matchSupported;          // ideal
+            else if (matchAny)       target = firstSupported(audio) || matchAny;
+        }
+        // No preference (or none usable): only step in if the current track is
+        // undecodable but a decodable one exists.
+        if (!target && active && active.unsupported) target = firstSupported(audio);
+
+        if (target && (!active || target.index !== active.index)) {
+            Player.setAudioTrack(target.index);
+            if (active && active.unsupported && !target.unsupported)
+                UI.toast('Switched to ' + (target.codec || 'a decodable') +
+                         ' audio — TV can’t decode ' + (active.codec || 'the default track'));
+            if (typeof Debug !== 'undefined')
+                Debug.player('chooseAudioTrack → ' + target.name +
+                             ' (active was ' + (active ? active.name : 'none') + ')');
+        }
+
+        // If we still can't get a decodable track, tell the user why it's silent.
+        var finalT = target || active;
+        if (finalT && finalT.unsupported && !firstSupported(audio)) {
+            UI.toast('No audio track this TV can decode (' +
+                     (finalT.codec || 'DTS/TrueHD') + ') — playing without sound');
+        }
+    }
+
     var prefsAppliedFor = null;
     function applyLanguagePreferences() {
         // Only apply once per file to avoid clobbering manual selections
         if (prefsAppliedFor === state.playingUri) return;
         prefsAppliedFor = state.playingUri;
 
-        var prefAudio = Settings.get('audioLang');
         var prefSub   = Settings.get('subtitleLang');
         var tracks    = Player.getTracks();
 
-        // Audio: only act if user has a non-empty preference
-        if (prefAudio) {
-            var want = prefAudio.toLowerCase();
-            for (var i = 0; i < tracks.audio.length; i++) {
-                var t = tracks.audio[i];
-                var lang = (t.lang || '').toLowerCase();
-                var nm   = (t.name || '').toLowerCase();
-                // Match on explicit lang field first (ISO 2 or 3 letter),
-                // then fall back to substring match on the display name.
-                if (lang === want ||
-                    (lang && want.length === 2 && lang.indexOf(want) === 0) ||
-                    (lang && lang.length === 2 && want.indexOf(lang) === 0) ||
-                    nm.indexOf(want) >= 0) {
-                    Player.setAudioTrack(t.index);
-                    if (typeof Debug !== 'undefined') Debug.player('applied audio pref ' + prefAudio + ' → ' + t.name);
-                    break;
-                }
-            }
-        }
+        // Audio: honour the language preference, but never leave the user on a
+        // track the TV can't decode (DTS/TrueHD) when a playable one exists.
+        chooseAudioTrack(tracks);
 
         // Subtitle: 'off' explicit, '' auto (no action), code → match
         if (prefSub === 'off') {

--- a/tizen-web-vlc/js/player.js
+++ b/tizen-web-vlc/js/player.js
@@ -766,6 +766,21 @@ var Player = (function () {
                 extractAndAppendEmbeddedSubs(url);
 
                 avOpen(url, function (reason) {
+                    // For MKV there's no point falling back to the HTML5
+                    // <video> element — Tizen's chromium can't demux Matroska,
+                    // so it would only produce the misleading "MKV not
+                    // supported" message.  AVPlay DOES support the MKV
+                    // container on these TVs, so a failure here is almost
+                    // always a codec inside it (most often DTS/TrueHD audio,
+                    // sometimes AV1 / HEVC-10bit video).  Surface that instead.
+                    if (isMkvUrl(url)) {
+                        if (typeof Debug !== 'undefined')
+                            Debug.player('AV MKV failed, no HTML5 fallback: ' + reason);
+                        try { if (av()) av().close(); } catch (e) {}
+                        avStopPolling();
+                        emit('onerror', 'MKV_CODEC: ' + reason);
+                        return;
+                    }
                     if (typeof Debug !== 'undefined')
                         Debug.player('AV local-file fallback → HTML5: ' + reason);
                     try { if (av()) av().close(); } catch (e) {}
@@ -869,12 +884,28 @@ var Player = (function () {
         if (backend === BACKEND_AVPLAY) avSetDisplayRect();
     }
 
+    /* Audio codecs Samsung TVs can't decode in-app, no matter the firmware:
+     *   - DTS / DTS-HD / DTS:X  — Samsung dropped DTS licensing years ago.
+     *   - TrueHD / MLP (Dolby)  — only ever handled via HDMI/eARC bitstream
+     *                             passthrough to an AVR, never decoded in-app.
+     * AVPlay reports these in extra_info.fourCC as DTS / DTSHD / TRUEHD / MLP
+     * (spelling varies by firmware), so match loosely.  When the only/active
+     * audio track uses one of these, the file plays silently (or AVPlay errors
+     * out entirely) — the fix is to switch to another track or transcode the
+     * audio, never to "fix the container". */
+    function isUndecodableAudioCodec(codec) {
+        // Leading word boundary only — catches the firmware spelling variants
+        // (DTS, DTS-HD, DTSHD, DTS:X, DCA, TRUEHD, TrueHD, MLP) without a
+        // trailing \b dropping the no-separator forms like "DTSHD".
+        return /\b(dts|dca|truehd|mlp)/i.test(String(codec || ''));
+    }
+
     /* AVPlay's extra_info field is a JSON string with fields like
      *   { "language":"eng", "channels":2, "fourCC":"AAC", ... }
      * for audio, and similar for subtitles.  Older firmwares hand back
-     * a plain string instead.  Return a {label, lang} pair either way. */
+     * a plain string instead.  Return {label, lang, codec} either way. */
     function parseAvExtraInfo(raw) {
-        if (!raw) return { label: '', lang: '' };
+        if (!raw) return { label: '', lang: '', codec: '' };
         var s = String(raw).trim();
         var obj = null;
         if (s.charAt(0) === '{') {
@@ -883,14 +914,15 @@ var Player = (function () {
         if (!obj) {
             // Not JSON — use as-is, and look for a 3-letter ISO code in it
             var m = s.match(/\b([a-z]{2,3})\b/i);
-            return { label: s, lang: m ? m[1].toLowerCase() : '' };
+            return { label: s, lang: m ? m[1].toLowerCase() : '', codec: s };
         }
-        var lang = (obj.language || obj.lang || '').toString().toLowerCase();
+        var lang  = (obj.language || obj.lang || '').toString().toLowerCase();
+        var codec = (obj.fourCC || obj.codec || '').toString();
         var parts = [];
         if (lang) parts.push(lang.toUpperCase());
-        if (obj.fourCC)   parts.push(obj.fourCC);
+        if (codec) parts.push(codec);
         if (obj.channels) parts.push(obj.channels + 'ch');
-        return { label: parts.join(' · ') || s, lang: lang };
+        return { label: parts.join(' · ') || s, lang: lang, codec: codec };
     }
 
     /* ── Track info ─────────────────────────────────────────────────────
@@ -939,10 +971,16 @@ var Player = (function () {
                     var parsed = parseAvExtraInfo(t.extra_info);
                     if (t.type === 'VIDEO') continue;
                     if (t.type === 'AUDIO') {
+                        var unsupported = isUndecodableAudioCodec(parsed.codec);
                         out.audio.push({
                             index:  t.index,
-                            name:   parsed.label || ('Audio ' + t.index),
+                            // Flag codecs the TV can't decode right in the
+                            // label so the user knows why a track is silent.
+                            name:   (parsed.label || ('Audio ' + t.index)) +
+                                    (unsupported ? ' — not supported by TV' : ''),
                             lang:   parsed.lang || '',
+                            codec:  parsed.codec || '',
+                            unsupported: unsupported,
                             type:   'AVPLAY',
                             active: (t.index === activeAudioIdx)
                         });


### PR DESCRIPTION
…rted

MKV plays via AVPlay on these TVs; the "MKV not supported" message came from a futile fallback to the HTML5 <video> element (which can't demux Matroska) after AVPlay failed on a codec inside the file — almost always DTS/TrueHD audio, which Samsung TVs can't decode in-app.

player.js:
- isUndecodableAudioCodec(): detect DTS / DTS-HD / DTSHD / DTS:X / DCA / TrueHD / MLP from AVPlay's extra_info fourCC (firmware spelling variants).
- parseAvExtraInfo() now returns the codec; getTracks() flags unsupported audio tracks (codec + `unsupported`) and annotates the menu label.
- For MKV, drop the pointless HTML5 fallback and emit an accurate "MKV_CODEC:" error instead of the container-blaming message.

app.js:
- chooseAudioTrack(): auto-switch off a DTS/TrueHD default to a decodable track (AC3/EAC3/AAC) when the file has one, honouring the audio-language preference first; toasts when a file is genuinely silent.
- Rewrite the MKV error overlay to point at the audio codec with ordered fixes (pick another track / audio-only re-encode / full remux).
- TV-info panel: MKV shown as supported via AVPlay; DTS/TrueHD as not decodable.

README: note S90C (Tizen 6.5) behaviour.