### PR TITLE
transcode-server: bundle ffmpeg into the native zips (Win/Linux)

### DIFF
--- a/.github/workflows/transcode-server-native.yml
+++ b/.github/workflows/transcode-server-native.yml
@@ -17,17 +17,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Native installs for users who don't want Docker. Same Go source as
-          # the container image; ffmpeg is expected to be on PATH (Linux/macOS
-          # via the system package manager, Windows via gyan.dev or BtbN — see
-          # vlc-transcode-server/README.md).
+          # Native installs for users who don't want Docker.  Same Go source
+          # as the container image.  Windows + Linux bundles ALSO ship
+          # ffmpeg + ffprobe (BtbN's GPL-licensed builds) so users can
+          # double-click and go — no separate install step.  macOS bundles
+          # don't (BtbN doesn't publish macOS, and brew install ffmpeg is
+          # the universal-correct answer on Mac anyway).
           - goos: linux
             goarch: amd64
+            ffmpeg_url: 'https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz'
+            ffmpeg_archive: tar.xz
           - goos: linux
             goarch: arm64
+            ffmpeg_url: 'https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linuxarm64-gpl.tar.xz'
+            ffmpeg_archive: tar.xz
           - goos: windows
             goarch: amd64
             ext: '.exe'
+            ffmpeg_url: 'https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip'
+            ffmpeg_archive: zip
           - goos: darwin
             goarch: amd64
           - goos: darwin
@@ -54,7 +62,24 @@ jobs:
           go build -trimpath -ldflags="-s -w" -o "$OUT" .
           ls -la "$OUT"
 
-      - name: Bundle (binary + README)
+      - name: Fetch + extract bundled ffmpeg (Linux / Windows only)
+        if: matrix.ffmpeg_url != ''
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/ff"
+          cd "$RUNNER_TEMP/ff"
+          curl -fL --retry 3 -o ffmpeg-bundle.${{ matrix.ffmpeg_archive }} "${{ matrix.ffmpeg_url }}"
+          if [ "${{ matrix.ffmpeg_archive }}" = "zip" ]; then
+            unzip -q ffmpeg-bundle.zip
+          else
+            tar -xf ffmpeg-bundle.tar.xz
+          fi
+          # BtbN archives extract to a single ffmpeg-master-latest-<plat>-gpl/
+          # directory with binaries in bin/ and licenses at the top level.
+          ROOT=$(find . -mindepth 1 -maxdepth 1 -type d | head -n1)
+          ls "$ROOT/bin"
+
+      - name: Bundle (binary + README + bundled ffmpeg if any)
         working-directory: vlc-transcode-server
         run: |
           set -euo pipefail
@@ -62,6 +87,21 @@ jobs:
           mkdir -p "$BUNDLE"
           cp "vlc-transcode${{ matrix.ext }}" "$BUNDLE/"
           cp README.md "$BUNDLE/"
+
+          # If this matrix entry bundles ffmpeg, copy ffmpeg + ffprobe alongside
+          # the binary and pull in the GPL license text so we're square with
+          # FFmpeg's licensing.
+          if [ -n "${{ matrix.ffmpeg_url }}" ]; then
+            ROOT=$(find "$RUNNER_TEMP/ff" -mindepth 1 -maxdepth 1 -type d | head -n1)
+            cp "$ROOT/bin/ffmpeg${{ matrix.ext }}"  "$BUNDLE/"
+            cp "$ROOT/bin/ffprobe${{ matrix.ext }}" "$BUNDLE/"
+            # BtbN ships its build's LICENSE.txt at the archive root; preserve
+            # it so the GPL attribution travels with the binary.
+            if [ -f "$ROOT/LICENSE.txt" ]; then
+              cp "$ROOT/LICENSE.txt" "$BUNDLE/FFMPEG_LICENSE.txt"
+            fi
+          fi
+
           mkdir -p "$GITHUB_WORKSPACE/dist"
           ZIP="$GITHUB_WORKSPACE/dist/vlc-transcode-${{ matrix.goos }}-${{ matrix.goarch }}.zip"
           ( cd "$BUNDLE" && zip -r "$ZIP" . )

