### PR TITLE
Add VLC Transcode Server companion (SMB→HLS) + TV pairing

### DIFF
--- a/.github/workflows/transcode-server-image.yml
+++ b/.github/workflows/transcode-server-image.yml
@@ -1,0 +1,61 @@
+name: Build transcode-server image
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'vlc-transcode-server/**'
+      - '.github/workflows/transcode-server-image.yml'
+    tags:
+      - 'transcode-v*'
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  # ghcr requires a lowercase image path.
+  IMAGE: ghcr.io/patrickst1991/vlc-transcode
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU (arm64 emulation for the ffmpeg layer)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive tags + labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=,format=short
+            type=match,pattern=transcode-v(.*),group=1
+
+      - name: Build and push (amd64 + arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: vlc-transcode-server
+          file: vlc-transcode-server/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/tizen-web-vlc/index.html
+++ b/tizen-web-vlc/index.html
@@ -219,6 +219,13 @@
             <button id="smb-save" class="settings-row"><span class="settings-label">Save SMB server</span></button>
         </div>
 
+        <h2 class="settings-section-title">Transcode server</h2>
+        <div class="settings-group">
+            <div class="settings-row"><div class="settings-label">Status</div><div class="settings-value" id="srv-status-val">Not paired</div></div>
+            <button id="srv-pair" class="settings-row" data-focus><span class="settings-label">Pair transcode server</span></button>
+            <button id="srv-unpair" class="settings-row"><span class="settings-label">Remove transcode server</span></button>
+        </div>
+
         <h2 class="settings-section-title">Subtitle appearance</h2>
         <div class="settings-group">
             <button class="settings-row" data-action="setting-subtitle-size">
@@ -284,6 +291,7 @@
 <script src="js/player.js"></script>
 <script src="js/qrcode.js"></script>
 <script src="js/url-drop.js"></script>
+<script src="js/server.js"></script>
 <script src="js/smb.js"></script>
 <script src="js/app.js"></script>
 </body>

--- a/tizen-web-vlc/js/server.js
+++ b/tizen-web-vlc/js/server.js
@@ -1,0 +1,146 @@
+/* server.js — pairing with, and routing playback through, the optional
+ * vlc-transcode-server companion (runs on the user's AM6b+ box).
+ *
+ * The idea: SMB browsing on the TV stays exactly as it is. The ONLY thing that
+ * changes is where the bytes come from when you press play. If a transcode
+ * server is paired, smb.js builds the playable URL from here
+ * (http://<server>/play?path=…) instead of the localhost smbproxy stream — so
+ * files the TV can't decode (DTS/TrueHD, heavy codecs) get transcoded on the box
+ * and arrive as TV-friendly HLS. If nothing is paired, smb.js falls back to the
+ * direct localhost stream and behaviour is unchanged.
+ *
+ * Pairing reuses the existing ntfy pairing code (UrlDrop.code()) but on a
+ * separate "-srv" topic so it never collides with "Get URL from device". The
+ * server posts its LAN URL + token there; we pull it once and store it.
+ *
+ * ES5 + XHR on purpose — safest on the Tizen 5.0 WebView.
+ */
+var TranscodeServer = (function () {
+    'use strict';
+
+    var STORE_KEY = 'vlctv_server_v1';
+    var NTFY_BASE = 'https://ntfy.sh';
+
+    function log(m) { if (typeof Debug !== 'undefined' && Debug.net) Debug.net('[server] ' + m); }
+
+    /* ── stored pairing ({url, token, name}) ───────────────────────────── */
+    function get() {
+        try { return JSON.parse(localStorage.getItem(STORE_KEY) || 'null'); }
+        catch (e) { return null; }
+    }
+    function set(s) {
+        try { localStorage.setItem(STORE_KEY, JSON.stringify(s || null)); } catch (e) {}
+    }
+    function clear() { try { localStorage.removeItem(STORE_KEY); } catch (e) {} }
+    function isPaired() { var s = get(); return !!(s && s.url); }
+
+    /* Build the URL AVPlay should open for an SMB-relative path. The server
+     * serves a live HLS manifest here (after transcoding/​remuxing as needed). */
+    function playUrl(path) {
+        var s = get();
+        if (!s || !s.url) return null;
+        var u = s.url.replace(/\/+$/, '') + '/play?path=' + encodeURIComponent(path);
+        if (s.token) u += '&token=' + encodeURIComponent(s.token);
+        return u;
+    }
+
+    /* Recognise our own play URLs so recent/watched tracking treats two routes
+     * to the same file consistently. */
+    function isPlayUrl(u) {
+        var s = get();
+        return !!(s && s.url && typeof u === 'string' && u.indexOf(s.url.replace(/\/+$/, '') + '/play') === 0);
+    }
+
+    /* ── pairing: pull the server's announcement off the -srv topic ─────── */
+    function topic() {
+        var code = (typeof UrlDrop !== 'undefined' && UrlDrop.code) ? UrlDrop.code() : '';
+        return 'vlctv-' + code + '-srv';
+    }
+
+    function xhrGet(url, cb) {
+        var done = false;
+        function finish(err, text) { if (done) return; done = true; cb(err, text); }
+        try {
+            var x = new XMLHttpRequest();
+            x.open('GET', url, true);
+            x.timeout = 10000;
+            x.onreadystatechange = function () {
+                if (x.readyState !== 4) return;
+                if (x.status >= 200 && x.status < 300) finish(null, x.responseText);
+                else finish(new Error('HTTP ' + x.status));
+            };
+            x.ontimeout = function () { finish(new Error('timeout')); };
+            x.onerror = function () { finish(new Error('network')); };
+            x.send();
+        } catch (e) { finish(e); }
+    }
+
+    /* ntfy poll returns newline-delimited JSON events; take the message body of
+     * the last "message" event and JSON.parse it into the announcement. */
+    function parseLatestAnnounce(text) {
+        var lines = String(text || '').split('\n'), latest = null;
+        for (var i = 0; i < lines.length; i++) {
+            var ln = lines[i].trim();
+            if (!ln) continue;
+            var ev = null;
+            try { ev = JSON.parse(ln); } catch (e) { continue; }
+            if (ev && ev.event === 'message' && ev.message) latest = ev.message;
+        }
+        if (!latest) return null;
+        try {
+            var ann = JSON.parse(latest);
+            if (ann && ann.type === 'vlc-transcode-server' && ann.url) return ann;
+        } catch (e) {}
+        return null;
+    }
+
+    /* Pull the announcement and store it. cb(err, announce). */
+    function pair(cb) {
+        var url = NTFY_BASE + '/' + encodeURIComponent(topic()) + '/json?poll=1';
+        log('pair GET ' + url);
+        xhrGet(url, function (err, text) {
+            if (err) return cb(err);
+            var ann = parseLatestAnnounce(text);
+            if (!ann) return cb(new Error('no server found — open the tool and press Pair there first'));
+            set({ url: ann.url, token: ann.token || '', name: ann.name || 'Transcode server' });
+            log('paired with ' + ann.name + ' @ ' + ann.url);
+            cb(null, ann);
+        });
+    }
+
+    /* ── Settings UI wiring ─────────────────────────────────────────────── */
+    function paintStatus() {
+        var el = document.getElementById('srv-status-val');
+        if (!el) return;
+        var s = get();
+        el.textContent = s && s.url ? (s.name || 'Paired') + ' · ' + s.url : 'Not paired';
+    }
+
+    function wireSettings() {
+        var pairBtn = document.getElementById('srv-pair');
+        var unpairBtn = document.getElementById('srv-unpair');
+        paintStatus();
+        if (pairBtn) pairBtn.addEventListener('click', function () {
+            if (typeof UI !== 'undefined' && UI.toast) UI.toast('Looking for your transcode server…');
+            pair(function (err) {
+                if (err) { if (UI && UI.toast) UI.toast('Pairing failed: ' + err.message); return; }
+                paintStatus();
+                if (UI && UI.toast) UI.toast('Transcode server paired');
+            });
+        });
+        if (unpairBtn) unpairBtn.addEventListener('click', function () {
+            clear(); paintStatus();
+            if (typeof UI !== 'undefined' && UI.toast) UI.toast('Transcode server removed');
+        });
+    }
+
+    if (document.readyState === 'loading')
+        document.addEventListener('DOMContentLoaded', wireSettings);
+    else
+        wireSettings();
+
+    return {
+        get: get, set: set, clear: clear, isPaired: isPaired,
+        playUrl: playUrl, isPlayUrl: isPlayUrl, pair: pair
+    };
+})();

--- a/tizen-web-vlc/js/smb.js
+++ b/tizen-web-vlc/js/smb.js
@@ -123,6 +123,18 @@ var SMB = (function () {
         return BASE + '/smb/stream?path=' + encodeURIComponent(path);
     }
 
+    /* The URL we actually play. If a transcode server is paired, route through
+     * it (HLS, server-side decode of DTS/TrueHD and codecs the TV can't handle);
+     * otherwise stream the file straight from the localhost smbproxy as before.
+     * Browsing is identical either way — only the bytes' origin changes. */
+    function playableUrl(path) {
+        if (typeof TranscodeServer !== 'undefined' && TranscodeServer.isPaired()) {
+            var u = TranscodeServer.playUrl(path);
+            if (u) return u;
+        }
+        return streamUrl(path);
+    }
+
     /* ── browsing UI (reuses #view-browse, like the USB browser) ───────────*/
     var pathStack = [];     // breadcrumb of folder paths, '' === share root
     var backHandler = null;
@@ -162,7 +174,7 @@ var SMB = (function () {
             // Playable files in this folder → the playlist for next/prev/auto-play.
             var playlist = entries
                 .filter(function (e) { return !e.isDir && isPlayable(e.name); })
-                .map(function (e) { return { uri: streamUrl(join(path, e.name)), title: e.name }; });
+                .map(function (e) { return { uri: playableUrl(join(path, e.name)), title: e.name }; });
 
             // ".." row to go up (except at root).
             if (pathStack.length > 0) {
@@ -187,7 +199,7 @@ var SMB = (function () {
                         render(join(path, e.name));
                         return;
                     }
-                    var uri = streamUrl(join(path, e.name));
+                    var uri = playableUrl(join(path, e.name));
                     var idx = 0;
                     for (var i = 0; i < playlist.length; i++) if (playlist[i].uri === uri) { idx = i; break; }
                     // Hand off to the player; release our Back handler so the

--- a/vlc-transcode-server/.dockerignore
+++ b/vlc-transcode-server/.dockerignore
@@ -1,0 +1,3 @@
+data/
+*.md
+.git

--- a/vlc-transcode-server/.gitignore
+++ b/vlc-transcode-server/.gitignore
@@ -1,0 +1,5 @@
+# persisted runtime config + transcode scratch
+/data/
+# local build artefacts
+/vlc-transcode
+*.test

--- a/vlc-transcode-server/Dockerfile
+++ b/vlc-transcode-server/Dockerfile
@@ -1,0 +1,31 @@
+# ── build stage ──────────────────────────────────────────────────────────────
+# Pure-Go (go-smb2 needs no cgo), so we can produce a fully static binary that
+# drops into any final image regardless of libc.
+FROM golang:1.23-bookworm AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /vlc-transcode .
+
+# ── runtime stage ────────────────────────────────────────────────────────────
+# Debian's ffmpeg covers software (libx264), VAAPI (Intel/AMD), V4L2 M2M and
+# NVENC (with host drivers). Rockchip rkmpp needs a custom ffmpeg build; on those
+# boxes auto-detect simply falls back to V4L2/software — see README.
+FROM debian:bookworm-slim
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ffmpeg \
+      mesa-va-drivers \
+      ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /vlc-transcode /usr/local/bin/vlc-transcode
+
+ENV DATA_DIR=/data \
+    WORK_DIR=/tmp/vlc-transcode \
+    PORT=8200
+VOLUME /data
+EXPOSE 8200
+
+ENTRYPOINT ["/usr/local/bin/vlc-transcode"]

--- a/vlc-transcode-server/Dockerfile
+++ b/vlc-transcode-server/Dockerfile
@@ -1,12 +1,16 @@
 # ── build stage ──────────────────────────────────────────────────────────────
-# Pure-Go (go-smb2 needs no cgo), so we can produce a fully static binary that
-# drops into any final image regardless of libc.
-FROM golang:1.23-bookworm AS build
+# Pure-Go (go-smb2 needs no cgo), so we cross-compile a fully static binary for
+# the target arch on the native build arch — no QEMU emulation for the Go step,
+# which keeps multi-arch builds fast.
+FROM --platform=$BUILDPLATFORM golang:1.23-bookworm AS build
+ARG TARGETOS
+ARG TARGETARCH
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /vlc-transcode .
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -trimpath -ldflags="-s -w" -o /vlc-transcode .
 
 # ── runtime stage ────────────────────────────────────────────────────────────
 # Debian's ffmpeg covers software (libx264), VAAPI (Intel/AMD), V4L2 M2M and

--- a/vlc-transcode-server/README.md
+++ b/vlc-transcode-server/README.md
@@ -17,13 +17,25 @@ hands the TV an HLS URL it *can* play.
 
 ## Run it
 
-You need Docker on the box. The image bundles ffmpeg — nothing else to install.
+You need Docker on the box. The image bundles ffmpeg — nothing else to install,
+nothing to clone or build.
+
+**One-liner:**
 
 ```bash
-git clone https://github.com/PatrickSt1991/vlc-tizen-tv.git
-cd vlc-tizen-tv/vlc-transcode-server
+docker run -d --name vlc-transcode --restart unless-stopped \
+  -p 8200:8200 -v "$PWD/vlc-data:/data" --device /dev/dri \
+  ghcr.io/patrickst1991/vlc-transcode:latest
+```
+
+**Or with Compose** (grab `docker-compose.yml` from this folder):
+
+```bash
 docker compose up -d
 ```
+
+(`--device /dev/dri` exposes the hardware encoder; it's harmless if the box
+doesn't have one — the server falls back to software.)
 
 Then open **`http://<box-ip>:8200`** in any browser and fill in your SMB share
 (host, share name, username/password — or toggle Guest). Use **Test connection**

--- a/vlc-transcode-server/README.md
+++ b/vlc-transcode-server/README.md
@@ -29,19 +29,32 @@ Then open **`http://<box-ip>:8200`** in any browser and fill in your SMB share
 (host, share name, username/password — or toggle Guest). Use **Test connection**
 and **Browse share** to confirm it can see your files.
 
-That's the whole setup. (Pairing with the TV app comes in a later step; for now
-you can verify transcoding directly — see below.)
+## Pair with the TV
+
+On the TV: **Settings → Transcode server → Pair**, then enter the code the TV
+shows into the **Pair with TV** box on this page. The server publishes its LAN
+address + a token to the TV (via the same ntfy pairing channel the app already
+uses), and the TV stores it.
+
+From then on the TV browses your SMB share exactly as before — but when you press
+play, the file streams through this box, transcoded as needed. Nothing else in
+the TV's flow changes; if the server is ever unpaired or offline the TV falls
+back to playing directly.
+
+> The server must point at the **same share** the TV browses, so the relative
+> paths line up.
 
 ## Verify transcoding (before the TV is involved)
 
-Point VLC on a laptop at a file via the server:
+The setup page shows a ready-made **Test transcoding** link (it includes the
+token). Open it in VLC on a laptop, swapping in a real file path:
 
 ```
-http://<box-ip>:8200/play?path=/Movies/SomeMovie.mkv
+http://<box-ip>:8200/play?path=/Movies/SomeMovie.mkv&token=<token>
 ```
 
 The server probes the file, decides remux-vs-transcode, starts ffmpeg, and
-redirects to the HLS playlist. A DTS/TrueHD file should now play **with sound**.
+serves the live HLS manifest. A DTS/TrueHD file should now play **with sound**.
 
 ## How it decides
 

--- a/vlc-transcode-server/README.md
+++ b/vlc-transcode-server/README.md
@@ -1,0 +1,83 @@
+# VLC Transcode Server
+
+A tiny self-hosted companion for the [VLC Tizen TV app](../). It runs on a small
+always-on box (e.g. an AM6b+), reads your media from an **SMB share**, and
+**transcodes only what the TV can't decode** — DTS / TrueHD audio, or an
+unsupported video codec — into a TV-friendly **HLS** stream. Files the TV can
+already play are remuxed untouched (near-zero CPU).
+
+The TV keeps browsing the share exactly as before; the only thing that changes
+is *where the bytes come from* when you press play.
+
+## Why it exists
+
+Samsung Tizen TVs can't decode DTS or TrueHD in-app (a hardware/licensing wall —
+even Plex plays those files silent). This box does the decode the TV can't, and
+hands the TV an HLS URL it *can* play.
+
+## Run it
+
+You need Docker on the box. The image bundles ffmpeg — nothing else to install.
+
+```bash
+git clone https://github.com/PatrickSt1991/vlc-tizen-tv.git
+cd vlc-tizen-tv/vlc-transcode-server
+docker compose up -d
+```
+
+Then open **`http://<box-ip>:8200`** in any browser and fill in your SMB share
+(host, share name, username/password — or toggle Guest). Use **Test connection**
+and **Browse share** to confirm it can see your files.
+
+That's the whole setup. (Pairing with the TV app comes in a later step; for now
+you can verify transcoding directly — see below.)
+
+## Verify transcoding (before the TV is involved)
+
+Point VLC on a laptop at a file via the server:
+
+```
+http://<box-ip>:8200/play?path=/Movies/SomeMovie.mkv
+```
+
+The server probes the file, decides remux-vs-transcode, starts ffmpeg, and
+redirects to the HLS playlist. A DTS/TrueHD file should now play **with sound**.
+
+## How it decides
+
+| Source | Treatment |
+|---|---|
+| Video + audio both TV-friendly | **Remux only** (copy/copy) |
+| Only audio is DTS/TrueHD | Copy video, transcode audio → AC3 (5.1) / AAC (stereo) |
+| Video codec unsupported | Hardware-transcode video → H.264, fix audio |
+
+## Hardware acceleration
+
+The encoder is **auto-detected at startup** — it picks the fastest H.264 encoder
+ffmpeg reports and falls back to software (`libx264`). Detection order:
+`rkmpp → vaapi → nvenc → qsv → v4l2m2m → libx264`.
+
+- **Intel / AMD (VAAPI):** works out of the box if `/dev/dri` is passed in
+  (it is, in the compose file).
+- **Nvidia / Jetson (NVENC):** needs the NVIDIA container runtime + drivers.
+- **Rockchip (rkmpp):** stock Debian ffmpeg has no rkmpp; the server falls back
+  to V4L2/software. Swap in an rkmpp-enabled ffmpeg build to enable it.
+- Force a specific encoder by setting `"encoder": "libx264"` in
+  `data/config.json` if auto-pick misbehaves.
+
+## Configuration
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `PORT` | `8200` | HTTP port |
+| `DATA_DIR` | `/data` | where `config.json` is persisted |
+| `WORK_DIR` | `/tmp/vlc-transcode` | scratch for HLS segments |
+
+## Known limitations (Phase 1)
+
+- **Seeking** works within the already-transcoded range; jumping far ahead waits
+  for the encode to reach that point (seek-restart is a planned improvement).
+- **Subtitles** are not muxed into the HLS stream yet (the TV app handles subs
+  separately).
+- One active stream per file; the box transcodes in real time, so a weak CPU may
+  not keep up with software encoding of heavy 4K video.

--- a/vlc-transcode-server/docker-compose.yml
+++ b/vlc-transcode-server/docker-compose.yml
@@ -2,8 +2,11 @@
 # Then open  http://<box-ip>:8200  to enter your SMB share details.
 services:
   vlc-transcode:
-    build: .
-    # Or, once published:  image: ghcr.io/patrickst1991/vlc-transcode:latest
+    # Pulls the prebuilt multi-arch image — no cloning or building needed.
+    image: ghcr.io/patrickst1991/vlc-transcode:latest
+    # Developers building from source instead: comment the line above and
+    # uncomment the next one (run from this directory).
+    # build: .
     container_name: vlc-transcode
     restart: unless-stopped
     ports:

--- a/vlc-transcode-server/docker-compose.yml
+++ b/vlc-transcode-server/docker-compose.yml
@@ -1,0 +1,19 @@
+# Drop this on the AM6b+ and run:  docker compose up -d
+# Then open  http://<box-ip>:8200  to enter your SMB share details.
+services:
+  vlc-transcode:
+    build: .
+    # Or, once published:  image: ghcr.io/patrickst1991/vlc-transcode:latest
+    container_name: vlc-transcode
+    restart: unless-stopped
+    ports:
+      - "8200:8200"
+    volumes:
+      - ./data:/data          # persists your SMB config
+    # Hardware encoder access. Harmless if the box has no /dev/dri — the server
+    # auto-detects and falls back to software. Comment out on boxes without it.
+    devices:
+      - /dev/dri:/dev/dri
+    # group_add may be needed so the container can use the render node:
+    #   - "video"
+    #   - "render"

--- a/vlc-transcode-server/go.mod
+++ b/vlc-transcode-server/go.mod
@@ -1,0 +1,10 @@
+module github.com/PatrickSt1991/vlc-tizen-tv/vlc-transcode-server
+
+go 1.23
+
+require github.com/hirochachacha/go-smb2 v1.1.0
+
+require (
+	github.com/geoffgarside/ber v1.1.0 // indirect
+	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de // indirect
+)

--- a/vlc-transcode-server/go.sum
+++ b/vlc-transcode-server/go.sum
@@ -1,0 +1,11 @@
+github.com/geoffgarside/ber v1.1.0 h1:qTmFG4jJbwiSzSXoNJeHcOprVzZ8Ulde2Rrrifu5U9w=
+github.com/geoffgarside/ber v1.1.0/go.mod h1:jVPKeCbj6MvQZhwLYsGwaGI52oUorHoHKNecGT85ZCc=
+github.com/hirochachacha/go-smb2 v1.1.0 h1:b6hs9qKIql9eVXAiN0M2wSFY5xnhbHAQoCwRKbaRTZI=
+github.com/hirochachacha/go-smb2 v1.1.0/go.mod h1:8F1A4d5EZzrGu5R7PU163UcMRDJQl4FtcxjBfsY8TZE=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de h1:ikNHVSjEfnvz6sxdSPCaPt572qowuyMDMJLLm3Db3ig=
+golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/vlc-transcode-server/internal/config/config.go
+++ b/vlc-transcode-server/internal/config/config.go
@@ -1,0 +1,96 @@
+// Package config holds the server's persisted, web-editable settings.
+//
+// Everything a non-technical user must set (SMB share + credentials) lives in a
+// single JSON file so the web UI can read/write it without anyone touching a
+// shell. The file is created on first save; missing/blank fields are fine — the
+// server just reports "not configured" until the SMB section is filled in.
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// SMB holds the connection details for the one share we read media from.
+type SMB struct {
+	Host      string `json:"host"`      // e.g. "192.168.1.10"
+	Port      int    `json:"port"`      // usually 445
+	Share     string `json:"share"`     // e.g. "Media"
+	User      string `json:"user"`      // empty when Anonymous
+	Pass      string `json:"pass"`      // empty when Anonymous
+	Domain    string `json:"domain"`    // usually empty
+	Anonymous bool   `json:"anonymous"` // guest/null session
+}
+
+// Config is the whole persisted document.
+type Config struct {
+	SMB SMB `json:"smb"`
+
+	// Encoder lets a user override the auto-detected ffmpeg encoder if the
+	// pick misbehaves on their box (e.g. "libx264", "h264_vaapi"). Empty =
+	// auto-detect.
+	Encoder string `json:"encoder,omitempty"`
+
+	path string     // backing file; not serialised
+	mu   sync.Mutex // guards Save against concurrent web writes
+}
+
+// Configured reports whether enough is set to attempt an SMB connection.
+func (c *Config) Configured() bool {
+	return c.SMB.Host != "" && c.SMB.Share != ""
+}
+
+// Load reads the config file, returning an empty (but usable) Config if it does
+// not exist yet. Only a malformed existing file is an error.
+func Load(path string) (*Config, error) {
+	c := &Config{path: path, SMB: SMB{Port: 445}}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return c, nil
+		}
+		return nil, err
+	}
+	if err := json.Unmarshal(b, c); err != nil {
+		return nil, err
+	}
+	c.path = path
+	if c.SMB.Port == 0 {
+		c.SMB.Port = 445
+	}
+	return c, nil
+}
+
+// Save atomically persists the current config to disk.
+func (c *Config) Save() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := os.MkdirAll(filepath.Dir(c.path), 0o755); err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := c.path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, c.path)
+}
+
+// View is the JSON shape sent to the web UI — no mutex, password masked.
+type View struct {
+	SMB     SMB    `json:"smb"`
+	Encoder string `json:"encoder,omitempty"`
+}
+
+// Redacted returns a lock-free view safe to send to the web UI.
+func (c *Config) Redacted() View {
+	v := View{SMB: c.SMB, Encoder: c.Encoder}
+	v.SMB.Pass = "" // never leak the stored password
+	return v
+}

