### PR TITLE
Make SMB connection debuggable, fail fast, and Back-able on errors

### DIFF
--- a/tizen-web-vlc/js/smb.js
+++ b/tizen-web-vlc/js/smb.js
@@ -17,6 +17,22 @@ var SMB = (function () {
     var BASE = 'http://127.0.0.1:8127';
     var CREDS_KEY = 'vlctv_smb_v1';
 
+    /* All SMB-side activity goes to the PC debug listener under one tag so the
+     * connection flow is actually traceable (the old code called Debug.log,
+     * which doesn't exist, so nothing was ever sent). */
+    function dbg(msg) { if (typeof Debug !== 'undefined' && Debug.send) Debug.send('SMB', msg); }
+
+    /* Pull the service's own ring-buffer log and forward the tail to the PC
+     * listener — this is how we see the NEGOTIATE / auth / socket errors that
+     * happen inside the background service, which can't reach the PC itself. */
+    function dumpServiceLogs() {
+        getJson(BASE + '/smb/debug/logs', function (err, res) {
+            if (err || !res || !res.logs) { dbg('service logs unavailable: ' + (err ? err.message : 'none')); return; }
+            var logs = res.logs, from = Math.max(0, logs.length - 40);
+            for (var i = from; i < logs.length; i++) dbg('svc ' + logs[i]);
+        });
+    }
+
     /* ── credentials ───────────────────────────────────────────────────── */
     function getCreds() {
         try { return JSON.parse(localStorage.getItem(CREDS_KEY) || '{}'); }
@@ -59,18 +75,19 @@ var SMB = (function () {
         try {
             var appId = tizen.application.getCurrentApplication().appInfo.id;
             var pkgId = appId.split('.')[0];
+            dbg('launching service ' + pkgId + '.smbproxy');
             tizen.application.launch(pkgId + '.smbproxy',
-                function () { if (typeof Debug !== 'undefined') Debug.log && Debug.log('smb svc launch ok'); },
-                function (e) { if (typeof Debug !== 'undefined') Debug.error && Debug.error('smb svc launch: ' + e.message); });
+                function () { dbg('service launch ok'); },
+                function (e) { dbg('service launch error: ' + (e && e.message)); });
         } catch (e) {
-            if (typeof Debug !== 'undefined') Debug.error && Debug.error('smb launch threw: ' + e.message);
+            dbg('service launch threw: ' + e.message);
         }
         // The service may already be running from a previous open; poll either way.
         var tries = 0;
         (function poll() {
             getJson(BASE + '/smb/ping', function (err) {
-                if (!err) return cb(null);
-                if (++tries > 18) return cb(new Error('SMB service did not start'));
+                if (!err) { dbg('service ping ok after ' + tries + ' tries'); return cb(null); }
+                if (++tries > 18) { dbg('service ping gave up after ' + tries + ' tries: ' + err.message); return cb(new Error('SMB service did not start')); }
                 setTimeout(poll, 300);
             });
         })();
@@ -78,13 +95,16 @@ var SMB = (function () {
 
     function connect(cb) {
         var c = getCreds();
+        dbg('connect -> ' + (c.host || '?') + '\\' + (c.share || '?') +
+            ' user=' + (c.anonymous ? '(guest)' : (c.user || '(none)')));
         postJson(BASE + '/smb/connect', {
             host: c.host, share: c.share, user: c.user || '',
             pass: c.pass || '', domain: c.domain || '', port: c.port || 445,
             anonymous: !!c.anonymous
         }, function (err, res) {
-            if (err) return cb(err);
-            if (!res.ok) return cb(new Error(res.error || 'connect failed'));
+            if (err) { dbg('connect transport error: ' + err.message); return cb(err); }
+            if (!res.ok) { dbg('connect rejected: ' + (res.error || 'unknown')); return cb(new Error(res.error || 'connect failed')); }
+            dbg('connect ok: dialect=' + res.dialect + ' signing=' + res.signing);
             cb(null, res);
         });
     }
@@ -221,12 +241,21 @@ var SMB = (function () {
         document.getElementById('browse-list').innerHTML =
             '<li><span class="icon">…</span><span class="name">Connecting…</span></li>';
 
+        // Install Back BEFORE the async work so it works on the "connecting" and
+        // error screens too — otherwise Back falls through to the app's global
+        // handler, which still thinks we're on the home view and can't exit here.
+        pathStack = [];
+        setupBack();
+
+        dbg('openBrowser');
         ensureService(function (err) {
-            if (err) { showError(err.message); return; }
+            if (err) { dbg('ensureService failed: ' + err.message); showError(err.message); return; }
             connect(function (err2) {
-                if (err2) { showError('Could not connect: ' + err2.message); return; }
-                pathStack = [];
-                setupBack();
+                if (err2) {
+                    showError('Could not connect: ' + err2.message + ' — press Back to return');
+                    dumpServiceLogs();   // surface the service-side NEGOTIATE/auth/socket trail
+                    return;
+                }
                 render('');
             });
         });

--- a/tizen-web-vlc/service/service.js
+++ b/tizen-web-vlc/service/service.js
@@ -236,13 +236,30 @@ SmbConnection.prototype._send = function (command, body, creditCharge, cb) {
 /* ── connect: open socket, then NEGOTIATE → SESSION_SETUP → TREE_CONNECT ──── */
 SmbConnection.prototype.connect = function (done) {
     var self = this;
+
+    // Single-shot completion: a connect can only succeed or fail once, so guard
+    // against the timer / 'error' / 'close' all racing to call back.
+    var settled = false;
+    function finish(err) {
+        if (settled) return; settled = true;
+        clearTimeout(timer);
+        done && done(err);
+    }
+    // net.connect to a dead/filtered host:445 otherwise hangs for the OS TCP
+    // timeout (minutes), so the HTTP POST just times out with no explanation.
+    var timer = setTimeout(function () {
+        log('SMB_CONNECT_TIMEOUT', self.host + ':' + self.port);
+        self._die('connect timeout');
+        finish(new Error('connect timed out to ' + self.host + ':' + self.port + ' (host/port/firewall?)'));
+    }, 8000);
+
     this.socket = net.connect(this.port, this.host, function () {
         log('SMB_TCP_OPEN', self.host + ':' + self.port);
         self._negotiate(function (err) {
-            if (err) return done(err);
+            if (err) return finish(err);
             self._sessionSetup(function (err2) {
-                if (err2) return done(err2);
-                self._treeConnect(done);
+                if (err2) return finish(err2);
+                self._treeConnect(finish);
             });
         });
     });
@@ -251,8 +268,8 @@ SmbConnection.prototype.connect = function (done) {
         self.rxbuf = Buffer.concat([self.rxbuf, chunk]);
         self._frame();
     });
-    this.socket.on('error', function (e) { self._die('sock:' + e.message); done && done(e); });
-    this.socket.on('close', function () { self._die('closed'); });
+    this.socket.on('error', function (e) { log('SMB_SOCK_ERR', e.message); self._die('sock:' + e.message); finish(e); });
+    this.socket.on('close', function () { self._die('closed'); finish(new Error('connection closed before ready')); });
 };
 
 SmbConnection.prototype._negotiate = function (cb) {


### PR DESCRIPTION
Diagnostics + UX fixes after testing the SMB share on a real TV. (Good news: the background service launches and answers `/smb/ping`, so Tizen TV *does* run it — the failure is in the connect step.)

## Nothing reached the debug listener
`smb.js` logged via `Debug.log`, which **doesn't exist** on the `Debug` object (it has `info/warn/error/send/...`), so every SMB log call silently no-op'd. Now:
- Every step (launch, ping, connect, reject, errors) goes through `Debug.send` under an **`SMB`** tag.
- On a connect failure, the client pulls the **service's own** ring-buffer log (`GET /smb/debug/logs`) and forwards the tail to the PC listener — that's the only way to see the NEGOTIATE / auth / socket trail that happens *inside* the background service.

## "Could not connect: timeout" with no detail
`service.js` had no socket connect timeout, so `net.connect(host:445)` to an unreachable/filtered host hangs for the OS TCP timeout (minutes) and `/smb/connect` never responds — the client just times out at 20s with a bare "timeout".
- Added an **8s connect timeout** that fails with a clear `connect timed out to <host>:<port> (host/port/firewall?)`.
- Guarded the connect callback so the timer / `error` / `close` can't fire it more than once.

## Back didn't work on the error screen
`SMB.openBrowser` shows `view-browse` but never sets the app's `state.view`, and only installed its Back handler **on success**. On the "Connecting…"/error screen, Back fell through to the global handler — which still thinks the view is Home — and tried to exit the app instead of going back.
- The Back handler is now installed **before** the async connect, so Back returns to Home from the connecting and error screens. The error text now also says "press Back to return".

## Next: remote text entry
Separately asked about typing into the SMB fields with the remote instead of the on-screen keyboard — handling that in a follow-up once we settle the scope.