### PR TITLE
transcode-server: surface "last paired" status across restarts

### DIFF
--- a/vlc-transcode-server/internal/config/config.go
+++ b/vlc-transcode-server/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 )
 
 // SMB holds the connection details for the one share we read media from.
@@ -24,6 +25,17 @@ type SMB struct {
 	Pass      string `json:"pass"`      // empty when Anonymous
 	Domain    string `json:"domain"`    // usually empty
 	Anonymous bool   `json:"anonymous"` // guest/null session
+}
+
+// LastPair records the most recent successful ntfy publish, so the web UI can
+// reassure the user across server restarts that pairing isn't forgotten — the
+// SMB form auto-fills from the persisted config but the TV's code isn't
+// recoverable from anywhere, which made it feel like the server "forgets"
+// after every upgrade.  Knowing the last code + time published is enough to
+// confirm the TV-side token is still valid.
+type LastPair struct {
+	Code string    `json:"code"` // the TV's pairing code we published to
+	At   time.Time `json:"at"`   // when the publish succeeded
 }
 
 // Config is the whole persisted document.
@@ -40,6 +52,11 @@ type Config struct {
 	// the transcoder. It rides in URLs the TV builds automatically — no user
 	// friction.
 	Token string `json:"token,omitempty"`
+
+	// LastPair is the most recent successful publish to ntfy — surfaced in the
+	// web UI as "Last paired with code XYZ at HH:MM".  Nil until the first
+	// successful Pair button click on the web UI.
+	LastPair *LastPair `json:"last_pair,omitempty"`
 
 	path string     // backing file; not serialised
 	mu   sync.Mutex // guards Save against concurrent web writes

--- a/vlc-transcode-server/internal/web/server.go
+++ b/vlc-transcode-server/internal/web/server.go
@@ -234,6 +234,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		"share":      s.cfg.SMB.Host + "/" + s.cfg.SMB.Share,
 		"token":      s.cfg.Token, // LAN-trusted UI; used to build the test link
 		"serverURL":  pair.LocalURL(s.port),
+		"lastPair":   s.cfg.LastPair, // nil until the first successful pair publish
 	})
 }
 
@@ -255,6 +256,14 @@ func (s *Server) handlePair(w http.ResponseWriter, r *http.Request) {
 	if err := pair.Publish(r.Context(), in.Code, url, s.cfg.Token); err != nil {
 		writeJSON(w, map[string]any{"ok": false, "error": err.Error()})
 		return
+	}
+	// Remember this for the web UI so the next visit (or the next binary
+	// upgrade) shows "last paired with code X at HH:MM" rather than feeling
+	// like the server has amnesia.  Failures to save are non-fatal — the
+	// pair publish already succeeded, so the TV side is good.
+	s.cfg.LastPair = &config.LastPair{Code: in.Code, At: time.Now().UTC()}
+	if err := s.cfg.Save(); err != nil {
+		log.Printf("warning: pair succeeded but persisting LastPair failed: %v", err)
 	}
 	writeJSON(w, map[string]any{"ok": true, "url": url})
 }

--- a/vlc-transcode-server/internal/web/static/app.js
+++ b/vlc-transcode-server/internal/web/static/app.js
@@ -15,6 +15,27 @@ function paintAnon() {
   $('creds').style.opacity = anon ? .4 : 1;
 }
 
