### PR TITLE
transcode-server: align web UI with the VLC TV app's theme

### DIFF
--- a/vlc-transcode-server/internal/web/static/index.html
+++ b/vlc-transcode-server/internal/web/static/index.html
@@ -5,32 +5,57 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>VLC Transcode Server</title>
 <style>
-  :root { --bg:#11141a; --card:#1b1f29; --line:#2a3040; --fg:#e7ecf3; --mut:#8d97a8; --acc:#ff7a18; --ok:#34c759; --err:#ff5a5a; }
+  /* Theme aligned with the VLC TV app (tizen-web-vlc/css/style.css):
+   * charcoal-blue base + sky-blue accent from the VLC cone icon, so the
+   * setup page on the LAN feels like the same product as the app on the TV
+   * rather than a separate utility. */
+  :root {
+    --bg:       #1e2a3d;              /* matches app --bg (charcoal-blue) */
+    --bg-2:     #283549;              /* subtle elevation; input fields, pills */
+    --card:     #2a3854;              /* matches app --bg-card */
+    --line:     rgba(255,255,255,.08);/* matches app --border */
+    --fg:       #ffffff;              /* matches app --fg */
+    --mut:      #d0dae5;              /* matches app --fg-mute */
+    --dim:      #8da0b8;              /* matches app --fg-dim */
+    --acc:      #4fc3f7;              /* matches app --accent (sky blue) */
+    --acc-2:    #81d4fa;              /* matches app --accent-2 */
+    --acc-soft: rgba(79,195,247,.18); /* matches app --accent-soft */
+    --ok:       #6ad06a;              /* slightly desaturated to fit the palette */
+    --err:      #ff7373;
+  }
   * { box-sizing:border-box; }
   body { margin:0; font:15px/1.5 system-ui,sans-serif; background:var(--bg); color:var(--fg); }
   .wrap { max-width:640px; margin:0 auto; padding:24px 18px 60px; }
   h1 { font-size:20px; margin:0 0 2px; display:flex; align-items:center; gap:10px; }
-  h1 .dot { width:10px; height:10px; border-radius:50%; background:var(--mut); }
+  h1 .dot { width:10px; height:10px; border-radius:50%; background:var(--dim); }
   .sub { color:var(--mut); margin:0 0 22px; font-size:13px; }
   .card { background:var(--card); border:1px solid var(--line); border-radius:12px; padding:18px; margin-bottom:16px; }
   .card h2 { font-size:14px; text-transform:uppercase; letter-spacing:.06em; color:var(--mut); margin:0 0 14px; }
   label { display:block; font-size:13px; color:var(--mut); margin:12px 0 4px; }
-  input[type=text], input[type=password] { width:100%; padding:10px 12px; border-radius:8px; border:1px solid var(--line); background:#0e1117; color:var(--fg); font-size:14px; }
+  input[type=text], input[type=password] { width:100%; padding:10px 12px; border-radius:8px; border:1px solid var(--line); background:var(--bg-2); color:var(--fg); font-size:14px; }
+  input[type=text]:focus, input[type=password]:focus { outline:none; border-color:var(--acc); }
   .row { display:flex; gap:12px; } .row > div { flex:1; }
   .toggle { display:flex; align-items:center; justify-content:space-between; margin-top:14px; }
   button { font:inherit; border:0; border-radius:8px; padding:10px 16px; cursor:pointer; }
-  .primary { background:var(--acc); color:#1b1209; font-weight:600; }
-  .ghost { background:#0e1117; color:var(--fg); border:1px solid var(--line); }
+  /* Sky-blue is light enough that white text washes out — use the dark
+   * background colour as the foreground for the primary button. */
+  .primary { background:var(--acc); color:var(--bg); font-weight:600; }
+  .primary:hover { background:var(--acc-2); }
+  .ghost { background:var(--bg-2); color:var(--fg); border:1px solid var(--line); }
+  .ghost:hover { background:var(--card); }
   .bar { display:flex; gap:10px; margin-top:18px; flex-wrap:wrap; }
   .msg { margin-top:12px; font-size:13px; min-height:18px; }
   .msg.ok { color:var(--ok); } .msg.err { color:var(--err); }
   .kv { display:flex; justify-content:space-between; padding:6px 0; border-bottom:1px solid var(--line); font-size:13px; }
   .kv:last-child { border:0; } .kv span:first-child { color:var(--mut); }
-  .pill { font-size:12px; padding:2px 8px; border-radius:99px; background:#0e1117; border:1px solid var(--line); }
-  .switch { width:46px; height:26px; border-radius:99px; background:#0e1117; border:1px solid var(--line); position:relative; cursor:pointer; }
-  .switch.on { background:var(--acc); }
+  .pill { font-size:12px; padding:2px 8px; border-radius:99px; background:var(--bg-2); border:1px solid var(--line); }
+  .switch { width:46px; height:26px; border-radius:99px; background:var(--bg-2); border:1px solid var(--line); position:relative; cursor:pointer; transition:background .15s; }
+  .switch.on { background:var(--acc); border-color:var(--acc); }
   .switch i { position:absolute; top:2px; left:2px; width:20px; height:20px; border-radius:50%; background:#fff; transition:.15s; }
   .switch.on i { left:22px; }
+  code { background:var(--bg-2); border:1px solid var(--line); color:var(--acc); }
+  a { color:var(--acc); }
+  a:hover { color:var(--acc-2); }
 </style>
 </head>
 <body>
@@ -89,7 +114,7 @@
   <div class="card" id="testcard" style="display:none">
     <h2>Test transcoding</h2>
     <p class="sub" style="margin:0 0 8px">Open this in VLC on a laptop to confirm a file plays (replace the path):</p>
-    <code id="testlink" style="display:block;word-break:break-all;background:#0e1117;border:1px solid var(--line);border-radius:8px;padding:10px;font-size:12px;color:var(--acc)"></code>
+    <code id="testlink" style="display:block;word-break:break-all;background:var(--bg-2);border:1px solid var(--line);border-radius:8px;padding:10px;font-size:12px;color:var(--acc)"></code>
   </div>
 </div>
 <script src="app.js"></script>


### PR DESCRIPTION
Server'\''s setup page used a near-black background (#11141a) with an ORANGE accent (#ff7a18); the TV app uses charcoal-blue (#1e2a3d) with the sky-blue (#4fc3f7) drawn from the VLC cone icon.  They share no visual language, so the setup page felt like a separate utility from the app it'\''s configuring.

Re-point the server'\''s CSS variables at the app'\''s tokens (same names where possible) so colours match across both surfaces:

  --bg       #11141a → #1e2a3d   charcoal-blue base
  --card     #1b1f29 → #2a3854   matches app --bg-card
  --line     #2a3040 → rgba(255,255,255,.08)
  --fg       #e7ecf3 → #ffffff
  --mut      #8d97a8 → #d0dae5
  + --dim    #8da0b8 (matches app --fg-dim, for the status dot)
  --acc      #ff7a18 → #4fc3f7   SKY-BLUE — biggest visual change
  + --acc-2  #81d4fa for hover
  + --acc-soft for future focus rings

Knock-on tweaks:
  - Primary button text: brown (#1b1209, picked for orange bg) → bg colour, the only foreground that has enough contrast on sky-blue.
  - Inputs / pills / ghost button: hard-coded #0e1117 backgrounds swapped for --bg-2 so they sit cleanly on the new card colour.
  - Added :focus and :hover states (input, primary, ghost, anchor) matching the app'\''s focus-ring pattern.
  - Switch component picks up the new accent for its "on" state automatically via var(--acc).

JS is untouched — only references var(--ok) and var(--mut), both still defined.  The /testlink inline style swapped its hardcoded #0e1117 for var(--bg-2) so it tracks the theme.