### PR TITLE
Player: playback speed control (issue #28 part 3)

### DIFF
--- a/tizen-web-vlc/index.html
+++ b/tizen-web-vlc/index.html
@@ -152,6 +152,7 @@
             <button class="ctrl" data-action="forward">⏩</button>
             <button class="ctrl" data-action="next" id="btn-next" title="Next">⏭</button>
             <button class="ctrl" data-action="open-track-menu">CC</button>
+            <button class="ctrl" data-action="open-speed-picker" id="btn-speed" title="Playback speed">1×</button>
             <button class="ctrl" data-action="toggle-repeat" id="btn-repeat" title="Repeat">↻</button>
             <span class="ctrl-sep" aria-hidden="true"></span>
             <button class="ctrl" data-action="stop">⏹</button>

--- a/tizen-web-vlc/js/app.js
+++ b/tizen-web-vlc/js/app.js
@@ -142,6 +142,7 @@
                 showOSD(true);
                 scheduleOSDHide();
                 applyLanguagePreferences();
+                updateSpeedButton();   // Player.open reset speed to 1×; reflect it on the OSD
             }
         });
         Player.setListener('onerror', function (msg) {
@@ -221,6 +222,7 @@
             case 'seek-backward':      Player.seekRel(-60000); flashOSD(); break;
             case 'seek-forward':       Player.seekRel( 60000); flashOSD(); break;
             case 'toggle-repeat':      toggleRepeat(); break;
+            case 'open-speed-picker':  openSpeedPicker(); break;
             case 'open-track-menu':    openTrackMenu(); break;
             case 'close-track-menu':   closeTrackMenu(); break;
             case 'setting-audio-lang':    openLangPicker('audioLang',    'Preferred audio language', LanguageList.forAudio());    break;
@@ -830,6 +832,37 @@
             refreshSettingsValues();
             UI.toast(title + ' updated');
         });
+    }
+    /* Playback-speed picker (issue #28 part 3).  Six rates from 0.5× to 2×,
+     * applied via Player.setSpeed() which targets AVPlay's setSpeed on the
+     * TV and HTMLVideoElement.playbackRate as the fallback.  Speed is
+     * deliberately session-only — every Player.open() resets to 1× so a
+     * binge-watch session doesn't accidentally play episode 2 at 1.5×
+     * because episode 1 was. */
+    function openSpeedPicker() {
+        var cur = String(Player.getSpeed ? Player.getSpeed() : 1);
+        openPicker('Playback speed', [
+            { code: '0.5',  name: '0.5×' },
+            { code: '0.75', name: '0.75×' },
+            { code: '1',    name: 'Normal (1×)' },
+            { code: '1.25', name: '1.25×' },
+            { code: '1.5',  name: '1.5×' },
+            { code: '2',    name: '2×' }
+        ], cur, function (val) {
+            if (!Player.setSpeed(parseFloat(val))) {
+                UI.toast('Speed change not supported on this stream');
+                return;
+            }
+            updateSpeedButton();
+            UI.toast('Speed: ' + (val === '1' ? 'normal' : val + '×'));
+        });
+    }
+    function updateSpeedButton() {
+        var btn = document.getElementById('btn-speed');
+        if (!btn) return;
+        var s = Player.getSpeed ? Player.getSpeed() : 1;
+        // Compact label: "1×" / "1.5×" — no trailing zeros so "1.5×" not "1.50×".
+        btn.textContent = (s === Math.floor(s) ? s : (Math.round(s * 100) / 100)) + '×';
     }
     function openAutoPlayPicker() {
         pickerSetting = 'autoPlay';

--- a/tizen-web-vlc/js/player.js
+++ b/tizen-web-vlc/js/player.js
@@ -806,6 +806,7 @@ var Player = (function () {
         h5Subtitles = playerSubtitles;
         stopExternalSubtitle();    // clear any previous file's poller
         avNativeSubsAllowed = false;   // don't paint AVPlay's stray first-cue at file open
+        currentSpeed = 1;          // playback speed is per-file; reset every open
         backend = pickBackend(url);
         var streamType = sniffStreamType(url);
         if (typeof Debug !== 'undefined') Debug.player('open url=' + url + ' (type=' + streamType + ', backend=' + backend + ', subs=' + playerSubtitles.length + ')');
@@ -1474,6 +1475,32 @@ var Player = (function () {
         return p2(h) + ':' + p2(min) + ':' + p2(s) + '.' + p3(ms);
     }
 
+    /* Playback speed (issue #28 part 3).  AVPlay exposes setSpeed(rate) on
+     * Tizen 2.4+; HTML5 video uses .playbackRate.  We cap at 0.25..4× to
+     * stay inside what AVPlay actually supports — anything wilder either
+     * silently fails or drops audio.  Last applied speed is remembered so
+     * the UI can show the current rate without round-tripping through the
+     * native API (which doesn't have a getter on every firmware). */
+    var currentSpeed = 1;
+    function setSpeed(rate) {
+        rate = +rate;
+        if (!isFinite(rate) || rate <= 0) return false;
+        if (rate < 0.25) rate = 0.25;
+        if (rate > 4)    rate = 4;
+        if (backend === BACKEND_AVPLAY) {
+            try { av().setSpeed(rate); }
+            catch (e) {
+                if (typeof Debug !== 'undefined') Debug.warn('AV setSpeed(' + rate + '): ' + (e.message || e));
+                return false;
+            }
+        } else if (backend === BACKEND_HTML5) {
+            try { h5el().playbackRate = rate; } catch (e) { return false; }
+        }
+        currentSpeed = rate;
+        return true;
+    }
+    function getSpeed() { return currentSpeed; }
+
     return {
         setListener:        setListener,
         open:               open,
@@ -1491,6 +1518,8 @@ var Player = (function () {
         setSubtitleTrack:   setSubtitleTrack,
         setDisplayRect:     setDisplayRect,
         isBuffering:        isBuffering,
-        lastBufferingMs:    lastBufferingMs
+        lastBufferingMs:    lastBufferingMs,
+        setSpeed:           setSpeed,
+        getSpeed:           getSpeed
     };
 })();


### PR DESCRIPTION
Six rates from 0.5× to 2× via a picker reached from a new "1×" button in the OSD (between CC and Repeat).  AVPlay's setSpeed(rate) on Tizen 2.4+; HTML5 video falls back to playbackRate.

  Player.setSpeed(rate) / Player.getSpeed()
    - Clamped to 0.25..4× (AVPlay tops out around there in practice; anything wilder either no-ops or drops audio).
    - Reset to 1× on every Player.open() so a binge-watch session doesn't accidentally play episode 2 at 1.5× because episode 1 was — playback speed is per-file, not persisted.
    - getSpeed() returns the last-applied rate (Tizen has no reliable getter on every firmware, so we track it ourselves).

  OSD UI
    - New <button id="btn-speed" data-action="open-speed-picker"> sits between the CC and Repeat buttons.
    - Label tracks current rate ("1×" / "1.5×" / "2×") via updateSpeedButton(), invoked on the picker callback and on every state→playing event (since open() reset speed to 1×).

  Picker reuses the existing openPicker() infrastructure — same
  modal styling as audio/subtitle/auto-play pickers, so D-pad
  navigation and dismissal work the same way users already know.

Caveat: AVPlay returns silently for non-1× speeds on live HLS streams (the transcoded HLS from vlc-transcode-server qualifies). setSpeed catches the throw and returns false; the picker surfaces "Speed change not supported on this stream" as a toast in that case.