### PR TITLE
transcode-server: gate encoder priority by runtime.GOOS

### DIFF
--- a/vlc-transcode-server/internal/transcode/caps.go
+++ b/vlc-transcode-server/internal/transcode/caps.go
@@ -3,6 +3,7 @@ package transcode
 import (
 	"context"
 	"os/exec"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -25,25 +26,46 @@ type Caps struct {
 }
 
 // encoderPriority lists H.264 encoders fastest/most-desirable first. Auto-pick
-// walks this and takes the first one ffmpeg reports as available; libx264 is
-// last and effectively always present, so detection never comes up empty.
+// walks this and takes the first one that's BOTH listed by ffmpeg AND runnable
+// on the current OS; libx264 is last and effectively always present, so
+// detection never comes up empty.
 //
-// Cross-platform note: encoders that don't exist on the running host just
-// won't be in ffmpeg's -encoders list, so the same priority array is safe to
-// use on Linux containers, native Windows .exe, and native macOS — each OS
-// auto-picks the encoder its ffmpeg actually ships with.
+// The OS gate matters because some ffmpeg builds compile an encoder in for
+// cross-platform consistency even when its runtime isn't there.  BtbN's
+// Windows build, for instance, still lists h264_vaapi in -encoders output
+// (libva linked in), but VAAPI has no working backend on Windows — picking it
+// would fail at runtime with "Error opening output files: Invalid argument"
+// the moment ffmpeg tries to open /dev/dri.  Without the gate, our auto-pick
+// chose h264_vaapi on the Windows build over the actually-working h264_qsv /
+// h264_nvenc / h264_amf below it.  The "oses" field restricts each encoder
+// family to the operating systems where its runtime actually exists.
 var encoderPriority = []struct {
 	name   string
 	family string
+	oses   []string // matched against runtime.GOOS; nil means "any OS"
 }{
-	{"h264_rkmpp", "rkmpp"},               // Rockchip RK3588/3568 (Linux native, custom ffmpeg)
-	{"h264_videotoolbox", "videotoolbox"}, // macOS (Apple Silicon + Intel Macs)
-	{"h264_vaapi", "vaapi"},               // Linux Intel/AMD (Mesa)
-	{"h264_nvenc", "nvenc"},               // NVIDIA / Jetson — cross-platform
-	{"h264_qsv", "qsv"},                   // Intel QuickSync — Windows + Linux
-	{"h264_amf", "amf"},                   // AMD AMF — Windows (and rare Linux builds)
-	{"h264_v4l2m2m", "v4l2m2m"},           // Amlogic and many generic ARM SoCs
-	{"libx264", "none"},                   // software — universal fallback
+	{"h264_rkmpp", "rkmpp", []string{"linux"}},                // Rockchip RK3588/3568 (custom ffmpeg, Linux only)
+	{"h264_videotoolbox", "videotoolbox", []string{"darwin"}}, // macOS hardware encoder
+	{"h264_vaapi", "vaapi", []string{"linux"}},                // Mesa / libva — Linux only
+	{"h264_nvenc", "nvenc", []string{"linux", "windows"}},     // NVIDIA / Jetson
+	{"h264_qsv", "qsv", []string{"linux", "windows"}},         // Intel QuickSync
+	{"h264_amf", "amf", []string{"windows"}},                  // AMD AMF — Windows only in practice
+	{"h264_v4l2m2m", "v4l2m2m", []string{"linux"}},            // ARM SoCs (Amlogic, etc.) — Linux only
+	{"libx264", "none", nil},                                  // software — any OS
+}
+
+// osMatches reports whether the encoder can run on runtime.GOOS.  Nil oses
+// means "no restriction".
+func osMatches(oses []string) bool {
+	if oses == nil {
+		return true
+	}
+	for _, o := range oses {
+		if o == runtime.GOOS {
+			return true
+		}
+	}
+	return false
 }
 
 // Probe locates ffmpeg/ffprobe and picks an encoder. override forces a specific
@@ -62,12 +84,18 @@ func Probe(override string) (*Caps, error) {
 
 	avail := listEncoders(ff)
 
-	// Honour an explicit override if ffmpeg actually has it.
+	// Honour an explicit override if ffmpeg actually has it — the user is
+	// telling us they know better than the auto-detect.  Skip the OS gate
+	// here; if they ask for h264_vaapi on Windows they get the obvious
+	// runtime error rather than a silent fallback that's harder to debug.
 	if override != "" && avail[override] {
 		c.VideoEncoder = override
 		c.HWAccel = familyOf(override)
 	} else {
 		for _, e := range encoderPriority {
+			if !osMatches(e.oses) {
+				continue
+			}
 			if avail[e.name] {
 				c.VideoEncoder = e.name
 				c.HWAccel = e.family


### PR DESCRIPTION
Tester running the freshly-bundled Windows binary hit:

    ffmpeg=…\ffmpeg.exe encoder=h264_vaapi (vaapi)
    play "/02 - Super Rabbit.avi" failed:
      ffmpeg exited before producing output:
      Error opening output files: Invalid argument

BtbN's Windows ffmpeg compiles libva in for cross-platform consistency, so `h264_vaapi` shows up in the `-encoders` output even though VAAPI has no working runtime on Windows (no /dev/dri, no Mesa).  Our auto-pick walks `encoderPriority` and takes the first match — h264_vaapi sat above the actually-working h264_qsv / h264_nvenc / h264_amf entries, so the Windows install silently chose the broken option.

Add an `oses []string` field to each priority entry, matched against runtime.GOOS in the auto-pick loop.  Each encoder is restricted to the OSes where its runtime actually exists:

  - rkmpp        → linux only
  - videotoolbox → darwin only
  - vaapi        → linux only      ← the bug
  - nvenc        → linux + windows
  - qsv          → linux + windows
  - amf          → windows only
  - v4l2m2m      → linux only
  - libx264      → any              ← universal fallback

The explicit-override path stays unfiltered — if a user puts `"encoder": "h264_vaapi"` in their config.json they get exactly what they asked for, including the obvious error, rather than a silent fallback that's harder to debug.

familyOf still resolves by name and ignores the new field, so the override flow is unchanged.