### PR TITLE
Player: D-pad Left/Right scrub by 10 s (issue #28 part 2)

### DIFF
--- a/tizen-web-vlc/js/app.js
+++ b/tizen-web-vlc/js/app.js
@@ -942,9 +942,14 @@
         var osdVisible = !document.getElementById('osd-bottom').classList.contains('hidden');
 
         switch (code) {
-            // All four arrows in player view navigate between OSD buttons.
-            // Seek is on the dedicated FF / RW media keys instead, so arrows
-            // don't fight navigation with seeking.
+            // Player view key mapping (issue #28 part 2):
+            //   Up/Down  → cycle between OSD buttons (no-op when OSD hidden,
+            //              just brings it up)
+            //   Left     → seek backward 10 s, keep OSD up
+            //   Right    → seek forward  10 s, keep OSD up
+            //   FF/RW    → still ±30 s on dedicated media keys
+            // The 10 s step matches YouTube-on-TV's D-pad scrubbing rate and
+            // is fine-grained enough that users don't overshoot a few seconds.
             case K.UP:
                 if (state.view === 'player' && !errorUp && !trackMenuOpen) {
                     if (!osdVisible) { flashOSD(); return true; }
@@ -973,16 +978,14 @@
                 return true;
             case K.LEFT:
                 if (state.view === 'player' && !errorUp && !trackMenuOpen) {
-                    if (!osdVisible) { flashOSD(); return true; }
-                    UI.moveFocusCyclic(-1);    // previous OSD button
-                    flashOSD();
+                    Player.seekRel(-10000);
+                    flashOSD();   // keeps the OSD up while scrubbing
                     return true;
                 }
                 UI.moveFocus('left');  return true;
             case K.RIGHT:
                 if (state.view === 'player' && !errorUp && !trackMenuOpen) {
-                    if (!osdVisible) { flashOSD(); return true; }
-                    UI.moveFocusCyclic(+1);    // next OSD button
+                    Player.seekRel(+10000);
                     flashOSD();
                     return true;
                 }


### PR DESCRIPTION
Before: all four arrows in player view cycled between OSD buttons — seek was only reachable through the OSD ⏪/⏩ buttons or the dedicated FF/RW media keys, both at fixed ±30 s, which the reporter called "too coarse" for fine-grained scrubbing.

After:
  - Left  → seek backward 10 s
  - Right → seek forward  10 s
  - Up/Down still cycle OSD buttons (Stop / CC / Repeat / etc.)
  - FF/RW media keys still seek ±30 s (unchanged)

10 s matches YouTube-on-TV's D-pad scrubbing rate and is fine enough that users don't overshoot.  flashOSD() on every press keeps the OSD (with its progress bar) visible the entire time the user is actively scrubbing, so they get the visual feedback the issue described as missing.

The seek bar isn't yet a separately focusable element — Up/Down still walk between buttons in the single OSD row — but Left/Right now do what users expect on a TV remote regardless of which OSD button has focus.  Thumbnail previews on scrub stay deferred (generating them needs a server-side keyframe extractor we don't have on the TV; would belong in vlc-transcode-server).