### PR TITLE
Settings: reorder + collapse text-input sections (issue #28 part 1)

### DIFF
--- a/tizen-web-vlc/css/style.css
+++ b/tizen-web-vlc/css/style.css
@@ -720,6 +720,53 @@ button:focus { outline: none; }
     font-weight: 500;
 }
 
+/* Collapsible section header — looks like the bare h2 above, but is a
+ * focusable button so D-pad navigation can expand the group on press.
+ * Sections containing text-input rows (SMB, Debug logging) are collapsed
+ * by default so passing them with the D-pad doesn't pop the on-screen
+ * keyboard for every input on the way past — that was the trigger for
+ * the lag / crash described in issue #28. */
+.settings-section-toggle {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 20px;
+    margin: 20px 0 16px;
+    background: transparent;
+    border: 2px solid transparent;
+    border-radius: var(--r);
+    color: var(--fg-mute);
+    text-align: left;
+    cursor: pointer;
+    transition: border-color .15s ease, background .15s ease, color .15s ease;
+}
+.settings-section-toggle .settings-section-title { margin: 0; }
+.settings-section-toggle:focus,
+.settings-section-toggle.focused {
+    border-color: var(--accent);
+    background: var(--bg-card);
+    color: var(--fg);
+    outline: none;
+    box-shadow: 0 0 0 4px var(--accent-soft);
+}
+.settings-section-chev {
+    font-size: 20px;
+    color: var(--fg-dim);
+    transition: transform .15s ease;
+    margin-left: 16px;
+}
+/* Expanded state (default rendering of an open <button aria-expanded="true">) */
+.settings-section-toggle[aria-expanded="true"] .settings-section-chev {
+    transform: rotate(90deg);
+}
+
+/* Hide the collapsed group entirely.  display:none means descendants have
+ * offsetParent === null, which the UI focus filter (ui.js:48) treats as
+ * non-focusable — exactly what we want, the keyboard never gets a chance
+ * to pop for hidden inputs. */
+.settings-group.is-collapsed { display: none; }
+
 /* TV info table */
 .tvinfo {
     background: var(--bg-card);

--- a/tizen-web-vlc/index.html
+++ b/tizen-web-vlc/index.html
@@ -208,24 +208,15 @@
             </button>
         </div>
 
-        <h2 class="settings-section-title">SMB network share</h2>
-        <div class="settings-group">
-            <label class="settings-row settings-row-input"><span class="settings-label">Server (IP/host)</span><input id="smb-host"   type="text"     placeholder="192.168.1.10"></label>
-            <label class="settings-row settings-row-input"><span class="settings-label">Share</span><input id="smb-share"  type="text"     placeholder="Media"></label>
-            <button class="settings-row" id="smb-anon"><div class="settings-label">Guest (no login)</div><div class="settings-value" id="smb-anon-val">Off</div></button>
-            <label class="settings-row settings-row-input"><span class="settings-label">Username</span><input id="smb-user"   type="text"     placeholder="guest"></label>
-            <label class="settings-row settings-row-input"><span class="settings-label">Password</span><input id="smb-pass"   type="password"></label>
-            <label class="settings-row settings-row-input"><span class="settings-label">Domain (optional)</span><input id="smb-domain" type="text"></label>
-            <button id="smb-save" class="settings-row"><span class="settings-label">Save SMB server</span></button>
-        </div>
-
-        <h2 class="settings-section-title">Transcode server</h2>
-        <div class="settings-group">
-            <div class="settings-row"><div class="settings-label">Status</div><div class="settings-value" id="srv-status-val">Not paired</div></div>
-            <button id="srv-pair" class="settings-row" data-focus><span class="settings-label">Pair transcode server</span></button>
-            <button id="srv-unpair" class="settings-row"><span class="settings-label">Remove transcode server</span></button>
-        </div>
-
+        <!-- Subtitle appearance is moved ABOVE the network-input sections
+             below: those sections contain text fields that pop the on-screen
+             keyboard the moment a focus lands on them, and on slower Tizen
+             firmware the open/close-keyboard storm while scrolling past them
+             could lag the UI or crash the app entirely (issue #28).  Sections
+             that contain text inputs are now collapsed by default — the
+             header is a focusable button that expands the group on press, so
+             users navigating with the D-pad land on chevrons rather than
+             stepping through every input. -->
         <h2 class="settings-section-title">Subtitle appearance</h2>
         <div class="settings-group">
             <button class="settings-row" data-action="setting-subtitle-size">
@@ -258,8 +249,35 @@
             </div>
         </div>
 
-        <h2 class="settings-section-title">Debug logging</h2>
-        <div class="settings-group">
+        <button class="settings-section-toggle" data-toggle="grp-smb" aria-expanded="false">
+            <span class="settings-section-title">SMB network share</span>
+            <span class="settings-section-chev" aria-hidden="true">▸</span>
+        </button>
+        <div class="settings-group is-collapsed" id="grp-smb">
+            <label class="settings-row settings-row-input"><span class="settings-label">Server (IP/host)</span><input id="smb-host"   type="text"     placeholder="192.168.1.10"></label>
+            <label class="settings-row settings-row-input"><span class="settings-label">Share</span><input id="smb-share"  type="text"     placeholder="Media"></label>
+            <button class="settings-row" id="smb-anon"><div class="settings-label">Guest (no login)</div><div class="settings-value" id="smb-anon-val">Off</div></button>
+            <label class="settings-row settings-row-input"><span class="settings-label">Username</span><input id="smb-user"   type="text"     placeholder="guest"></label>
+            <label class="settings-row settings-row-input"><span class="settings-label">Password</span><input id="smb-pass"   type="password"></label>
+            <label class="settings-row settings-row-input"><span class="settings-label">Domain (optional)</span><input id="smb-domain" type="text"></label>
+            <button id="smb-save" class="settings-row"><span class="settings-label">Save SMB server</span></button>
+        </div>
+
+        <button class="settings-section-toggle" data-toggle="grp-srv" aria-expanded="false">
+            <span class="settings-section-title">Transcode server</span>
+            <span class="settings-section-chev" aria-hidden="true">▸</span>
+        </button>
+        <div class="settings-group is-collapsed" id="grp-srv">
+            <div class="settings-row"><div class="settings-label">Status</div><div class="settings-value" id="srv-status-val">Not paired</div></div>
+            <button id="srv-pair" class="settings-row"><span class="settings-label">Pair transcode server</span></button>
+            <button id="srv-unpair" class="settings-row"><span class="settings-label">Remove transcode server</span></button>
+        </div>
+
+        <button class="settings-section-toggle" data-toggle="grp-dbg" aria-expanded="false">
+            <span class="settings-section-title">Debug logging</span>
+            <span class="settings-section-chev" aria-hidden="true">▸</span>
+        </button>
+        <div class="settings-group is-collapsed" id="grp-dbg">
             <button class="settings-row" id="dbg-enabled"><div class="settings-label">Send debug logs</div><div class="settings-value" id="dbg-enabled-val">Off</div></button>
             <label class="settings-row settings-row-input"><span class="settings-label">Listener IP</span><input id="dbg-host" type="text" placeholder="192.168.1.50"></label>
             <label class="settings-row settings-row-input"><span class="settings-label">Listener port</span><input id="dbg-port" type="text" placeholder="9999"></label>

--- a/tizen-web-vlc/js/app.js
+++ b/tizen-web-vlc/js/app.js
@@ -101,6 +101,24 @@
             if (t) handleAction(t.dataset.action, t);
         });
 