--- a/vlc-transcode-server/internal/config/config.go
+++ b/vlc-transcode-server/internal/config/config.go
@@ -7,6 +7,8 @@
 package config
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -33,6 +35,12 @@ type Config struct {
 	// auto-detect.
 	Encoder string `json:"encoder,omitempty"`
 
+	// Token is a long random secret minted on first run. The TV receives it
+	// during pairing and sends it on /play, so a random LAN device can't drive
+	// the transcoder. It rides in URLs the TV builds automatically — no user
+	// friction.
+	Token string `json:"token,omitempty"`
+
 	path string     // backing file; not serialised
 	mu   sync.Mutex // guards Save against concurrent web writes
 }
@@ -40,6 +48,19 @@ type Config struct {
 // Configured reports whether enough is set to attempt an SMB connection.
 func (c *Config) Configured() bool {
 	return c.SMB.Host != "" && c.SMB.Share != ""
+}
+
+// EnsureToken mints the pairing secret on first run and persists it.
+func (c *Config) EnsureToken() error {
+	if c.Token != "" {
+		return nil
+	}
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return err
+	}
+	c.Token = hex.EncodeToString(b)
+	return c.Save()
 }
 
 // Load reads the config file, returning an empty (but usable) Config if it does

--- a/vlc-transcode-server/internal/pair/pair.go
+++ b/vlc-transcode-server/internal/pair/pair.go
@@ -1,0 +1,95 @@
+// Package pair implements the TV handshake. It reuses the app's existing
+// ntfy.sh pairing-code transport (see the TV app's url-drop.js): the TV mints a
+// long code and shows it; here we publish this server's LAN URL + token to the
+// derived topic so the TV can discover and save it.
+//
+// A SEPARATE topic suffix ("-srv") is used so a server announcement never
+// collides with the "Get URL from device" play feature, which polls the bare
+// "vlctv-<code>" topic.
+package pair
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const ntfyBase = "https://ntfy.sh"
+
+// Announce is the JSON the TV receives and stores.
+type Announce struct {
+	Type  string `json:"type"`  // always "vlc-transcode-server"
+	URL   string `json:"url"`   // e.g. "http://192.168.1.50:8200"
+	Token string `json:"token"` // sent back on /play
+	Name  string `json:"name"`  // friendly box name
+}
+
+// topicFor maps a TV pairing code to the server-announce topic.
+func topicFor(code string) string { return "vlctv-" + code + "-srv" }
+
+// Publish posts this server's details to the TV's pairing topic.
+func Publish(ctx context.Context, code, serverURL, token string) error {
+	code = strings.TrimSpace(code)
+	if code == "" {
+		return fmt.Errorf("empty pairing code")
+	}
+	ann := Announce{Type: "vlc-transcode-server", URL: serverURL, Token: token, Name: hostname()}
+	body, _ := json.Marshal(ann)
+
+	ctx, cancel := context.WithTimeout(ctx, 12*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ntfyBase+"/"+topicFor(code), bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	// ntfy keeps the last message cached so the TV can pull it on demand later.
+	req.Header.Set("Cache", "yes")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("ntfy returned %s", resp.Status)
+	}
+	return nil
+}
+
+// LocalURL guesses this box's LAN URL by checking which source address the OS
+// would use to reach the internet — that's the interface the TV reaches us on.
+func LocalURL(port int) string {
+	ip := outboundIP()
+	if ip == "" {
+		ip = "127.0.0.1"
+	}
+	return fmt.Sprintf("http://%s:%d", ip, port)
+}
+
+func outboundIP() string {
+	// No packets are actually sent for a UDP "connect"; it just resolves the
+	// route and picks the local source address.
+	c, err := net.Dial("udp", "8.8.8.8:80")
+	if err != nil {
+		return ""
+	}
+	defer c.Close()
+	if a, ok := c.LocalAddr().(*net.UDPAddr); ok {
+		return a.IP.String()
+	}
+	return ""
+}
+
+func hostname() string {
+	h, err := os.Hostname()
+	if err != nil || h == "" {
+		return "VLC Transcode Server"
+	}
+	return h
+}

