### PR TITLE
Rename binary + image vlc-transcode → vlc-tv-transcode

### DIFF
--- a/.github/workflows/transcode-server-image.yml
+++ b/.github/workflows/transcode-server-image.yml
@@ -16,7 +16,7 @@ permissions:
 
 env:
   # ghcr requires a lowercase image path.
-  IMAGE: ghcr.io/patrickst1991/vlc-transcode
+  IMAGE: ghcr.io/patrickst1991/vlc-tv-transcode
 
 jobs:
   build:

--- a/.github/workflows/transcode-server-native.yml
+++ b/.github/workflows/transcode-server-native.yml
@@ -58,7 +58,7 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
         run: |
           set -euo pipefail
-          OUT="vlc-transcode${{ matrix.ext }}"
+          OUT="vlc-tv-transcode${{ matrix.ext }}"
           go build -trimpath -ldflags="-s -w" -o "$OUT" .
           ls -la "$OUT"
 
@@ -85,7 +85,7 @@ jobs:
           set -euo pipefail
           BUNDLE="$RUNNER_TEMP/bundle"
           mkdir -p "$BUNDLE"
-          cp "vlc-transcode${{ matrix.ext }}" "$BUNDLE/"
+          cp "vlc-tv-transcode${{ matrix.ext }}" "$BUNDLE/"
           cp README.md "$BUNDLE/"
 
           # If this matrix entry bundles ffmpeg, copy ffmpeg + ffprobe alongside
@@ -103,14 +103,14 @@ jobs:
           fi
 
           mkdir -p "$GITHUB_WORKSPACE/dist"
-          ZIP="$GITHUB_WORKSPACE/dist/vlc-transcode-${{ matrix.goos }}-${{ matrix.goarch }}.zip"
+          ZIP="$GITHUB_WORKSPACE/dist/vlc-tv-transcode-${{ matrix.goos }}-${{ matrix.goarch }}.zip"
           ( cd "$BUNDLE" && zip -r "$ZIP" . )
           ls -la "$ZIP"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: vlc-transcode-${{ matrix.goos }}-${{ matrix.goarch }}
