### PR TITLE
Make the debug log endpoint configurable in Settings

### DIFF
--- a/tizen-web-vlc/index.html
+++ b/tizen-web-vlc/index.html
@@ -251,6 +251,14 @@
             </div>
         </div>
 
+        <h2 class="settings-section-title">Debug logging</h2>
+        <div class="settings-group">
+            <button class="settings-row" id="dbg-enabled"><div class="settings-label">Send debug logs</div><div class="settings-value" id="dbg-enabled-val">Off</div></button>
+            <label class="settings-row settings-row-input"><span class="settings-label">Listener IP</span><input id="dbg-host" type="text" placeholder="192.168.1.50"></label>
+            <label class="settings-row settings-row-input"><span class="settings-label">Listener port</span><input id="dbg-port" type="text" placeholder="9999"></label>
+            <button id="dbg-save" class="settings-row"><span class="settings-label">Save debug settings</span></button>
+        </div>
+
         <h2 class="settings-section-title">TV Information</h2>
         <div class="tvinfo" id="tvinfo">Loading…</div>
     </div>

--- a/tizen-web-vlc/js/debug.js
+++ b/tizen-web-vlc/js/debug.js
@@ -1,15 +1,29 @@
-/* Debug telemetry — fire-and-forget HTTP POSTs to the PC's listener.
+/* Debug telemetry — fire-and-forget HTTP POSTs to a PC listener.
  *
- * Set DEBUG = false (or remove this file's <script> tag) for production.
- * The PowerShell HTTP listener you already have on port 9999 will receive
- * each line — just like the canary did.
+ * The endpoint is configured at runtime under Settings → Debug logging and
+ * persisted in localStorage, so anyone can point it at their own machine
+ * instead of editing a hard-coded IP. It ships DISABLED: nothing is sent
+ * until you turn it on and enter your listener's IP. (A simple HTTP listener
+ * on the chosen port — e.g. the PowerShell one on 9999 — receives each line.)
  */
 
 var Debug = (function () {
-    var DEBUG    = true;
-    var PC_URL   = 'http://192.168.2.22:9999/';
-    var startTs  = Date.now();
-    var seq      = 0;
+    var CFG_KEY = 'vlctv_debug_v1';
+    var startTs = Date.now();
+    var seq     = 0;
+
+    function loadCfg() {
+        try {
+            var c = JSON.parse(localStorage.getItem(CFG_KEY) || '{}');
+            return { enabled: !!c.enabled, host: c.host || '', port: c.port || 9999 };
+        } catch (e) {
+            return { enabled: false, host: '', port: 9999 };
+        }
+    }
+    var cfg = loadCfg();
+
+    function active() { return cfg.enabled && !!cfg.host; }
+    function url()    { return 'http://' + cfg.host + ':' + cfg.port + '/'; }
 
     function ts() {
         var t = (Date.now() - startTs) / 1000;
@@ -17,19 +31,20 @@ var Debug = (function () {
     }
 
     function send(tag, msg) {
-        if (!DEBUG) return;
+        if (!active()) return;
         seq++;
         var payload = ts() + ' #' + seq + ' [' + tag + '] ' +
                       (typeof msg === 'string' ? msg : JSON.stringify(msg));
+        var dest = url();
         try {
             var x = new XMLHttpRequest();
-            x.open('POST', PC_URL, true);
+            x.open('POST', dest, true);
             x.setRequestHeader('Content-Type', 'text/plain');
             x.send(payload);
         } catch (e) {
             try {
                 var img = new Image();
-                img.src = PC_URL + '?msg=' + encodeURIComponent(payload) + '&_=' + Date.now();
+                img.src = dest + '?msg=' + encodeURIComponent(payload) + '&_=' + Date.now();
             } catch (e2) {}
         }
     }
@@ -44,6 +59,44 @@ var Debug = (function () {
     function browse(m){ send('BROWSE', m); }
     function key   (m){ send('KEY',    m); }
 
+    /* Update + persist the endpoint config (called by the settings form). */
+    function configure(c) {
+        cfg = {
+            enabled: !!(c && c.enabled),
+            host: (c && c.host) ? String(c.host).trim() : '',
+            port: (c && parseInt(c.port, 10)) || 9999
+        };
+        try { localStorage.setItem(CFG_KEY, JSON.stringify(cfg)); } catch (e) {}
+    }
+    function getConfig() { return { enabled: cfg.enabled, host: cfg.host, port: cfg.port }; }
+
+    /* Wire the Settings form (toggle + IP + port + Save). */
+    function wireForm() {
+        var save = document.getElementById('dbg-save');
+        if (!save) return;
+        var hostEl = document.getElementById('dbg-host');
+        var portEl = document.getElementById('dbg-port');
+        var enBtn  = document.getElementById('dbg-enabled');
+        var enVal  = document.getElementById('dbg-enabled-val');
+        if (hostEl) hostEl.value = cfg.host || '';
+        if (portEl) portEl.value = cfg.port || 9999;
+        var enState = cfg.enabled;
+        function paint() { if (enVal) enVal.textContent = enState ? 'On' : 'Off'; }
+        paint();
+        if (enBtn) enBtn.addEventListener('click', function () { enState = !enState; paint(); });
+        save.addEventListener('click', function () {
+            configure({ enabled: enState,
+                        host: hostEl ? hostEl.value : '',
+                        port: portEl ? portEl.value : 9999 });
+            if (typeof UI !== 'undefined' && UI.toast) UI.toast('Debug settings saved');
+            if (active()) send('INFO', 'debug logging enabled from settings → ' + url());
+        });
+    }
+    if (document.readyState === 'loading')
+        document.addEventListener('DOMContentLoaded', wireForm);
+    else
+        wireForm();
+
     /* Capture unhandled JS errors automatically */
     window.addEventListener('error', function (ev) {
         send('JSERR',
@@ -54,7 +107,8 @@ var Debug = (function () {
              ev.reason && ev.reason.message ? ev.reason.message : String(ev.reason));
     });
 
-    /* Boot banner — confirms the app loaded + the build it's from */
+    /* Boot banner — confirms the app loaded + the build it's from (only sent
+     * when logging is enabled and an endpoint is set). */
     send('BOOT',
          'VLC TV starting; UA=' + navigator.userAgent +
          '; href=' + location.href);
@@ -64,6 +118,7 @@ var Debug = (function () {
         info: info, warn: warn, error: error,
         view: view, action: action,
         player: player, browse: browse, key: key,
-        get enabled() { return DEBUG; }
+        configure: configure, getConfig: getConfig,
+        get enabled() { return cfg.enabled; }
     };
 })();


### PR DESCRIPTION
The debug listener IP was hard-coded (`http://192.168.2.22:9999/`), so anyone else who wanted to capture logs had to edit `debug.js` and rebuild. This moves it into the UI.

## What changed
- **Settings → Debug logging** (new section): a **Send debug logs** On/Off toggle, a **Listener IP** field, and a **Listener port** field (defaults to 9999), with a Save button.
- `debug.js` reads its endpoint from a persisted `localStorage` config instead of constants, and `Debug.configure()` updates it live.
- **Ships disabled.** Nothing is sent until you toggle it on *and* enter an IP — so a fresh install on anyone's TV is silent by default rather than firing at a stranger's old IP.

## Notes
- The remote number keys (from #20) already type into these fields, so the IP/port are enterable without the on-screen keyboard.
- Uses the same full-width settings-row layout and toggle-button pattern as the SMB section, so D-pad navigation lands on each field cleanly.
- Independent of the SMB Buffer-polyfill PR (#21) — different files.