### PR TITLE
Rebrand installer references: Jellyfin2Samsung → Apps2Samsung

### DIFF
--- a/.github/workflows/build-wgt.yml
+++ b/.github/workflows/build-wgt.yml
@@ -134,12 +134,12 @@ jobs:
 
 
             2. **Choose your installation method:**
-              ### ✅ Easy — via Jellyfin2Samsung (recommended)
-              Download and install automatically through [Jellyfin2Samsung](https://jellyfin2samsung.madebypatrick.nl/):
+              ### ✅ Easy — via Apps2Samsung (recommended)
+              Download and install automatically through [Apps2Samsung](https://apps2samsung.madebypatrick.nl/):
               - Open the app, select **Tizen Community** as the release channel
               - Pick **vlc-tizen-tv** and follow the on-screen steps
 
-              > Jellyfin2Samsung handles signing and sideloading for you.
+              > Apps2Samsung handles signing and sideloading for you.
 
               ---
                

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ files are published there by the build workflow.
 
 ### 2. Install the `.wgt`
 
-#### Install with Jellyfin2Samsung
+#### Install with Apps2Samsung
 
-Download the latest version from [Jellyfin2Samsung](https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases/latest) choose Tizen Community as release and choose vlc-tizen-tv.
+Download the latest version from [Apps2Samsung](https://github.com/Apps2Samsung/Apps2Samsung/releases/latest) choose Tizen Community as release and choose vlc-tizen-tv.
 
 Launch **VLC TV** from your TV's app list.
 


### PR DESCRIPTION
The installer was rebranded **Jellyfin2Samsung → Apps2Samsung**. Updates the references to the new name, site, and repo:

- **`.github/workflows/build-wgt.yml`** — the GitHub Release notes template: name + site `https://apps2samsung.madebypatrick.nl/`.
- **`README.md`** — install section: name + repo `https://github.com/Apps2Samsung/Apps2Samsung/releases/latest`.

No build-logic changes; release-notes/docs text only. Verified no `jellyfin2samsung` / `Samsung-Jellyfin-Installer` references remain.