### PR TITLE
Feed crypto real typed arrays for HMAC on the TV runtime

### DIFF
--- a/tizen-web-vlc/service/service.js
+++ b/tizen-web-vlc/service/service.js
@@ -121,8 +121,13 @@ function md4(buf) {
     out.writeUInt32LE(c >>> 0, 8); out.writeUInt32LE(d >>> 0, 12);
     return out;
 }
-function hmacMd5(key, data)    { return crypto.createHmac('md5',    key).update(data).digest(); }
-function hmacSha256(key, data) { return crypto.createHmac('sha256', key).update(data).digest(); }
+/* The TV's crypto rejects our polyfilled (legacy, non-Uint8Array) Buffers with
+ * "this is not a typed array", while accepting its own crypto.randomBytes()
+ * output — so hand crypto genuine typed arrays. No-op on real Node (Buffer is
+ * already a Uint8Array). */
+function toU8(b) { return (b instanceof Uint8Array) ? b : new Uint8Array(b); }
+function hmacMd5(key, data)    { return crypto.createHmac('md5',    toU8(key)).update(toU8(data)).digest(); }
+function hmacSha256(key, data) { return crypto.createHmac('sha256', toU8(key)).update(toU8(data)).digest(); }
 /* The TV's partial Buffer can't do string encodings ('ucs2'/'binary' throw
  * "<enc> is not a function"), so build/decode UTF-16LE and ASCII by hand. */
 function utf16le(str) {
@@ -837,4 +842,7 @@ var server = http.createServer(function (req, res) {
 
 server.listen(PORT, LISTEN_HOST, function () { log('SMB_PROXY_LISTENING', LISTEN_HOST + ':' + PORT); });
 
-process.on('uncaughtException', function (e) { log('UNCAUGHT', e && e.message); });
+process.on('uncaughtException', function (e) {
+    var where = (e && e.stack) ? String(e.stack).split('\n').slice(0, 4).join(' <- ') : '';
+    log('UNCAUGHT', (e && e.message) + (where ? ' | ' + where : ''));
+});


### PR DESCRIPTION
## Next partial-Buffer gap

With `Buffer.alloc` and the string encodings fixed, the connection reaches NTLM auth and then dies (confirmed on the correct NAS IP):

```
SMB_NEGOTIATE {dialect:0x210, signingRequired:false, maxRead:8388608}
UNCAUGHT this is not a typed array.
```

The only crypto primitive the auth path uses that NEGOTIATE didn't is `crypto.createHmac().update().digest()`. The TV's crypto accepts its own `crypto.randomBytes()` output but rejects our polyfilled **legacy (non-`Uint8Array`) Buffers** as HMAC key/data with "this is not a typed array".

## Fix
- `toU8(b)` wraps HMAC key/data in a real `Uint8Array` view before handing them to crypto. No-op on real Node (Buffer already is a `Uint8Array`); on the TV it gives crypto the typed array it wants.
- `uncaughtException` now logs the stack tail, so if any *other* runtime gap remains it's pinpointed by location, not just message.

## Verified
- Regression-tested against the real NAS (Patrick/Azge6czt) on full Node → still `{ok:true}` + lists the share, so the conversion doesn't break the working path.
- The TV-runtime fix can't be exercised from here, but the diagnosis matches the trail exactly and the stack logging will confirm on the next on-device run.

Stacks on top of the merged Buffer fixes; same `service.js`.