--- a/vlc-transcode-server/internal/smb/client.go
+++ b/vlc-transcode-server/internal/smb/client.go
@@ -1,0 +1,183 @@
+// Package smb wraps go-smb2 with the few operations this server needs: list a
+// folder (for the web UI's "test browse") and open a file as a seekable reader
+// (so ffmpeg/HTTP can range-read it). A single share is mounted and kept open;
+// if the session drops we transparently re-dial on the next call.
+package smb
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hirochachacha/go-smb2"
+
+	"github.com/PatrickSt1991/vlc-tizen-tv/vlc-transcode-server/internal/config"
+)
+
+// Entry is one item in a folder listing.
+type Entry struct {
+	Name  string `json:"name"`
+	IsDir bool   `json:"isDir"`
+	Size  int64  `json:"size"`
+}
+
+// File is a seekable handle to one SMB file plus its size.
+type File struct {
+	*smb2.File
+	Size int64
+}
+
+// Client holds the live session/mount and re-dials on demand.
+type Client struct {
+	cfg *config.SMB
+
+	mu      sync.Mutex
+	conn    net.Conn
+	session *smb2.Session
+	share   *smb2.Share
+}
+
+// New returns a client bound to the given SMB settings. Nothing connects until
+// the first call.
+func New(cfg *config.SMB) *Client { return &Client{cfg: cfg} }
+
+// normalise converts an incoming "/Movies/x.mkv" into the backslash-free,
+// leading-slash-free form go-smb2 expects, and blocks ".." traversal so a
+// crafted path can't escape the share.
+func normalise(p string) (string, error) {
+	p = strings.ReplaceAll(p, "\\", "/")
+	p = strings.TrimPrefix(p, "/")
+	clean := path.Clean("/" + p)
+	if strings.Contains(clean, "..") {
+		return "", fmt.Errorf("invalid path")
+	}
+	return strings.TrimPrefix(clean, "/"), nil
+}
+
+// ensure (re)establishes the mount if needed. Caller holds c.mu.
+func (c *Client) ensure() error {
+	if c.share != nil {
+		return nil
+	}
+	if c.cfg.Host == "" || c.cfg.Share == "" {
+		return fmt.Errorf("SMB not configured")
+	}
+	port := c.cfg.Port
+	if port == 0 {
+		port = 445
+	}
+	d := net.Dialer{Timeout: 10 * time.Second}
+	conn, err := d.Dial("tcp", fmt.Sprintf("%s:%d", c.cfg.Host, port))
+	if err != nil {
+		return fmt.Errorf("dial %s: %w", c.cfg.Host, err)
+	}
+	init := &smb2.NTLMInitiator{Domain: c.cfg.Domain}
+	if !c.cfg.Anonymous {
+		init.User = c.cfg.User
+		init.Password = c.cfg.Pass
+	} else {
+		// A guest/null session: many NAS boxes accept an empty user.
+		init.User = c.cfg.User // often "" or "Guest"
+	}
+	dialer := &smb2.Dialer{Initiator: init}
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+	defer cancel()
+	sess, err := dialer.DialContext(ctx, conn)
+	if err != nil {
+		conn.Close()
+		return fmt.Errorf("smb auth: %w", err)
+	}
+	share, err := sess.Mount(c.cfg.Share)
+	if err != nil {
+		sess.Logoff()
+		conn.Close()
+		return fmt.Errorf("mount %q: %w", c.cfg.Share, err)
+	}
+	c.conn, c.session, c.share = conn, sess, share
+	return nil
+}
+
+// reset tears the session down so the next call re-dials. Caller holds c.mu.
+func (c *Client) reset() {
+	if c.share != nil {
+		c.share.Umount()
+	}
+	if c.session != nil {
+		c.session.Logoff()
+	}
+	if c.conn != nil {
+		c.conn.Close()
+	}
+	c.share, c.session, c.conn = nil, nil, nil
+}
+
+// Probe forces a connect (used by the web UI's "Test connection" button).
+func (c *Client) Probe() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.reset() // always test fresh credentials
+	return c.ensure()
+}
+
+// List returns the entries of a folder ("" or "/" = share root).
+func (c *Client) List(p string) ([]Entry, error) {
+	rel, err := normalise(p)
+	if err != nil {
+		return nil, err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := c.ensure(); err != nil {
+		return nil, err
+	}
+	dir := rel
+	if dir == "" {
+		dir = "."
+	}
+	infos, err := c.share.ReadDir(dir)
+	if err != nil {
+		c.reset() // drop a possibly-stale session
+		return nil, err
+	}
+	out := make([]Entry, 0, len(infos))
+	for _, fi := range infos {
+		out = append(out, Entry{Name: fi.Name(), IsDir: fi.IsDir(), Size: fi.Size()})
+	}
+	return out, nil
+}
+
+// Open returns a seekable handle to a file. The caller must Close it.
+func (c *Client) Open(p string) (*File, error) {
+	rel, err := normalise(p)
+	if err != nil {
+		return nil, err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := c.ensure(); err != nil {
+		return nil, err
+	}
+	f, err := c.share.Open(rel)
+	if err != nil {
+		c.reset()
+		return nil, err
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	if fi.IsDir() {
+		f.Close()
+		return nil, fmt.Errorf("%s is a directory", p)
+	}
+	return &File{File: f, Size: fi.Size()}, nil
+}
+
+// ensure *smb2.File satisfies io.ReadSeeker for http.ServeContent.
+var _ io.ReadSeeker = (*smb2.File)(nil)

--- a/vlc-transcode-server/internal/transcode/caps.go
+++ b/vlc-transcode-server/internal/transcode/caps.go
@@ -1,0 +1,116 @@
+package transcode
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Caps describes what this box's ffmpeg can actually do, probed once at
+// startup. The whole point of probing (rather than configuring) is that the
+// same image can be dropped on a Rockchip board, an Intel mini-PC, a Pi, or a
+// plain VM and pick the fastest encoder it finds — falling back to libx264 so
+// it always works somewhere.
+type Caps struct {
+	FFmpeg  string // resolved ffmpeg path
+	FFprobe string // resolved ffprobe path
+
+	// VideoEncoder is the chosen H.264 encoder name (e.g. "h264_vaapi").
+	VideoEncoder string
+	// HWAccel is the matching family ("vaapi","v4l2m2m","nvenc","none").
+	HWAccel string
+	// VAAPIDevice is the render node for VAAPI, if that family was chosen.
+	VAAPIDevice string
+}
+
+// encoderPriority lists H.264 encoders fastest/most-desirable first. Auto-pick
+// walks this and takes the first one ffmpeg reports as available; libx264 is
+// last and effectively always present, so detection never comes up empty.
+var encoderPriority = []struct {
+	name   string
+	family string
+}{
+	{"h264_rkmpp", "rkmpp"},   // Rockchip RK3588/3568
+	{"h264_vaapi", "vaapi"},   // Intel/AMD (and some ARM via Mesa)
+	{"h264_nvenc", "nvenc"},   // Nvidia / Jetson
+	{"h264_qsv", "qsv"},       // Intel QuickSync
+	{"h264_v4l2m2m", "v4l2m2m"}, // Amlogic and many generic ARM SoCs
+	{"libx264", "none"},       // software — universal fallback
+}
+
+// Probe locates ffmpeg/ffprobe and picks an encoder. override forces a specific
+// encoder name (from config) instead of auto-detection; an empty override means
+// auto.
+func Probe(override string) (*Caps, error) {
+	ff, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		return nil, err
+	}
+	fp, err := exec.LookPath("ffprobe")
+	if err != nil {
+		return nil, err
+	}
+	c := &Caps{FFmpeg: ff, FFprobe: fp}
+
+	avail := listEncoders(ff)
+
+	// Honour an explicit override if ffmpeg actually has it.
+	if override != "" && avail[override] {
+		c.VideoEncoder = override
+		c.HWAccel = familyOf(override)
+	} else {
+		for _, e := range encoderPriority {
+			if avail[e.name] {
+				c.VideoEncoder = e.name
+				c.HWAccel = e.family
+				break
+			}
+		}
+	}
+	if c.VideoEncoder == "" { // extremely unlikely; ffmpeg without libx264
+		c.VideoEncoder = "libx264"
+		c.HWAccel = "none"
+	}
+	if c.HWAccel == "vaapi" {
+		c.VAAPIDevice = firstExisting([]string{"/dev/dri/renderD128", "/dev/dri/renderD129"})
+	}
+	return c, nil
+}
+
+func familyOf(enc string) string {
+	for _, e := range encoderPriority {
+		if e.name == enc {
+			return e.family
+		}
+	}
+	return "none"
+}
+
+// listEncoders returns the set of encoder names `ffmpeg -encoders` reports.
+func listEncoders(ffmpeg string) map[string]bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, ffmpeg, "-hide_banner", "-encoders").Output()
+	set := map[string]bool{}
+	if err != nil {
+		return set
+	}
+	// Each encoder row looks like: " V..... libx264   libx264 H.264 ...".
+	for _, line := range strings.Split(string(out), "\n") {
+		f := strings.Fields(line)
+		if len(f) >= 2 && len(f[0]) == 6 { // the flags column is 6 chars
+			set[f[1]] = true
+		}
+	}
+	return set
+}
+
+func firstExisting(paths []string) string {
+	for _, p := range paths {
+		if fileExists(p) {
+			return p
+		}
+	}
+	return ""
+}