+        // Collapsible Settings sections (issue #28): clicking a section
+        // toggle expands or collapses the next-sibling .settings-group it
+        // points at via data-toggle.  Because the collapsed state uses
+        // display:none, the inputs inside fall out of the focusable list
+        // and the D-pad can't accidentally land on them — which is what
+        // was popping the on-screen keyboard repeatedly and lagging /
+        // crashing the app on slower Tizen firmware.
+        document.body.addEventListener('click', function (ev) {
+            var t = ev.target.closest('.settings-section-toggle');
+            if (!t) return;
+            var grp = document.getElementById(t.getAttribute('data-toggle'));
+            if (!grp) return;
+            var opening = grp.classList.contains('is-collapsed');
+            grp.classList.toggle('is-collapsed', !opening);
+            t.setAttribute('aria-expanded', opening ? 'true' : 'false');
+            UI.refreshFocusables();
+        });
+
         // Preset URL chips
         document.querySelectorAll('.preset').forEach(function (el) {
             el.addEventListener('click', function () {


### PR DESCRIPTION
On slower Tizen firmware, every D-pad press onto a text input field pops the on-screen keyboard.  Walking past 5-7 inputs to reach the Subtitle appearance section open/close/open/close-d the keyboard in rapid sequence — laggy at best, crashed the app at worst (reported in issue #28).

Two changes that together fix the experience:

  - Reorder Settings so Subtitle appearance + Cast from another device come BEFORE any section that contains text-input rows. Users reach the subtitle controls without traversing inputs at all.

  - Collapse the three text-input sections (SMB network share, Transcode server, Debug logging) by default.  Each section title is now a focusable <button class="settings-section-toggle"> with a chevron; pressing it expands the group below.  Collapsed state uses display:none, which means descendants have offsetParent === null and the UI focus filter (ui.js:48) skips them entirely — the keyboard never gets a chance to pop for an input that isn't currently visible.

New CSS for the toggle pattern lives next to .settings-section-title so the visual language stays consistent; chev rotates on aria-expanded="true".  JS handler is one new event listener that flips the is-collapsed class on the targeted group and calls UI.refreshFocusables() to rebuild the focus ring.