+// Format a UTC ISO timestamp as "just now / N min ago / today at HH:MM /
+// YYYY-MM-DD HH:MM" depending on how recent it is.  Keeps the "last paired"
+// line readable without bringing in a date library.
+function formatAgo(iso) {
+  if (!iso) return '';
+  const t = new Date(iso);
+  if (isNaN(t)) return '';
+  const sec = Math.floor((Date.now() - t.getTime()) / 1000);
+  if (sec < 60)             return 'just now';
+  if (sec < 60 * 60)        return Math.floor(sec / 60) + ' min ago';
+  // Today: same Y/M/D as now → show HH:MM
+  const now = new Date();
+  const sameDay =
+    t.getFullYear() === now.getFullYear() &&
+    t.getMonth()    === now.getMonth() &&
+    t.getDate()     === now.getDate();
+  const hhmm = String(t.getHours()).padStart(2,'0') + ':' + String(t.getMinutes()).padStart(2,'0');
+  if (sameDay) return 'today at ' + hhmm;
+  return t.toISOString().slice(0,10) + ' ' + hhmm;
+}
+
 async function loadStatus() {
   try {
     const s = await (await fetch('/api/status')).json();
@@ -26,6 +47,17 @@ async function loadStatus() {
     if (s.configured && s.serverURL && s.token) {
       $('testcard').style.display = '';
       $('testlink').textContent = s.serverURL + '/play?path=/Movies/YourFile.mkv&token=' + s.token;
+    }
+    // "Last paired" indicator — survives server restarts so the user doesn't
+    // think they have to re-pair after every binary upgrade.
+    const lp = s.lastPair;
+    const lpEl = $('lastpair');
+    if (lp && lp.code && lp.at) {
+      lpEl.textContent = 'Last paired with code ' + lp.code + ' · ' + formatAgo(lp.at) +
+                         ' — the TV should still be paired; only re-pair if you reinstall the app on it.';
+      lpEl.style.display = '';
+    } else {
+      lpEl.style.display = 'none';
     }
   } catch (e) { /* server starting */ }
 }
@@ -41,6 +73,8 @@ async function pair() {
   if (res.ok) {
     $('pairmsg').textContent = 'Sent ' + res.url + ' to the TV. Press “Pair” on the TV to finish.';
     $('pairmsg').className = 'msg ok';
+    // Pick up the freshly-saved lastPair without waiting for the 5 s poll.
+    loadStatus();
   } else {
     $('pairmsg').textContent = 'Pairing failed: ' + (res.error || 'unknown');
     $('pairmsg').className = 'msg err';

--- a/vlc-transcode-server/internal/web/static/index.html
+++ b/vlc-transcode-server/internal/web/static/index.html
@@ -81,6 +81,9 @@
       <div style="flex:0 0 auto;display:flex;align-items:flex-end"><button class="primary" id="pair">Pair</button></div>
     </div>
     <div class="msg" id="pairmsg"></div>
+    <!-- Persisted across restarts so the user can see "yes, a TV is paired"
+         rather than wondering if they need to re-pair after every upgrade. -->
+    <p class="sub" id="lastpair" style="margin:8px 0 0;display:none"></p>
   </div>
 
   <div class="card" id="testcard" style="display:none">


### PR DESCRIPTION
Verified: the pairing token IS persisting in config.json across server restarts and binary upgrades.  But the web UI had no indicator showing that pairing already happened — every fresh visit showed an empty "Enter pairing code" box, which made it feel like the server forgot, prompting unnecessary re-pairing after every reinstall.  UX gap, not a data bug.

Fix records the most recent successful publish in the same config.json that already persists SMB + Token + Encoder, then shows it in the web UI as "Last paired with code XYZ · today at HH:MM — the TV should still be paired".

  config.go
    + LastPair {Code string, At time.Time}
    + Config.LastPair *LastPair (json: last_pair,omitempty)

  web/server.go
    + handleStatus: include lastPair in /api/status response
    + handlePair: on successful Publish, set cfg.LastPair + Save (Save failure logged as a warning — the pair publish already succeeded, TV side is good either way)

  web/static/index.html
    + <p id="lastpair"> placeholder under the Pair button

  web/static/app.js
    + formatAgo() helper: "just now / N min ago / today at HH:MM / YYYY-MM-DD HH:MM" depending on recency
    + loadStatus paints / hides the lastpair line based on the lastPair field from /api/status
    + pair() calls loadStatus() on success so the UI updates immediately rather than waiting for the 5 s poll