--- a/vlc-transcode-server/internal/transcode/decide.go
+++ b/vlc-transcode-server/internal/transcode/decide.go
@@ -1,0 +1,59 @@
+package transcode
+
+// What the Samsung Tizen TVs in scope can decode in-app via AVPlay. Video: H.264
+// and HEVC are the safe set. Audio: AAC/AC3/EAC3/MP3 play; DTS and TrueHD/MLP do
+// not (the hardware wall we documented — even Plex plays them silent). Keeping
+// these as plain sets makes the policy easy to read and to widen later.
+var tvVideoOK = map[string]bool{
+	"h264": true,
+	"hevc": true, "h265": true,
+}
+var tvAudioOK = map[string]bool{
+	"aac": true, "ac3": true, "eac3": true,
+	"mp3": true, "mp2": true,
+}
+
+// Plan is the decision for one file.
+type Plan struct {
+	CopyVideo bool   // remux video stream untouched
+	CopyAudio bool   // remux audio stream untouched
+	AudioEnc  string // ffmpeg audio encoder when CopyAudio is false
+	Reason    string // human-readable, for logs and the web UI
+
+	mi *MediaInfo
+}
+
+// Decide chooses the cheapest treatment that yields a TV-playable HLS stream:
+//
+//   - both streams already fine        → remux only (copy/copy, ~no CPU)
+//   - only the audio codec is the wall → copy video, re-encode just the audio
+//   - video codec unsupported          → hardware-transcode video + fix audio
+//
+// Re-encoded audio targets AC3 when the source is multichannel (keeps 5.1) and
+// AAC for stereo — both decode on every TV in scope.
+func Decide(mi *MediaInfo) Plan {
+	videoOK := mi.VideoCodec == "" || tvVideoOK[mi.VideoCodec]
+	audioOK := mi.AudioCodec == "" || tvAudioOK[mi.AudioCodec]
+
+	p := Plan{mi: mi, CopyVideo: videoOK, CopyAudio: audioOK}
+	if !audioOK {
+		if mi.AudioChans > 2 {
+			p.AudioEnc = "ac3"
+		} else {
+			p.AudioEnc = "aac"
+		}
+	}
+
+	switch {
+	case videoOK && audioOK:
+		p.Reason = "remux only — both streams TV-compatible"
+	case videoOK && !audioOK:
+		p.Reason = "copy video, transcode audio " + mi.AudioCodec + "→" + p.AudioEnc
+	default:
+		p.Reason = "transcode video " + mi.VideoCodec + "→h264"
+		if !audioOK {
+			p.Reason += ", audio " + mi.AudioCodec + "→" + p.AudioEnc
+		}
+	}
+	return p
+}