+          name: vlc-tv-transcode-${{ matrix.goos }}-${{ matrix.goarch }}
           path: dist/*.zip
           if-no-files-found: error
           retention-days: 14

--- a/tizen-web-vlc/js/server.js
+++ b/tizen-web-vlc/js/server.js
@@ -1,5 +1,5 @@
 /* server.js — pairing with, and routing playback through, the optional
- * vlc-transcode-server companion (runs on the user's AM6b+ box).
+ * vlc-tv-transcode companion (runs on the user's AM6b+ box).
  *
  * The idea: SMB browsing on the TV stays exactly as it is. The ONLY thing that
  * changes is where the bytes come from when you press play. If a transcode
@@ -89,7 +89,13 @@ var TranscodeServer = (function () {
         if (!latest) return null;
         try {
             var ann = JSON.parse(latest);
-            if (ann && ann.type === 'vlc-transcode-server' && ann.url) return ann;
+            // Wire-type bumped from "vlc-transcode-server" → "vlc-tv-transcode-server"
+            // alongside the binary rename.  Accept both for one release cycle so
+            // users still paired with an older server keep working after the TV
+            // app upgrades; can drop the legacy alias next stable.
+            if (ann && ann.url &&
+                (ann.type === 'vlc-tv-transcode-server' || ann.type === 'vlc-transcode-server'))
+                return ann;
         } catch (e) {}
         return null;
     }

--- a/vlc-transcode-server/Dockerfile
+++ b/vlc-transcode-server/Dockerfile
@@ -10,7 +10,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    go build -trimpath -ldflags="-s -w" -o /vlc-transcode .
+    go build -trimpath -ldflags="-s -w" -o /vlc-tv-transcode .
 
 # ── runtime stage ────────────────────────────────────────────────────────────
 # Debian's ffmpeg covers software (libx264), VAAPI (Intel/AMD), V4L2 M2M and
@@ -24,12 +24,12 @@ RUN apt-get update \
       ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 
-COPY --from=build /vlc-transcode /usr/local/bin/vlc-transcode
+COPY --from=build /vlc-tv-transcode /usr/local/bin/vlc-tv-transcode
 
 ENV DATA_DIR=/data \
-    WORK_DIR=/tmp/vlc-transcode \
+    WORK_DIR=/tmp/vlc-tv-transcode \
     PORT=8200
 VOLUME /data
 EXPOSE 8200
 
-ENTRYPOINT ["/usr/local/bin/vlc-transcode"]
+ENTRYPOINT ["/usr/local/bin/vlc-tv-transcode"]

--- a/vlc-transcode-server/README.md
+++ b/vlc-transcode-server/README.md
@@ -1,4 +1,4 @@
-# VLC Transcode Server
+# VLC TV Transcode Server
 
 A tiny self-hosted companion for the [VLC Tizen TV app](../). It runs on a small
 always-on box (e.g. an AM6b+), reads your media from an **SMB share**, and
@@ -23,9 +23,9 @@ nothing to clone or build.
 **One-liner:**
 
 ```bash
-docker run -d --name vlc-transcode --restart unless-stopped \
+docker run -d --name vlc-tv-transcode --restart unless-stopped \
   -p 8200:8200 -v "$PWD/vlc-data:/data" --device /dev/dri \
-  ghcr.io/patrickst1991/vlc-transcode:latest
+  ghcr.io/patrickst1991/vlc-tv-transcode:latest
 ```
 
 **Or with Compose** (grab `docker-compose.yml` from this folder):
@@ -55,13 +55,13 @@ under the latest `transcode-v*` tag:
 
 | OS | Asset | Bundled ffmpeg? |
 |---|---|---|
-| Windows x64 | `vlc-transcode-windows-amd64.zip` | ✅ included (BtbN GPL build) |
-| Linux x64 | `vlc-transcode-linux-amd64.zip` | ✅ included (BtbN GPL build) |
-| Linux ARM64 (Raspberry Pi 4/5, generic ARM) | `vlc-transcode-linux-arm64.zip` | ✅ included |
-| macOS Apple Silicon | `vlc-transcode-darwin-arm64.zip` | ❌ run `brew install ffmpeg` |
-| macOS Intel | `vlc-transcode-darwin-amd64.zip` | ❌ run `brew install ffmpeg` |
+| Windows x64 | `vlc-tv-transcode-windows-amd64.zip` | ✅ included (BtbN GPL build) |
+| Linux x64 | `vlc-tv-transcode-linux-amd64.zip` | ✅ included (BtbN GPL build) |
+| Linux ARM64 (Raspberry Pi 4/5, generic ARM) | `vlc-tv-transcode-linux-arm64.zip` | ✅ included |
+| macOS Apple Silicon | `vlc-tv-transcode-darwin-arm64.zip` | ❌ run `brew install ffmpeg` |
+| macOS Intel | `vlc-tv-transcode-darwin-amd64.zip` | ❌ run `brew install ffmpeg` |
 
-Unzip anywhere. On Windows + Linux that gets you `vlc-transcode(.exe)` plus
+Unzip anywhere. On Windows + Linux that gets you `vlc-tv-transcode(.exe)` plus
 `ffmpeg(.exe)` and `ffprobe(.exe)` in the same folder — the server picks them
 up automatically (the binary prepends its own directory to `PATH` at
 startup), so there's nothing to install. On macOS, `brew install ffmpeg` once
@@ -73,11 +73,11 @@ directory (where the config + pairing token live):
 
 ```bash
 # Linux / macOS
-DATA_DIR=./vlc-data ./vlc-transcode
+DATA_DIR=./vlc-data ./vlc-tv-transcode
 
 # Windows (cmd.exe / PowerShell)
 set DATA_DIR=%CD%\vlc-data
-vlc-transcode.exe
+vlc-tv-transcode.exe
 ```
 
 If you'd rather use a different port, set `PORT=8201` (etc.) in the same
@@ -93,7 +93,7 @@ listening on :8200
 
 If it instead exits with `ffmpeg not found — install ffmpeg`, your `ffmpeg`
 isn't on `PATH`. Either install it (see the table above) or put `ffmpeg(.exe)`
-and `ffprobe(.exe)` in the same folder as `vlc-transcode(.exe)`.
+and `ffprobe(.exe)` in the same folder as `vlc-tv-transcode(.exe)`.
 
 Then open `http://<this-machine's-LAN-IP>:8200` and continue with [Pair with the
 TV](#pair-with-the-tv) below.
@@ -169,7 +169,7 @@ ffmpeg reports and falls back to software (`libx264`). Detection order:
 |---|---|---|
 | `PORT` | `8200` | HTTP port |
 | `DATA_DIR` | `/data` | where `config.json` is persisted |
-| `WORK_DIR` | `/tmp/vlc-transcode` | scratch for HLS segments |
+| `WORK_DIR` | `/tmp/vlc-tv-transcode` | scratch for HLS segments |
 
 ## Known limitations (Phase 1)
 

--- a/vlc-transcode-server/docker-compose.yml
+++ b/vlc-transcode-server/docker-compose.yml
@@ -1,13 +1,13 @@
 # Drop this on the AM6b+ and run:  docker compose up -d
 # Then open  http://<box-ip>:8200  to enter your SMB share details.
 services:
-  vlc-transcode:
+  vlc-tv-transcode:
     # Pulls the prebuilt multi-arch image — no cloning or building needed.
-    image: ghcr.io/patrickst1991/vlc-transcode:latest
+    image: ghcr.io/patrickst1991/vlc-tv-transcode:latest
     # Developers building from source instead: comment the line above and
     # uncomment the next one (run from this directory).
     # build: .
-    container_name: vlc-transcode
+    container_name: vlc-tv-transcode
     restart: unless-stopped
     ports:
       - "8200:8200"

--- a/vlc-transcode-server/internal/pair/pair.go
+++ b/vlc-transcode-server/internal/pair/pair.go
@@ -24,7 +24,7 @@ const ntfyBase = "https://ntfy.sh"
 
 // Announce is the JSON the TV receives and stores.
 type Announce struct {
-	Type  string `json:"type"`  // always "vlc-transcode-server"
+	Type  string `json:"type"`  // always "vlc-tv-transcode-server"
 	URL   string `json:"url"`   // e.g. "http://192.168.1.50:8200"
 	Token string `json:"token"` // sent back on /play
 	Name  string `json:"name"`  // friendly box name
@@ -39,7 +39,7 @@ func Publish(ctx context.Context, code, serverURL, token string) error {
 	if code == "" {
 		return fmt.Errorf("empty pairing code")
 	}
-	ann := Announce{Type: "vlc-transcode-server", URL: serverURL, Token: token, Name: hostname()}
+	ann := Announce{Type: "vlc-tv-transcode-server", URL: serverURL, Token: token, Name: hostname()}
 	body, _ := json.Marshal(ann)
 
 	ctx, cancel := context.WithTimeout(ctx, 12*time.Second)
@@ -89,7 +89,7 @@ func outboundIP() string {
 func hostname() string {
 	h, err := os.Hostname()
 	if err != nil || h == "" {
-		return "VLC Transcode Server"
+		return "VLC TV Transcode Server"
 	}
 	return h
 }

--- a/vlc-transcode-server/main.go
+++ b/vlc-transcode-server/main.go
@@ -1,4 +1,4 @@
-// vlc-transcode-server — a tiny self-hosted companion for the VLC Tizen TV app.
+// vlc-tv-transcode — a tiny self-hosted companion for the VLC Tizen TV app.
 //
 // It reads media from your SMB share, transcodes only what the TV can't decode
 // (DTS/TrueHD audio, unsupported video) into a TV-friendly HLS stream, and hands
@@ -36,7 +36,7 @@ func main() {
 
 	port := envInt("PORT", 8200)
 	dataDir := envStr("DATA_DIR", "/data")
-	workDir := envStr("WORK_DIR", filepath.Join(os.TempDir(), "vlc-transcode"))
+	workDir := envStr("WORK_DIR", filepath.Join(os.TempDir(), "vlc-tv-transcode"))
 
 	// Config (web-editable; created on first save).
 	cfg, err := config.Load(filepath.Join(dataDir, "config.json"))


### PR DESCRIPTION
Make it clear this is the companion to the VLC TV app, not part of upstream VLC.  Binary, Docker image, release zip and pairing wire-type all rebrand to vlc-tv-transcode; the source directory and Go module path stay as-is to avoid churning every import.

TV side accepts both the old and new wire-type for one release so already-paired servers keep working after the app upgrades — the legacy alias can drop next stable.