--- a/vlc-transcode-server/README.md
+++ b/vlc-transcode-server/README.md
@@ -53,26 +53,21 @@ go through the same encoder auto-detection at startup.
 [Releases page](https://github.com/PatrickSt1991/vlc-tizen-tv/releases),
 under the latest `transcode-v*` tag:
 
-| OS | Asset |
-|---|---|
-| Windows x64 | `vlc-transcode-windows-amd64.zip` |
-| macOS Apple Silicon | `vlc-transcode-darwin-arm64.zip` |
-| macOS Intel | `vlc-transcode-darwin-amd64.zip` |
-| Linux x64 | `vlc-transcode-linux-amd64.zip` |
-| Linux ARM64 (Raspberry Pi 4/5, generic ARM) | `vlc-transcode-linux-arm64.zip` |
+| OS | Asset | Bundled ffmpeg? |
+|---|---|---|
+| Windows x64 | `vlc-transcode-windows-amd64.zip` | ✅ included (BtbN GPL build) |
+| Linux x64 | `vlc-transcode-linux-amd64.zip` | ✅ included (BtbN GPL build) |
+| Linux ARM64 (Raspberry Pi 4/5, generic ARM) | `vlc-transcode-linux-arm64.zip` | ✅ included |
+| macOS Apple Silicon | `vlc-transcode-darwin-arm64.zip` | ❌ run `brew install ffmpeg` |
+| macOS Intel | `vlc-transcode-darwin-amd64.zip` | ❌ run `brew install ffmpeg` |
 
-Unzip anywhere. There's a single executable plus this README.
+Unzip anywhere. On Windows + Linux that gets you `vlc-transcode(.exe)` plus
+`ffmpeg(.exe)` and `ffprobe(.exe)` in the same folder — the server picks them
+up automatically (the binary prepends its own directory to `PATH` at
+startup), so there's nothing to install. On macOS, `brew install ffmpeg` once
+and it's permanently on `PATH`.
 
-**2. Install ffmpeg**, because — unlike the Docker image — the bundle doesn't
-ship it. Recommended sources:
-
-| OS | Where to get ffmpeg |
-|---|---|
-| Windows | [gyan.dev "full" build](https://www.gyan.dev/ffmpeg/builds/) or [BtbN "gpl" build](https://github.com/BtbN/FFmpeg-Builds/releases). Either includes `h264_qsv` (Intel), `h264_nvenc` (NVIDIA), and `h264_amf` (AMD). Drop `ffmpeg.exe` and `ffprobe.exe` either on your `PATH` or next to `vlc-transcode.exe`. |
-| macOS | `brew install ffmpeg` — Homebrew's build includes `h264_videotoolbox` for native Apple Silicon / Intel HW encoding. |
-| Linux | `apt install ffmpeg` or your distro equivalent. Includes VAAPI, NVENC and software encoders. |
-
-**3. Run it.** It listens on `:8200` on all interfaces, so it's reachable
+**2. Run it.** It listens on `:8200` on all interfaces, so it's reachable
 from the TV out of the box. You only need to point it at a writable data
 directory (where the config + pairing token live):
 

--- a/vlc-transcode-server/main.go
+++ b/vlc-transcode-server/main.go
@@ -24,6 +24,16 @@ import (
 func main() {
 	log.SetFlags(log.LstdFlags)
 
+	// Native installs bundle ffmpeg/ffprobe in the same directory as this
+	// binary — prepend that directory to PATH so exec.LookPath finds them
+	// without the user having to add anything to their system PATH.  On
+	// Docker / system installs this is a no-op (ffmpeg is already on PATH
+	// and the lookup just finds the system one first if our dir doesn't
+	// contain a binary by that name).
+	if exe, err := os.Executable(); err == nil {
+		os.Setenv("PATH", filepath.Dir(exe)+string(os.PathListSeparator)+os.Getenv("PATH"))
+	}
+
 	port := envInt("PORT", 8200)
 	dataDir := envStr("DATA_DIR", "/data")
 	workDir := envStr("WORK_DIR", filepath.Join(os.TempDir(), "vlc-transcode"))


### PR DESCRIPTION
User running the freshly-built Windows binary on a clean PC immediately hit "ffmpeg not found" — the bundle deliberately didn't ship ffmpeg and asked them to install it first.  That's friction we can erase: the native zip should be "double-click and go", because anyone reaching for a native install instead of Docker is opting out of figuring things out.

Per-platform changes:

  Workflow (.github/workflows/transcode-server-native.yml)
    - Add ffmpeg_url + ffmpeg_archive to the matrix for linux/amd64, linux/arm64, and windows/amd64 — pointing at BtbN's ffmpeg-master-latest-*-gpl builds (zip on Windows, tar.xz on Linux).  macOS entries deliberately leave them blank so the bundle stays small there.
    - New "Fetch + extract bundled ffmpeg" step runs only when the matrix entry sets ffmpeg_url; downloads BtbN's archive, extracts to RUNNER_TEMP/ff/<root>/.
    - Bundle step copies ffmpeg(.exe) + ffprobe(.exe) into the zip alongside the binary, plus FFMPEG_LICENSE.txt for GPL attribution.

  main.go
    - Prepend the binary's own directory to PATH at startup so the bundled ffmpeg is picked up by exec.LookPath without the user having to add anything to their system PATH.  No-op on Docker / system installs where ffmpeg already resolves.

  README.md
    - Replace the "install ffmpeg yourself" step with a per-platform table that calls out which bundles ship it and which ask for brew install ffmpeg (macOS only).
    - Renumber sections to drop the now-unnecessary install step.

macOS isn't bundled because BtbN doesn't publish macOS builds and evermeet.cx's URLs aren't stable enough to script in CI; brew install ffmpeg is the universal-correct answer on Mac.