--- a/vlc-transcode-server/internal/transcode/manager.go
+++ b/vlc-transcode-server/internal/transcode/manager.go
@@ -1,0 +1,220 @@
+package transcode
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// nowFn is a seam so tests could fake the clock; real code uses time.Now.
+var nowFn = time.Now
+
+// idleTimeout kills a session whose playlist/segments haven't been requested in
+// a while — i.e. the user stopped watching or moved on.
+const idleTimeout = 90 * time.Second
+
+// RawURLFunc builds the internal HTTP URL ffmpeg should read for an SMB path.
+// (Injected so this package doesn't import the web/http layer.)
+type RawURLFunc func(smbPath string) string
+
+// Manager owns the working directory and the live session set.
+type Manager struct {
+	caps    *Caps
+	workDir string
+	rawURL  RawURLFunc
+
+	mu       sync.Mutex
+	sessions map[string]*session
+}
+
+// NewManager wires the manager and starts the idle-reaper goroutine.
+func NewManager(caps *Caps, workDir string, rawURL RawURLFunc) (*Manager, error) {
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		return nil, err
+	}
+	// Clear stale work from a previous run.
+	entries, _ := filepath.Glob(filepath.Join(workDir, "*"))
+	for _, e := range entries {
+		os.RemoveAll(e)
+	}
+	m := &Manager{caps: caps, workDir: workDir, rawURL: rawURL, sessions: map[string]*session{}}
+	go m.reap()
+	return m, nil
+}
+
+// Caps exposes the probed capabilities (for the status page).
+func (m *Manager) Caps() *Caps { return m.caps }
+
+// EnsureSession returns a ready session for the given SMB path, starting ffmpeg
+// (after probing + deciding) if one isn't already running. It blocks until the
+// first segment exists so the caller can immediately redirect AVPlay to the
+// playlist.
+func (m *Manager) EnsureSession(ctx context.Context, smbPath string) (*session, error) {
+	id := idFor(smbPath)
+
+	m.mu.Lock()
+	if s, ok := m.sessions[id]; ok && !s.isDone() {
+		s.Touch()
+		m.mu.Unlock()
+		if err := waitReady(ctx, s); err != nil {
+			return nil, err
+		}
+		return s, nil
+	}
+	m.mu.Unlock()
+
+	in := m.rawURL(smbPath)
+
+	// Probe + decide before committing to a session.
+	mi, err := m.caps.Inspect(ctx, in)
+	if err != nil {
+		return nil, fmt.Errorf("probe failed: %w", err)
+	}
+	plan := Decide(mi)
+	log.Printf("transcode %q: %s (codec v=%s a=%s/%dch)", smbPath, plan.Reason, mi.VideoCodec, mi.AudioCodec, mi.AudioChans)
+
+	dir := filepath.Join(m.workDir, id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, err
+	}
+
+	sctx, cancel := context.WithCancel(context.Background())
+	s := &session{
+		ID: id, SrcPath: smbPath, Dir: dir, Plan: plan,
+		cancel: cancel, logTail: newRing(60), lastAccess: nowFn(),
+	}
+
+	args := m.caps.buildArgs(in, plan, dir)
+	cmd := exec.CommandContext(sctx, m.caps.FFmpeg, args...)
+	s.cmd = cmd
+
+	stderr, _ := cmd.StderrPipe()
+	if err := cmd.Start(); err != nil {
+		cancel()
+		os.RemoveAll(dir)
+		return nil, fmt.Errorf("start ffmpeg: %w", err)
+	}
+	go drain(stderr, s)
+	go func() {
+		err := cmd.Wait()
+		s.mu.Lock()
+		s.done, s.exitErr = true, err
+		s.mu.Unlock()
+	}()
+
+	m.mu.Lock()
+	m.sessions[id] = s
+	m.mu.Unlock()
+
+	if err := waitReady(ctx, s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// Session looks up a live session by id (used when serving segments).
+func (m *Manager) Session(id string) (*session, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s, ok := m.sessions[id]
+	return s, ok
+}
+
+func (s *session) isDone() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.done
+}
+
+// waitReady blocks until the first segment is written, ffmpeg dies, or ctx ends.
+func waitReady(ctx context.Context, s *session) error {
+	deadline := time.NewTimer(30 * time.Second)
+	defer deadline.Stop()
+	tick := time.NewTicker(150 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		if s.ready() {
+			return nil
+		}
+		if s.isDone() {
+			return fmt.Errorf("ffmpeg exited before producing output: %s", s.tail())
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline.C:
+			return fmt.Errorf("timed out waiting for transcode to start: %s", s.tail())
+		case <-tick.C:
+		}
+	}
+}
+
+// reap stops sessions that have gone idle.
+func (m *Manager) reap() {
+	t := time.NewTicker(15 * time.Second)
+	for range t.C {
+		now := nowFn()
+		m.mu.Lock()
+		for id, s := range m.sessions {
+			s.mu.Lock()
+			idle := now.Sub(s.lastAccess) > idleTimeout
+			done := s.done
+			s.mu.Unlock()
+			if idle || (done && now.Sub(s.lastAccess) > 10*time.Second) {
+				log.Printf("reap session %s (%s)", id, s.SrcPath)
+				s.stop()
+				delete(m.sessions, id)
+			}
+		}
+		m.mu.Unlock()
+	}
+}
+
+func drain(r interface{ Read([]byte) (int, error) }, s *session) {
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		s.logTail.add(sc.Text())
+	}
+}
+
+func (s *session) tail() string { return s.logTail.last() }
+
+// ── tiny line ring buffer for surfacing ffmpeg's last words on failure ──────
+type ring struct {
+	mu   sync.Mutex
+	buf  []string
+	n    int
+	full bool
+}
+
+func newRing(n int) *ring { return &ring{buf: make([]string, n)} }
+func (r *ring) add(line string) {
+	r.mu.Lock()
+	r.buf[r.n] = line
+	r.n = (r.n + 1) % len(r.buf)
+	if r.n == 0 {
+		r.full = true
+	}
+	r.mu.Unlock()
+}
+func (r *ring) last() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.full && r.n == 0 {
+		return "(no output)"
+	}
+	// Return the most recent non-empty line.
+	for i := 0; i < len(r.buf); i++ {
+		idx := (r.n - 1 - i + len(r.buf)) % len(r.buf)
+		if r.buf[idx] != "" {
+			return r.buf[idx]
+		}
+	}
+	return "(no output)"
+}

--- a/vlc-transcode-server/internal/transcode/probe.go
+++ b/vlc-transcode-server/internal/transcode/probe.go
@@ -1,0 +1,87 @@
+package transcode
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"strconv"
+	"time"
+)
+
+// MediaInfo is the slice of ffprobe output we care about.
+type MediaInfo struct {
+	VideoCodec string  // "h264", "hevc", "vp9", ... ("" = no video)
+	AudioCodec string  // "dts", "truehd", "aac", "ac3", ... of the default track
+	AudioChans int     // channel count of that track
+	Duration   float64 // seconds (0 if unknown)
+}
+
+// ffprobe JSON shapes (only the fields we read).
+type ffStream struct {
+	CodecType     string `json:"codec_type"`
+	CodecName     string `json:"codec_name"`
+	Channels      int    `json:"channels"`
+	Disposition   struct {
+		Default int `json:"default"`
+	} `json:"disposition"`
+}
+type ffFormat struct {
+	Duration string `json:"duration"`
+}
+type ffProbeOut struct {
+	Streams []ffStream `json:"streams"`
+	Format  ffFormat   `json:"format"`
+}
+
+// Inspect runs ffprobe against a (local raw-bridge) URL and summarises it. We
+// pick the *default* audio track if the container flags one, else the first —
+// that's the track AVPlay would default to, so it's the one whose codec decides
+// whether the TV can play the file as-is.
+func (c *Caps) Inspect(ctx context.Context, url string) (*MediaInfo, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, c.FFprobe,
+		"-hide_banner", "-loglevel", "error",
+		"-print_format", "json",
+		"-show_streams", "-show_format",
+		url,
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	var probe ffProbeOut
+	if err := json.Unmarshal(out, &probe); err != nil {
+		return nil, err
+	}
+
+	mi := &MediaInfo{}
+	var firstAudio *ffStream
+	var defAudio *ffStream
+	for i := range probe.Streams {
+		s := &probe.Streams[i]
+		switch s.CodecType {
+		case "video":
+			if mi.VideoCodec == "" {
+				mi.VideoCodec = s.CodecName
+			}
+		case "audio":
+			if firstAudio == nil {
+				firstAudio = s
+			}
+			if defAudio == nil && s.Disposition.Default == 1 {
+				defAudio = s
+			}
+		}
+	}
+	if a := defAudio; a != nil {
+		mi.AudioCodec, mi.AudioChans = a.CodecName, a.Channels
+	} else if firstAudio != nil {
+		mi.AudioCodec, mi.AudioChans = firstAudio.CodecName, firstAudio.Channels
+	}
+	if d, err := strconv.ParseFloat(probe.Format.Duration, 64); err == nil {
+		mi.Duration = d
+	}
+	return mi, nil
+}

--- a/vlc-transcode-server/internal/transcode/session.go
+++ b/vlc-transcode-server/internal/transcode/session.go
@@ -1,0 +1,142 @@
+package transcode
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// A session is one running ffmpeg producing an HLS stream for one source file.
+// Segments land in Dir; index.m3u8 is the playlist AVPlay loads.
+type session struct {
+	ID       string
+	SrcPath  string // SMB-relative path, for logs
+	Dir      string
+	Plan     Plan
+	cmd      *exec.Cmd
+	cancel   context.CancelFunc
+	logTail  *ring
+
+	mu         sync.Mutex
+	lastAccess time.Time
+	done       bool
+	exitErr    error
+}
+
+// Touch records activity so the idle reaper leaves the session alive.
+func (s *session) Touch() {
+	s.mu.Lock()
+	s.lastAccess = nowFn()
+	s.mu.Unlock()
+}
+
+// playlistPath / firstSegmentReady let /play know when it's safe to redirect.
+func (s *session) playlistPath() string { return filepath.Join(s.Dir, "index.m3u8") }
+
+func (s *session) ready() bool {
+	if !fileExists(s.playlistPath()) {
+		return false
+	}
+	segs, _ := filepath.Glob(filepath.Join(s.Dir, "seg*.ts"))
+	return len(segs) > 0
+}
+
+// stop kills ffmpeg and removes the working directory.
+func (s *session) stop() {
+	if s.cancel != nil {
+		s.cancel()
+	}
+	if s.Dir != "" {
+		os.RemoveAll(s.Dir)
+	}
+}
+
+// buildArgs assembles the ffmpeg command line from the box's capabilities and
+// the per-file plan. Software decode + (optional) hardware encode keeps the
+// device handling simple while still offloading the expensive encode step.
+func (c *Caps) buildArgs(in string, p Plan, dir string) []string {
+	a := []string{"-hide_banner", "-loglevel", "warning", "-y"}
+
+	// Robustness on the internal HTTP raw bridge.
+	a = append(a, "-reconnect", "1", "-reconnect_streamed", "1", "-reconnect_delay_max", "2")
+
+	// VAAPI needs its device declared before the input.
+	if !p.CopyVideo && c.HWAccel == "vaapi" && c.VAAPIDevice != "" {
+		a = append(a, "-vaapi_device", c.VAAPIDevice)
+	}
+
+	a = append(a, "-i", in)
+
+	// One video + one audio track; subtitles are handled by the app, not muxed.
+	a = append(a, "-map", "0:v:0?", "-map", "0:a:0?", "-sn")
+
+	// ── video ──────────────────────────────────────────────────────────
+	if p.CopyVideo {
+		a = append(a, "-c:v", "copy")
+	} else {
+		a = append(a, c.videoEncodeArgs()...)
+	}
+
+	// ── audio ──────────────────────────────────────────────────────────
+	if p.CopyAudio {
+		a = append(a, "-c:a", "copy")
+	} else if p.AudioEnc == "ac3" {
+		ch := p.mi.AudioChans
+		if ch == 0 || ch > 6 {
+			ch = 6 // AC-3 tops out at 5.1
+		}
+		a = append(a, "-c:a", "ac3", "-b:a", "640k", "-ac", fmt.Sprintf("%d", ch))
+	} else { // aac
+		a = append(a, "-c:a", "aac", "-b:a", "256k")
+	}
+
+	// ── HLS muxer: growing ("event") VOD playlist, keep every segment so the
+	// user can seek back across the whole transcoded range. ENDLIST is written
+	// when ffmpeg finishes. ────────────────────────────────────────────────
+	a = append(a,
+		"-f", "hls",
+		"-hls_time", "4",
+		"-hls_list_size", "0",
+		"-hls_flags", "independent_segments+append_list",
+		"-hls_playlist_type", "event",
+		"-hls_segment_type", "mpegts",
+		"-hls_segment_filename", filepath.Join(dir, "seg%05d.ts"),
+		"-start_number", "0",
+		filepath.Join(dir, "index.m3u8"),
+	)
+	return a
+}
+
+func (c *Caps) videoEncodeArgs() []string {
+	switch c.HWAccel {
+	case "vaapi":
+		return []string{"-vf", "format=nv12,hwupload", "-c:v", "h264_vaapi", "-b:v", "8M", "-maxrate", "10M"}
+	case "nvenc":
+		return []string{"-c:v", "h264_nvenc", "-preset", "p4", "-rc", "vbr", "-cq", "21", "-pix_fmt", "yuv420p"}
+	case "qsv":
+		return []string{"-c:v", "h264_qsv", "-global_quality", "21", "-pix_fmt", "nv12"}
+	case "rkmpp":
+		return []string{"-c:v", "h264_rkmpp", "-b:v", "8M", "-pix_fmt", "yuv420p"}
+	case "v4l2m2m":
+		return []string{"-c:v", "h264_v4l2m2m", "-b:v", "8M", "-pix_fmt", "yuv420p"}
+	default: // software
+		return []string{"-c:v", "libx264", "-preset", "veryfast", "-crf", "21", "-pix_fmt", "yuv420p"}
+	}
+}
+
+// idFor derives a stable session id from the source path.
+func idFor(path string) string {
+	h := sha1.Sum([]byte(path))
+	return hex.EncodeToString(h[:])[:16]
+}
+
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}

