### PR TITLE
Polyfill Buffer.alloc/Buffer.from for the TV's legacy Node runtime

### DIFF
--- a/tizen-web-vlc/service/service.js
+++ b/tizen-web-vlc/service/service.js
@@ -28,6 +28,22 @@ var http   = require('http');
 var net    = require('net');
 var crypto = require('crypto');
 
+/* The TV's Node runtime predates Buffer.alloc / Buffer.from (added in Node
+ * 4.5/5.10) — it only has the legacy `new Buffer()` constructor. Without this
+ * shim every SMB request throws "Buffer.alloc is not a function" the moment a
+ * connection is built, so /smb/ping works but /smb/connect hangs and times out.
+ * Polyfill onto the legacy constructor, matching alloc's zero-fill semantics. */
+if (typeof Buffer.alloc !== 'function') {
+    Buffer.alloc = function (size, fill) {
+        var b = new Buffer(size);
+        b.fill(fill === undefined ? 0 : fill);
+        return b;
+    };
+}
+if (typeof Buffer.from !== 'function') {
+    Buffer.from = function (data, encoding) { return new Buffer(data, encoding); };
+}
+
 var PORT        = 8127;
 var LISTEN_HOST = '127.0.0.1';
 
@@ -697,11 +713,19 @@ function handleConnect(req, res) {
         // Drop any stale connection for this share so creds changes take effect.
         var key = connKey(creds);
         if (conns[key]) { try { conns[key]._die('reconnect'); } catch (e) {} delete conns[key]; }
-        getConn(creds, function (err, c) {
-            if (err) { log('CONNECT_FAIL', err.message); return sendJson(res, 502, { ok: false, error: err.message }); }
-            lastCreds = creds;
-            sendJson(res, 200, { ok: true, dialect: '0x' + c.dialect.toString(16), signing: c.signing });
-        });
+        // Wrap so a synchronous throw (e.g. a missing runtime API) returns an
+        // error to the client immediately instead of bubbling to the uncaught
+        // handler and leaving the request to time out.
+        try {
+            getConn(creds, function (err, c) {
+                if (err) { log('CONNECT_FAIL', err.message); return sendJson(res, 502, { ok: false, error: err.message }); }
+                lastCreds = creds;
+                sendJson(res, 200, { ok: true, dialect: '0x' + c.dialect.toString(16), signing: c.signing });
+            });
+        } catch (e) {
+            log('CONNECT_THREW', e && e.message);
+            sendJson(res, 500, { ok: false, error: 'service error: ' + (e && e.message) });
+        }
     });
 }
 


### PR DESCRIPTION
## The actual cause of the connect timeout

Your on-TV debug trail (now visible thanks to the logging PR) showed:

```
[SMB] connect -> 192.168.2.195\Media user=(guest)
[SMB] connect transport error: timeout
[SMB] svc ... SMB_PROXY_LISTENING 127.0.0.1:8127
[SMB] svc ... UNCAUGHT Buffer.alloc is not a function
```

The set's Node runtime predates `Buffer.alloc` / `Buffer.from` (added in Node 4.5 / 5.10) — it only has the legacy `new Buffer()` constructor. `/smb/ping` worked because it touches no Buffers, but `/smb/connect` builds an `SmbConnection` whose constructor calls `Buffer.alloc(...)` → throws → the request never gets a response → the client times out at 20s.

## Fix

- Polyfill `Buffer.alloc` / `Buffer.from` onto `new Buffer()` when missing, matching `alloc`'s zero-fill semantics (the SMB2/MD4 code relies on zeroed buffers).
- Wrap the connect handler in try/catch so a synchronous throw returns a `500` to the client immediately instead of bubbling to the uncaught handler and hanging.

## Note on this specific server

I verified from WSL that `192.168.2.195:445` is reachable and the **`Media` share exists** (it's a Synology NAS). But **guest access to it failed** in testing — Synology disables guest by default. After this fix the connect will actually attempt NEGOTIATE/auth and the debug log will show the real SMB status; you'll most likely need to enter a real **username/password** instead of guest.