### PR TITLE
transcode-server: native Windows / macOS binaries + extended HW encod…

### DIFF
--- a/.github/workflows/transcode-server-native.yml
+++ b/.github/workflows/transcode-server-native.yml
@@ -1,0 +1,102 @@
+name: Build transcode-server native binaries
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'transcode-v*'
+
+permissions:
+  contents: write   # needed to create / attach assets to the GitHub Release
+
+jobs:
+  build:
+    name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Native installs for users who don't want Docker. Same Go source as
+          # the container image; ffmpeg is expected to be on PATH (Linux/macOS
+          # via the system package manager, Windows via gyan.dev or BtbN — see
+          # vlc-transcode-server/README.md).
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+            ext: '.exe'
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache-dependency-path: vlc-transcode-server/go.sum
+
+      - name: Cross-compile
+        working-directory: vlc-transcode-server
+        env:
+          CGO_ENABLED: 0
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          set -euo pipefail
+          OUT="vlc-transcode${{ matrix.ext }}"
+          go build -trimpath -ldflags="-s -w" -o "$OUT" .
+          ls -la "$OUT"
+
+      - name: Bundle (binary + README)
+        working-directory: vlc-transcode-server
+        run: |
+          set -euo pipefail
+          BUNDLE="$RUNNER_TEMP/bundle"
+          mkdir -p "$BUNDLE"
+          cp "vlc-transcode${{ matrix.ext }}" "$BUNDLE/"
+          cp README.md "$BUNDLE/"
+          mkdir -p "$GITHUB_WORKSPACE/dist"
+          ZIP="$GITHUB_WORKSPACE/dist/vlc-transcode-${{ matrix.goos }}-${{ matrix.goarch }}.zip"
+          ( cd "$BUNDLE" && zip -r "$ZIP" . )
+          ls -la "$ZIP"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vlc-transcode-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/*.zip
+          if-no-files-found: error
+          retention-days: 14
+
+  release:
+    name: Attach binaries to GitHub Release
+    # Only run on tag pushes — workflow_dispatch builds the binaries (uploaded
+    # as build artifacts) but doesn't touch a release.
+    if: startsWith(github.ref, 'refs/tags/transcode-v')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: List
+        run: ls -la dist
+
+      - name: Create / update release with assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.zip
+          fail_on_unmatched_files: true
+          tag_name: ${{ github.ref_name }}
+          # Don't overwrite the body/title the maintainer set on the tag.
+          generate_release_notes: false

--- a/vlc-transcode-server/README.md
+++ b/vlc-transcode-server/README.md
@@ -41,6 +41,84 @@ Then open **`http://<box-ip>:8200`** in any browser and fill in your SMB share
 (host, share name, username/password — or toggle Guest). Use **Test connection**
 and **Browse share** to confirm it can see your files.
 
+## Run it natively (Windows / macOS / no-Docker Linux)
+
+Docker is the recommended path on a server / NAS / Proxmox box that's going to
+stay up. For Windows and macOS — or any machine where installing Docker is more
+effort than the transcoder itself — there are static binaries you can run
+straight, no container. They're built from the same Go source as the image and
+go through the same encoder auto-detection at startup.
+
+**1. Grab the binary** for your platform from the
+[Releases page](https://github.com/PatrickSt1991/vlc-tizen-tv/releases),
+under the latest `transcode-v*` tag:
+
+| OS | Asset |
+|---|---|
+| Windows x64 | `vlc-transcode-windows-amd64.zip` |
+| macOS Apple Silicon | `vlc-transcode-darwin-arm64.zip` |
+| macOS Intel | `vlc-transcode-darwin-amd64.zip` |
+| Linux x64 | `vlc-transcode-linux-amd64.zip` |
+| Linux ARM64 (Raspberry Pi 4/5, generic ARM) | `vlc-transcode-linux-arm64.zip` |
+
+Unzip anywhere. There's a single executable plus this README.
+
+**2. Install ffmpeg**, because — unlike the Docker image — the bundle doesn't
+ship it. Recommended sources:
+
+| OS | Where to get ffmpeg |
+|---|---|
+| Windows | [gyan.dev "full" build](https://www.gyan.dev/ffmpeg/builds/) or [BtbN "gpl" build](https://github.com/BtbN/FFmpeg-Builds/releases). Either includes `h264_qsv` (Intel), `h264_nvenc` (NVIDIA), and `h264_amf` (AMD). Drop `ffmpeg.exe` and `ffprobe.exe` either on your `PATH` or next to `vlc-transcode.exe`. |
+| macOS | `brew install ffmpeg` — Homebrew's build includes `h264_videotoolbox` for native Apple Silicon / Intel HW encoding. |
+| Linux | `apt install ffmpeg` or your distro equivalent. Includes VAAPI, NVENC and software encoders. |
+
+**3. Run it.** It listens on `:8200` on all interfaces, so it's reachable
+from the TV out of the box. You only need to point it at a writable data
+directory (where the config + pairing token live):
+
+```bash
+# Linux / macOS
+DATA_DIR=./vlc-data ./vlc-transcode
+
+# Windows (cmd.exe / PowerShell)
+set DATA_DIR=%CD%\vlc-data
+vlc-transcode.exe
+```
+
+If you'd rather use a different port, set `PORT=8201` (etc.) in the same
+env. The default `/data` is fine inside Docker but won't exist on a native
+install — `./vlc-data` next to the binary is the easiest choice.
+
+On first start, the binary prints something like:
+
+```
+ffmpeg=/usr/bin/ffmpeg encoder=h264_qsv (qsv)
+listening on :8200
+```
+
+If it instead exits with `ffmpeg not found — install ffmpeg`, your `ffmpeg`
+isn't on `PATH`. Either install it (see the table above) or put `ffmpeg(.exe)`
+and `ffprobe(.exe)` in the same folder as `vlc-transcode(.exe)`.
+
+Then open `http://<this-machine's-LAN-IP>:8200` and continue with [Pair with the
+TV](#pair-with-the-tv) below.
+
+### Why native sometimes beats Docker
+
+For Windows users specifically, the native binary unlocks GPU encoding that
+Docker can't reach:
+
+| GPU | Docker on Windows | Native Windows |
+|---|---|---|
+| Intel iGPU (QuickSync) | ❌ no path — `--device /dev/dri` doesn't exist on WSL2 | ✅ `h264_qsv` auto-detected |
+| NVIDIA | ⚠️ works with Docker Desktop + NVIDIA Container Toolkit + `--gpus all` (fiddly) | ✅ `h264_nvenc` auto-detected |
+| AMD | ❌ no path | ✅ `h264_amf` auto-detected |
+| None / unsupported | software (`libx264`), slow | software (`libx264`), slow |
+
+On macOS, native always wins — Docker Desktop on macOS runs a Linux VM with no
+GPU passthrough, so the container is forced into software encoding; the native
+binary uses `h264_videotoolbox` via macOS's hardware encoder.
+
 ## Pair with the TV
 
 On the TV: **Settings → Transcode server → Pair**, then enter the code the TV

--- a/vlc-transcode-server/internal/transcode/caps.go
+++ b/vlc-transcode-server/internal/transcode/caps.go
@@ -27,16 +27,23 @@ type Caps struct {
 // encoderPriority lists H.264 encoders fastest/most-desirable first. Auto-pick
 // walks this and takes the first one ffmpeg reports as available; libx264 is
 // last and effectively always present, so detection never comes up empty.
+//
+// Cross-platform note: encoders that don't exist on the running host just
+// won't be in ffmpeg's -encoders list, so the same priority array is safe to
+// use on Linux containers, native Windows .exe, and native macOS — each OS
+// auto-picks the encoder its ffmpeg actually ships with.
 var encoderPriority = []struct {
 	name   string
 	family string
 }{
-	{"h264_rkmpp", "rkmpp"},   // Rockchip RK3588/3568
-	{"h264_vaapi", "vaapi"},   // Intel/AMD (and some ARM via Mesa)
-	{"h264_nvenc", "nvenc"},   // Nvidia / Jetson
-	{"h264_qsv", "qsv"},       // Intel QuickSync
-	{"h264_v4l2m2m", "v4l2m2m"}, // Amlogic and many generic ARM SoCs
-	{"libx264", "none"},       // software — universal fallback
+	{"h264_rkmpp", "rkmpp"},               // Rockchip RK3588/3568 (Linux native, custom ffmpeg)
+	{"h264_videotoolbox", "videotoolbox"}, // macOS (Apple Silicon + Intel Macs)
+	{"h264_vaapi", "vaapi"},               // Linux Intel/AMD (Mesa)
+	{"h264_nvenc", "nvenc"},               // NVIDIA / Jetson — cross-platform
+	{"h264_qsv", "qsv"},                   // Intel QuickSync — Windows + Linux
+	{"h264_amf", "amf"},                   // AMD AMF — Windows (and rare Linux builds)
+	{"h264_v4l2m2m", "v4l2m2m"},           // Amlogic and many generic ARM SoCs
+	{"libx264", "none"},                   // software — universal fallback
 }
 
 // Probe locates ffmpeg/ffprobe and picks an encoder. override forces a specific


### PR DESCRIPTION
…er list

Right now the transcode-server only ships as a Linux Docker image and relies on --device /dev/dri for hardware acceleration.  That leaves Windows / macOS users with two bad choices: WSL2 with broken GPU passthrough, or software-only Docker encoding (~1× realtime).

Same Go source — CGO_ENABLED=0 and pure-Go SMB already — cross-compiles to every common target without changing a line.  Three pieces:

  1. caps.go: extend encoderPriority with h264_videotoolbox (macOS) and h264_amf (AMD on Windows).  Existing rkmpp/vaapi/nvenc/qsv/ v4l2m2m/libx264 stay where they are; the auto-detect walks the list and picks whatever ffmpeg actually has on the host, so the same array is safe for all platforms.

  2. .github/workflows/transcode-server-native.yml: new sibling workflow alongside the Docker one.  GOOS/GOARCH matrix builds linux/amd64, linux/arm64, windows/amd64, darwin/amd64, darwin/arm64; each bundle gets zipped with the README and uploaded.  On a transcode-v* tag, all five zips attach to the GitHub Release automatically.

  3. README.md: new "Run it natively" section covering download + ffmpeg install (gyan.dev / BtbN / brew / apt) + run command for each OS, plus a table showing why native beats Docker on Windows (QSV / NVENC / AMF auto-detect without GPU passthrough) and why native is the only HW-accel path on macOS at all.