--- a/vlc-transcode-server/internal/web/manifest_test.go
+++ b/vlc-transcode-server/internal/web/manifest_test.go
@@ -1,0 +1,13 @@
+package web
+
+import "testing"
+
+func TestRewriteManifest(t *testing.T) {
+	in := []byte("#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:4\n#EXTINF:4.000,\nseg00000.ts\n#EXTINF:4.000,\nseg00001.ts\n")
+	out := string(rewriteManifest(in, "/hls/abc123/"))
+
+	want := "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:4\n#EXTINF:4.000,\n/hls/abc123/seg00000.ts\n#EXTINF:4.000,\n/hls/abc123/seg00001.ts\n"
+	if out != want {
+		t.Fatalf("rewrite mismatch:\n got: %q\nwant: %q", out, want)
+	}
+}

--- a/vlc-transcode-server/internal/web/server.go
+++ b/vlc-transcode-server/internal/web/server.go
@@ -11,12 +11,13 @@ import (
 	"io/fs"
 	"log"
 	"net/http"
+	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/PatrickSt1991/vlc-tizen-tv/vlc-transcode-server/internal/config"
+	"github.com/PatrickSt1991/vlc-tizen-tv/vlc-transcode-server/internal/pair"
 	"github.com/PatrickSt1991/vlc-tizen-tv/vlc-transcode-server/internal/smb"
 	"github.com/PatrickSt1991/vlc-tizen-tv/vlc-transcode-server/internal/transcode"
 )
@@ -60,6 +61,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/api/test", s.handleTest)
 	mux.HandleFunc("/api/browse", s.handleBrowse)
 	mux.HandleFunc("/api/status", s.handleStatus)
+	mux.HandleFunc("/api/pair", s.handlePair)
 
 	// Media plane.
 	mux.HandleFunc("/raw", s.handleRaw)   // ffmpeg input (localhost only)
@@ -89,9 +91,17 @@ func (s *Server) handleRaw(w http.ResponseWriter, r *http.Request) {
 	http.ServeContent(w, r, filepath.Base(p), time.Time{}, f.File)
 }
 
-// handlePlay ensures a transcode session exists, then redirects the player to
-// its HLS playlist. This is the URL the TV ultimately hands to AVPlay.
+// handlePlay is the URL the TV hands to AVPlay. It ensures a transcode session,
+// then serves that session's live HLS manifest *directly* (rewriting segment
+// names to absolute /hls/<id>/ paths). Serving the manifest here — rather than
+// 302-redirecting — means we don't depend on AVPlay following redirects, and
+// AVPlay's periodic manifest re-fetch (live/event playlist) simply re-hits this
+// handler, which returns the current segment list as ffmpeg extends it.
 func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request) {
+	if !s.checkToken(r) {
+		http.Error(w, "unauthorized — pair the TV first", http.StatusForbidden)
+		return
+	}
 	p := r.URL.Query().Get("path")
 	if p == "" {
 		http.Error(w, "missing path", http.StatusBadRequest)
@@ -106,7 +116,37 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "transcode failed: "+err.Error(), http.StatusBadGateway)
 		return
 	}
-	http.Redirect(w, r, "/hls/"+sess.ID+"/index.m3u8", http.StatusFound)
+
+	raw, err := os.ReadFile(filepath.Join(sess.Dir, "index.m3u8"))
+	if err != nil {
+		http.Error(w, "playlist not ready", http.StatusBadGateway)
+		return
+	}
+	w.Header().Set("Content-Type", "application/vnd.apple.mpegurl")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Write(rewriteManifest(raw, "/hls/"+sess.ID+"/"))
+}
+
+// rewriteManifest prefixes bare segment filenames with the absolute HLS path so
+// they resolve regardless of the manifest's own URL.
+func rewriteManifest(m3u8 []byte, prefix string) []byte {
+	lines := strings.Split(string(m3u8), "\n")
+	for i, ln := range lines {
+		t := strings.TrimSpace(ln)
+		if t == "" || strings.HasPrefix(t, "#") {
+			continue // comment/tag or blank — leave untouched
+		}
+		lines[i] = prefix + t // a segment (or sub-playlist) reference
+	}
+	return []byte(strings.Join(lines, "\n"))
+}
+
+// checkToken enforces the pairing secret. A request is allowed when no token is
+// configured (shouldn't happen — EnsureToken runs at startup) or the supplied
+// token matches.
+func (s *Server) checkToken(r *http.Request) bool {
+	want := s.cfg.Token
+	return want == "" || r.URL.Query().Get("token") == want
 }
 
 // handleHLS serves the playlist and segments from a session's working dir.
@@ -192,7 +232,31 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		"encoder":    caps.VideoEncoder,
 		"hwaccel":    caps.HWAccel,
 		"share":      s.cfg.SMB.Host + "/" + s.cfg.SMB.Share,
+		"token":      s.cfg.Token, // LAN-trusted UI; used to build the test link
+		"serverURL":  pair.LocalURL(s.port),
 	})
