### PR TITLE
transcode-server: surface full ffmpeg log on early-exit failure

### DIFF
--- a/vlc-transcode-server/internal/transcode/manager.go
+++ b/vlc-transcode-server/internal/transcode/manager.go
@@ -143,7 +143,7 @@ func waitReady(ctx context.Context, s *session) error {
 			return nil
 		}
 		if s.isDone() {
-			return fmt.Errorf("ffmpeg exited before producing output: %s", s.tail())
+			return fmt.Errorf("ffmpeg exited before producing output: %s", s.tailAll())
 		}
 		select {
 		case <-ctx.Done():
@@ -185,6 +185,14 @@ func drain(r interface{ Read([]byte) (int, error) }, s *session) {
 
 func (s *session) tail() string { return s.logTail.last() }
 
+// tailAll returns every non-empty line the ring still holds, oldest first,
+// joined with " / " so it survives travelling through a single-line error
+// message.  Used when ffmpeg dies before producing output — the bare last
+// line ("Nothing was written into output file…") rarely names the actual
+// cause, but the lines before it (input format, stream count, demuxer
+// warnings, codec rejections) usually do. */
+func (s *session) tailAll() string { return s.logTail.dump() }
+
 // ── tiny line ring buffer for surfacing ffmpeg's last words on failure ──────
 type ring struct {
 	mu   sync.Mutex
@@ -217,4 +225,36 @@ func (r *ring) last() string {
 		}
 	}
 	return "(no output)"
+}
+
+// dump returns every non-empty line oldest-first, joined with " / ".
+func (r *ring) dump() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.full && r.n == 0 {
+		return "(no output)"
+	}
+	size := len(r.buf)
+	start := 0
+	if r.full {
+		start = r.n // when full, oldest line lives at r.n
+	}
+	lines := make([]string, 0, size)
+	for i := 0; i < size; i++ {
+		idx := (start + i) % size
+		if r.buf[idx] != "" {
+			lines = append(lines, r.buf[idx])
+		}
+	}
+	if len(lines) == 0 {
+		return "(no output)"
+	}
+	// " / " is a separator unlikely to appear inside ffmpeg's own log lines,
+	// keeps everything on one telemetry line even when it travels through
+	// log.Printf or an HTTP error body.
+	out := lines[0]
+	for _, ln := range lines[1:] {
+		out += " / " + ln
+	}
+	return out
 }

--- a/vlc-transcode-server/internal/transcode/session.go
+++ b/vlc-transcode-server/internal/transcode/session.go
@@ -61,7 +61,12 @@ func (s *session) stop() {
 // the per-file plan. Software decode + (optional) hardware encode keeps the
 // device handling simple while still offloading the expensive encode step.
 func (c *Caps) buildArgs(in string, p Plan, dir string) []string {
-	a := []string{"-hide_banner", "-loglevel", "warning", "-y"}
+	// loglevel "info" keeps the lines we actually need for diagnosis (input
+	// format, stream count, codec mapping, "Output #0" / "Stream mapping",
+	// demuxer warnings) — without flooding the ring buffer like "verbose"
+	// would.  When ffmpeg dies, tailAll() dumps all of these to the failure
+	// message so we can see the cause rather than just "Nothing was written".
+	a := []string{"-hide_banner", "-loglevel", "info", "-y"}
 
 	// Robustness on the internal HTTP raw bridge.
 	a = append(a, "-reconnect", "1", "-reconnect_streamed", "1", "-reconnect_delay_max", "2")


### PR DESCRIPTION
When ffmpeg exits before producing output we currently report only the last non-empty line via session.tail().  For the Windows tester'\''s "Nothing was written into output file" failure mode that's actively unhelpful — the cause (input format, demuxer warning, codec rejection) sits on the lines BEFORE the final summary line, but they get dropped.

Two small changes:

  - Add ring.dump() / session.tailAll(): same ring buffer (60 lines), but returns every non-empty line oldest-first joined with " / " so it survives a single-line log.Printf.  Use it on the "ffmpeg exited before producing output" branch in waitReady.

  - Bump ffmpeg'\''s -loglevel from "warning" to "info" so the ring captures the lines we actually need for diagnosis: input format, stream count, codec mapping ("Stream mapping:", "Output #0"), demuxer warnings.  "verbose" would be noisier than helpful; "info" is the sweet spot.

Should give the next "Nothing was written" run enough context to identify whether it'\''s the HTTP raw bridge, the AVI demuxer, NVENC initialization, or something else.