+}
+
+// handlePair publishes this server's LAN URL + token to the TV's pairing topic.
+// The user enters the code shown on the TV; the TV then pulls the announcement.
+func (s *Server) handlePair(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method", http.StatusMethodNotAllowed)
+		return
+	}
+	var in struct {
+		Code string `json:"code"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		http.Error(w, "bad json", http.StatusBadRequest)
+		return
+	}
+	url := pair.LocalURL(s.port)
+	if err := pair.Publish(r.Context(), in.Code, url, s.cfg.Token); err != nil {
+		writeJSON(w, map[string]any{"ok": false, "error": err.Error()})
+		return
+	}
+	writeJSON(w, map[string]any{"ok": true, "url": url})
 }
 
 // ── helpers ──────────────────────────────────────────────────────────────────
@@ -223,6 +287,3 @@ func urlEscape(s string) string {
 	r := strings.NewReplacer(" ", "%20", "?", "%3F", "#", "%23", "&", "%26", "+", "%2B")
 	return r.Replace(s)
 }
-
-// for the status page formatting of durations if needed later.
-var _ = strconv.Itoa

--- a/vlc-transcode-server/internal/web/server.go
+++ b/vlc-transcode-server/internal/web/server.go
@@ -1,0 +1,228 @@
+// Package web is the HTTP surface: the internal raw-file bridge ffmpeg reads,
+// the /play + /hls endpoints AVPlay consumes, and the JSON API behind the
+// point-and-click setup page.
+package web
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"log"
+	"net/http"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/PatrickSt1991/vlc-tizen-tv/vlc-transcode-server/internal/config"
+	"github.com/PatrickSt1991/vlc-tizen-tv/vlc-transcode-server/internal/smb"
+	"github.com/PatrickSt1991/vlc-tizen-tv/vlc-transcode-server/internal/transcode"
+)
+
+//go:embed static/*
+var staticFS embed.FS
+
+// Server bundles the dependencies the handlers need.
+type Server struct {
+	cfg  *config.Config
+	smb  *smb.Client
+	mgr  *transcode.Manager
+	port int
+}
+
+// New constructs the HTTP server glue. The manager is wired afterwards via
+// SetManager because it needs this server's RawURL builder at construction.
+func New(cfg *config.Config, smbc *smb.Client, mgr *transcode.Manager, port int) *Server {
+	return &Server{cfg: cfg, smb: smbc, mgr: mgr, port: port}
+}
+
+// SetManager injects the transcode manager once it has been built.
+func (s *Server) SetManager(mgr *transcode.Manager) { s.mgr = mgr }
+
+// RawURL is the transcode.RawURLFunc: where ffmpeg reads an SMB file from.
+// 127.0.0.1 keeps the bridge off the LAN — only our own ffmpeg uses it.
+func (s *Server) RawURL(smbPath string) string {
+	return fmt.Sprintf("http://127.0.0.1:%d/raw?path=%s", s.port, urlEscape(smbPath))
+}
+
+// Handler builds the routed mux.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+
+	// Setup UI (embedded).
+	sub, _ := fs.Sub(staticFS, "static")
+	mux.Handle("/", http.FileServer(http.FS(sub)))
+
+	// JSON API for the setup page.
+	mux.HandleFunc("/api/config", s.handleConfig)
+	mux.HandleFunc("/api/test", s.handleTest)
+	mux.HandleFunc("/api/browse", s.handleBrowse)
+	mux.HandleFunc("/api/status", s.handleStatus)
+
+	// Media plane.
+	mux.HandleFunc("/raw", s.handleRaw)   // ffmpeg input (localhost only)
+	mux.HandleFunc("/play", s.handlePlay) // TV entry point → 302 to playlist
+	mux.HandleFunc("/hls/", s.handleHLS)  // playlist + segments
+
+	return cors(mux)
+}
+
+// ── media plane ─────────────────────────────────────────────────────────────
+
+// handleRaw streams an SMB file with Range support so ffmpeg can seek it.
+func (s *Server) handleRaw(w http.ResponseWriter, r *http.Request) {
+	p := r.URL.Query().Get("path")
+	if p == "" {
+		http.Error(w, "missing path", http.StatusBadRequest)
+		return
+	}
+	f, err := s.smb.Open(p)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer f.Close()
+	// http.ServeContent handles Range, If-Range, and content-type sniffing using
+	// the seekable SMB handle.
+	http.ServeContent(w, r, filepath.Base(p), time.Time{}, f.File)
+}
+
+// handlePlay ensures a transcode session exists, then redirects the player to
+// its HLS playlist. This is the URL the TV ultimately hands to AVPlay.
+func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request) {
+	p := r.URL.Query().Get("path")
+	if p == "" {
+		http.Error(w, "missing path", http.StatusBadRequest)
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 35*time.Second)
+	defer cancel()
+
+	sess, err := s.mgr.EnsureSession(ctx, p)
+	if err != nil {
+		log.Printf("play %q failed: %v", p, err)
+		http.Error(w, "transcode failed: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	http.Redirect(w, r, "/hls/"+sess.ID+"/index.m3u8", http.StatusFound)
+}
+
+// handleHLS serves the playlist and segments from a session's working dir.
+func (s *Server) handleHLS(w http.ResponseWriter, r *http.Request) {
+	rest := strings.TrimPrefix(r.URL.Path, "/hls/")
+	parts := strings.SplitN(rest, "/", 2)
+	if len(parts) != 2 || parts[1] == "" {
+		http.NotFound(w, r)
+		return
+	}
+	id, name := parts[0], parts[1]
+	if strings.Contains(name, "..") || strings.ContainsAny(name, "/\\") {
+		http.Error(w, "bad name", http.StatusBadRequest)
+		return
+	}
+	sess, ok := s.mgr.Session(id)
+	if !ok {
+		http.Error(w, "no such session", http.StatusNotFound)
+		return
+	}
+	sess.Touch() // each playlist/segment fetch keeps the session alive
+
+	if strings.HasSuffix(name, ".m3u8") {
+		w.Header().Set("Content-Type", "application/vnd.apple.mpegurl")
+	} else if strings.HasSuffix(name, ".ts") {
+		w.Header().Set("Content-Type", "video/mp2t")
+	}
+	http.ServeFile(w, r, filepath.Join(sess.Dir, name))
+}
+
+// ── setup API ────────────────────────────────────────────────────────────────
+
+func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, s.cfg.Redacted())
+	case http.MethodPost:
+		var in config.SMB
+		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+			http.Error(w, "bad json", http.StatusBadRequest)
+			return
+		}
+		// An empty password on save means "keep the stored one" so the masked
+		// form round-trips without wiping credentials.
+		if in.Pass == "" {
+			in.Pass = s.cfg.SMB.Pass
+		}
+		if in.Port == 0 {
+			in.Port = 445
+		}
+		s.cfg.SMB = in
+		if err := s.cfg.Save(); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, map[string]bool{"ok": true})
+	default:
+		http.Error(w, "method", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleTest(w http.ResponseWriter, r *http.Request) {
+	if err := s.smb.Probe(); err != nil {
+		writeJSON(w, map[string]any{"ok": false, "error": err.Error()})
+		return
+	}
+	writeJSON(w, map[string]bool{"ok": true})
+}
+
+func (s *Server) handleBrowse(w http.ResponseWriter, r *http.Request) {
+	entries, err := s.smb.List(r.URL.Query().Get("path"))
+	if err != nil {
+		writeJSON(w, map[string]any{"ok": false, "error": err.Error()})
+		return
+	}
+	writeJSON(w, map[string]any{"ok": true, "entries": entries})
+}
+
+func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	caps := s.mgr.Caps()
+	writeJSON(w, map[string]any{
+		"configured": s.cfg.Configured(),
+		"encoder":    caps.VideoEncoder,
+		"hwaccel":    caps.HWAccel,
+		"share":      s.cfg.SMB.Host + "/" + s.cfg.SMB.Share,
+	})
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(v)
+}
+
+// cors lets the Tizen WebView (origin null / file://) call the API and media
+// endpoints without preflight friction. The server only exposes read access to
+// the configured share, so permissive CORS is acceptable on a LAN appliance.
+func cors(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func urlEscape(s string) string {
+	// Minimal query escaping; path values rarely contain reserved chars but be safe.
+	r := strings.NewReplacer(" ", "%20", "?", "%3F", "#", "%23", "&", "%26", "+", "%2B")
+	return r.Replace(s)
+}
+
+// for the status page formatting of durations if needed later.
+var _ = strconv.Itoa

--- a/vlc-transcode-server/internal/web/static/app.js
+++ b/vlc-transcode-server/internal/web/static/app.js
@@ -21,8 +21,30 @@ async function loadStatus() {
     $('st-enc').textContent = s.encoder || '—';
     $('st-hw').textContent = s.hwaccel === 'none' ? 'software' : (s.hwaccel || '—');
     $('st-share').textContent = s.configured ? s.share : 'not configured';
+    $('st-url').textContent = s.serverURL || '—';
     $('hdot').style.background = s.configured ? 'var(--ok)' : 'var(--mut)';
+    if (s.configured && s.serverURL && s.token) {
+      $('testcard').style.display = '';
+      $('testlink').textContent = s.serverURL + '/play?path=/Movies/YourFile.mkv&token=' + s.token;
+    }
   } catch (e) { /* server starting */ }
+}
+
+async function pair() {
+  const code = $('code').value.trim();
+  if (!code) { $('pairmsg').textContent = 'Enter the code shown on the TV.'; $('pairmsg').className = 'msg err'; return; }
+  $('pairmsg').textContent = 'Pairing…'; $('pairmsg').className = 'msg';
+  const res = await (await fetch('/api/pair', {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ code }),
+  })).json();
+  if (res.ok) {
+    $('pairmsg').textContent = 'Sent ' + res.url + ' to the TV. Press “Pair” on the TV to finish.';
+    $('pairmsg').className = 'msg ok';
+  } else {
+    $('pairmsg').textContent = 'Pairing failed: ' + (res.error || 'unknown');
+    $('pairmsg').className = 'msg err';
+  }
 }
 
 async function loadConfig() {
@@ -98,6 +120,7 @@ $('anon').onclick = () => { anon = !anon; paintAnon(); };
 $('save').onclick = save;
 $('test').onclick = test;
 $('browse').onclick = async () => { await save(); browse(''); };
+$('pair').onclick = pair;
 
 loadConfig();
 loadStatus();

--- a/vlc-transcode-server/internal/web/static/app.js
+++ b/vlc-transcode-server/internal/web/static/app.js
@@ -1,0 +1,104 @@
+'use strict';
+// Setup-page logic. Plain fetch + DOM — no build step, served from the binary.
+
+const $ = (id) => document.getElementById(id);
+let anon = false;
+
+function setMsg(text, kind) {
+  const m = $('msg');
+  m.textContent = text || '';
+  m.className = 'msg' + (kind ? ' ' + kind : '');
+}
+
+function paintAnon() {
+  $('anon').classList.toggle('on', anon);
+  $('creds').style.opacity = anon ? .4 : 1;
+}
+
+async function loadStatus() {
+  try {
+    const s = await (await fetch('/api/status')).json();
+    $('st-enc').textContent = s.encoder || '—';
+    $('st-hw').textContent = s.hwaccel === 'none' ? 'software' : (s.hwaccel || '—');
+    $('st-share').textContent = s.configured ? s.share : 'not configured';
+    $('hdot').style.background = s.configured ? 'var(--ok)' : 'var(--mut)';
+  } catch (e) { /* server starting */ }
+}
+
+async function loadConfig() {
+  const c = await (await fetch('/api/config')).json();
+  const smb = c.smb || c.SMB || {};
+  $('host').value = smb.host || '';
+  $('port').value = smb.port || 445;
+  $('share').value = smb.share || '';
+  $('user').value = smb.user || '';
+  $('domain').value = smb.domain || '';
+  anon = !!smb.anonymous;
+  paintAnon();
+}
+
+function readForm() {
+  return {
+    host: $('host').value.trim(),
+    port: parseInt($('port').value, 10) || 445,
+    share: $('share').value.trim(),
+    user: $('user').value.trim(),
+    pass: $('pass').value,        // blank = keep stored
+    domain: $('domain').value.trim(),
+    anonymous: anon,
+  };
+}
+
+async function save() {
+  const r = await fetch('/api/config', {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(readForm()),
+  });
+  if (r.ok) { setMsg('Saved.', 'ok'); $('pass').value = ''; loadStatus(); }
+  else setMsg('Save failed.', 'err');
+}
+
+async function test() {
+  setMsg('Testing…');
+  await save();
+  const res = await (await fetch('/api/test', { method: 'POST' })).json();
+  if (res.ok) setMsg('Connected to the share ✓', 'ok');
+  else setMsg('Could not connect: ' + (res.error || 'unknown'), 'err');
+}
+
+async function browse(path) {
+  setMsg('Loading ' + (path || 'root') + '…');
+  const res = await (await fetch('/api/browse?path=' + encodeURIComponent(path || ''))).json();
+  const ul = $('list');
+  ul.innerHTML = '';
+  if (!res.ok) { setMsg('Browse failed: ' + (res.error || 'unknown'), 'err'); return; }
+  setMsg('');
+  if (path) {
+    const up = document.createElement('li');
+    up.textContent = '↩ ..';
+    up.style.cursor = 'pointer'; up.style.padding = '4px 0';
+    up.onclick = () => browse(path.split('/').slice(0, -1).join('/'));
+    ul.appendChild(up);
+  }
+  (res.entries || []).forEach((e) => {
+    const li = document.createElement('li');
+    li.style.padding = '4px 0';
+    li.textContent = (e.isDir ? '📁 ' : '🎬 ') + e.name;
+    if (e.isDir) {
+      li.style.cursor = 'pointer';
+      li.onclick = () => browse((path ? path + '/' : '') + e.name);
+    } else {
+      li.style.color = 'var(--mut)';
+    }
+    ul.appendChild(li);
+  });
+}
+
+$('anon').onclick = () => { anon = !anon; paintAnon(); };
+$('save').onclick = save;
+$('test').onclick = test;
+$('browse').onclick = async () => { await save(); browse(''); };
+
+loadConfig();
+loadStatus();
+setInterval(loadStatus, 5000);

--- a/vlc-transcode-server/internal/web/static/index.html
+++ b/vlc-transcode-server/internal/web/static/index.html
@@ -43,6 +43,7 @@
     <div class="kv"><span>Encoder</span><span class="pill" id="st-enc">…</span></div>
     <div class="kv"><span>Hardware accel</span><span class="pill" id="st-hw">…</span></div>
     <div class="kv"><span>Share</span><span id="st-share">…</span></div>
+    <div class="kv"><span>This server</span><span id="st-url">…</span></div>
   </div>
 
   <div class="card">
@@ -70,6 +71,22 @@
     </div>
     <div class="msg" id="msg"></div>
     <ul id="list" style="list-style:none;padding:0;margin:12px 0 0;font-size:13px;"></ul>
+  </div>
+
+  <div class="card">
+    <h2>Pair with TV</h2>
+    <p class="sub" style="margin:0 0 10px">On the TV: <b>Settings → Transcode server → Pair</b>. Enter the code it shows here.</p>
+    <div class="row">
+      <div><label>TV pairing code</label><input type="text" id="code" placeholder="e.g. 7gk2p9qx1m"></div>
+      <div style="flex:0 0 auto;display:flex;align-items:flex-end"><button class="primary" id="pair">Pair</button></div>
+    </div>
+    <div class="msg" id="pairmsg"></div>
+  </div>
+
+  <div class="card" id="testcard" style="display:none">
+    <h2>Test transcoding</h2>
+    <p class="sub" style="margin:0 0 8px">Open this in VLC on a laptop to confirm a file plays (replace the path):</p>
+    <code id="testlink" style="display:block;word-break:break-all;background:#0e1117;border:1px solid var(--line);border-radius:8px;padding:10px;font-size:12px;color:var(--acc)"></code>
   </div>
 </div>
 <script src="app.js"></script>

--- a/vlc-transcode-server/internal/web/static/index.html
+++ b/vlc-transcode-server/internal/web/static/index.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>VLC Transcode Server</title>
+<style>
+  :root { --bg:#11141a; --card:#1b1f29; --line:#2a3040; --fg:#e7ecf3; --mut:#8d97a8; --acc:#ff7a18; --ok:#34c759; --err:#ff5a5a; }
+  * { box-sizing:border-box; }
+  body { margin:0; font:15px/1.5 system-ui,sans-serif; background:var(--bg); color:var(--fg); }
+  .wrap { max-width:640px; margin:0 auto; padding:24px 18px 60px; }
+  h1 { font-size:20px; margin:0 0 2px; display:flex; align-items:center; gap:10px; }
+  h1 .dot { width:10px; height:10px; border-radius:50%; background:var(--mut); }
+  .sub { color:var(--mut); margin:0 0 22px; font-size:13px; }
+  .card { background:var(--card); border:1px solid var(--line); border-radius:12px; padding:18px; margin-bottom:16px; }
+  .card h2 { font-size:14px; text-transform:uppercase; letter-spacing:.06em; color:var(--mut); margin:0 0 14px; }
+  label { display:block; font-size:13px; color:var(--mut); margin:12px 0 4px; }
+  input[type=text], input[type=password] { width:100%; padding:10px 12px; border-radius:8px; border:1px solid var(--line); background:#0e1117; color:var(--fg); font-size:14px; }
+  .row { display:flex; gap:12px; } .row > div { flex:1; }
+  .toggle { display:flex; align-items:center; justify-content:space-between; margin-top:14px; }
+  button { font:inherit; border:0; border-radius:8px; padding:10px 16px; cursor:pointer; }
+  .primary { background:var(--acc); color:#1b1209; font-weight:600; }
+  .ghost { background:#0e1117; color:var(--fg); border:1px solid var(--line); }
+  .bar { display:flex; gap:10px; margin-top:18px; flex-wrap:wrap; }
+  .msg { margin-top:12px; font-size:13px; min-height:18px; }
+  .msg.ok { color:var(--ok); } .msg.err { color:var(--err); }
+  .kv { display:flex; justify-content:space-between; padding:6px 0; border-bottom:1px solid var(--line); font-size:13px; }
+  .kv:last-child { border:0; } .kv span:first-child { color:var(--mut); }
+  .pill { font-size:12px; padding:2px 8px; border-radius:99px; background:#0e1117; border:1px solid var(--line); }
+  .switch { width:46px; height:26px; border-radius:99px; background:#0e1117; border:1px solid var(--line); position:relative; cursor:pointer; }
+  .switch.on { background:var(--acc); }
+  .switch i { position:absolute; top:2px; left:2px; width:20px; height:20px; border-radius:50%; background:#fff; transition:.15s; }
+  .switch.on i { left:22px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1><span class="dot" id="hdot"></span> VLC Transcode Server</h1>
+  <p class="sub">Reads your SMB share, transcodes only what the TV can't play, streams it back.</p>
+
+  <div class="card">
+    <h2>Status</h2>
+    <div class="kv"><span>Encoder</span><span class="pill" id="st-enc">…</span></div>
+    <div class="kv"><span>Hardware accel</span><span class="pill" id="st-hw">…</span></div>
+    <div class="kv"><span>Share</span><span id="st-share">…</span></div>
+  </div>
+
+  <div class="card">
+    <h2>SMB Share</h2>
+    <div class="row">
+      <div><label>Host / IP</label><input type="text" id="host" placeholder="192.168.1.10"></div>
+      <div style="max-width:110px"><label>Port</label><input type="text" id="port" placeholder="445"></div>
+    </div>
+    <label>Share name</label><input type="text" id="share" placeholder="Media">
+    <div class="toggle">
+      <span>Guest / anonymous</span>
+      <div class="switch" id="anon"><i></i></div>
+    </div>
+    <div id="creds">
+      <div class="row">
+        <div><label>Username</label><input type="text" id="user" placeholder="patrick"></div>
+        <div><label>Domain (optional)</label><input type="text" id="domain"></div>
+      </div>
+      <label>Password</label><input type="password" id="pass" placeholder="••••••• (blank = unchanged)">
+    </div>
+    <div class="bar">
+      <button class="primary" id="save">Save</button>
+      <button class="ghost" id="test">Test connection</button>
+      <button class="ghost" id="browse">Browse share</button>
+    </div>
+    <div class="msg" id="msg"></div>
+    <ul id="list" style="list-style:none;padding:0;margin:12px 0 0;font-size:13px;"></ul>
+  </div>
+</div>
+<script src="app.js"></script>
+</body>
+</html>

--- a/vlc-transcode-server/main.go
+++ b/vlc-transcode-server/main.go
@@ -33,6 +33,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("config: %v", err)
 	}
+	if err := cfg.EnsureToken(); err != nil {
+		log.Fatalf("token: %v", err)
+	}
 
 	// Auto-detect ffmpeg + the best available H.264 encoder.
 	caps, err := transcode.Probe(cfg.Encoder)

--- a/vlc-transcode-server/main.go
+++ b/vlc-transcode-server/main.go
@@ -1,0 +1,88 @@
+// vlc-transcode-server — a tiny self-hosted companion for the VLC Tizen TV app.
+//
+// It reads media from your SMB share, transcodes only what the TV can't decode
+// (DTS/TrueHD audio, unsupported video) into a TV-friendly HLS stream, and hands
+// the TV a URL to play. Everything is configured from an embedded web page, and
+// the ffmpeg encoder is auto-detected at startup so the same build runs on a
+// Rockchip board, an Intel mini-PC, a Pi, or a plain VM.
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/PatrickSt1991/vlc-tizen-tv/vlc-transcode-server/internal/config"
+	"github.com/PatrickSt1991/vlc-tizen-tv/vlc-transcode-server/internal/smb"
+	"github.com/PatrickSt1991/vlc-tizen-tv/vlc-transcode-server/internal/transcode"
+	"github.com/PatrickSt1991/vlc-tizen-tv/vlc-transcode-server/internal/web"
+)
+
+func main() {
+	log.SetFlags(log.LstdFlags)
+
+	port := envInt("PORT", 8200)
+	dataDir := envStr("DATA_DIR", "/data")
+	workDir := envStr("WORK_DIR", filepath.Join(os.TempDir(), "vlc-transcode"))
+
+	// Config (web-editable; created on first save).
+	cfg, err := config.Load(filepath.Join(dataDir, "config.json"))
+	if err != nil {
+		log.Fatalf("config: %v", err)
+	}
+
+	// Auto-detect ffmpeg + the best available H.264 encoder.
+	caps, err := transcode.Probe(cfg.Encoder)
+	if err != nil {
+		log.Fatalf("ffmpeg not found — install ffmpeg (the Docker image bundles it): %v", err)
+	}
+	log.Printf("ffmpeg=%s encoder=%s (%s)", caps.FFmpeg, caps.VideoEncoder, caps.HWAccel)
+
+	smbClient := smb.New(&cfg.SMB)
+
+	// The manager needs to know how to build the localhost raw-bridge URL, which
+	// lives in the web layer — wire it after constructing the server.
+	srv := web.New(cfg, smbClient, nil, port)
+	mgr, err := transcode.NewManager(caps, workDir, srv.RawURL)
+	if err != nil {
+		log.Fatalf("manager: %v", err)
+	}
+	srv.SetManager(mgr)
+
+	addr := fmt.Sprintf(":%d", port)
+	httpSrv := &http.Server{
+		Addr:              addr,
+		Handler:           srv.Handler(),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	if cfg.Configured() {
+		log.Printf("SMB target: %s/%s", cfg.SMB.Host, cfg.SMB.Share)
+	} else {
+		log.Printf("not configured yet — open http://<this-box>%s to set your SMB share", addr)
+	}
+	log.Printf("listening on %s", addr)
+	if err := httpSrv.ListenAndServe(); err != nil {
+		log.Fatalf("http: %v", err)
+	}
+}
+
+func envStr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func envInt(k string, def int) int {
+	if v := os.Getenv(k); v != "" {
+		var n int
+		if _, err := fmt.Sscanf(v, "%d", &n); err == nil {
+			return n
+		}
+	}
+	return def
+}


### PR DESCRIPTION
A self-hosted companion that fixes the codecs the TV can't decode (DTS / TrueHD, unsupported video) by transcoding them on a small always-on box (e.g. an AM6b+) and streaming TV-friendly **HLS** back. The TV keeps browsing SMB exactly as before — only *where the bytes come from* changes when you press play.

## How it works
- The TV mints a pairing code (existing ntfy mechanism). The server publishes its LAN URL + token to a separate `vlctv-<code>-srv` topic; the TV pulls it once and stores it.
- SMB **browsing on the TV is unchanged** (still the localhost smbproxy). When a server is paired, `smb.js` routes the *play* URL through `http://<server>/play?path=…` (HLS); otherwise it falls back to the direct localhost stream. Behaviour is byte-for-byte identical when nothing is paired.
- The server reads the file from its own SMB connection, probes it, and does the **cheapest** treatment: remux (copy/copy), audio-only transcode (DTS/TrueHD → AC3/AAC), or full hardware transcode.

## What's in it
- **`vlc-transcode-server/`** — Go service: SMB client, startup ffmpeg-encoder auto-detect (`rkmpp→vaapi→nvenc→qsv→v4l2m2m→libx264`), ffprobe decision engine, HLS session manager, embedded point-and-click web setup UI, Dockerfile + compose.
- **TV app** — new `js/server.js` (`TranscodeServer`), `smb.js` play-URL swap, and a "Transcode server" settings section.
- **CI** — multi-arch (amd64 + arm64) image published to `ghcr.io/patrickst1991/vlc-transcode`.

## Verification
- Go `build` + `vet` + unit test green; media plane verified end-to-end with stub ffmpeg (manifest rewrite, segment fetch, correct dts→ac3 decision).
- TV JS passes `node --check`.
- ⚠️ **Not yet verified on real TV hardware** — AVPlay HLS playback on an actual Samsung TV is the remaining check before this should be treated as stable.

## Pre-release builds for testing
- Server image: `ghcr.io/patrickst1991/vlc-transcode:0.1.0-beta`
- TV app: release `v1.0-20260619-1105` (`vlctv.wgt`)

## Known limitations
- Seeking only within the already-transcoded range (no seek-restart yet).
- Subtitles not yet muxed into the HLS stream (app handles subs separately).
- Rockchip rkmpp needs a custom ffmpeg build; stock falls back to V4L2/software.

🤖 Generated with [Claude Code](https://claude.com/claude-code)