### PR TITLE
Remote: MediaSession fallback + log unhandled keys (issue #42)

### DIFF
--- a/tizen-web-vlc/js/app.js
+++ b/tizen-web-vlc/js/app.js
@@ -191,6 +191,17 @@
         // Reflow display rect on size changes
         window.addEventListener('resize', Player.setDisplayRect);
 
+        // Second path for dedicated remote media keys (issue #42): on some
+        // Samsung Smart Monitors the remote's Play / Pause / FF / RW keys
+        // never arrive as `keydown` events at all — they're routed through
+        // Chromium's MediaSession API instead.  Register handlers so those
+        // remotes control playback too.  Only meaningful for the HTML5
+        // backend (MP4/HLS); the AVPlay backend doesn't own a media element
+        // and never becomes the browser's "active" media session, so this
+        // is best-effort — the tvinputdevice path in remote.js remains the
+        // primary route for AVPlay files.
+        installMediaSessionHandlers();
+
         UI.showView('view-home');
         updateRepeatButton();        // reflect saved repeat preference on OSD
         SubtitleStyle.apply();       // push saved subtitle appearance onto the overlay
@@ -597,6 +608,25 @@
         osdHideTimer = setTimeout(function () { showOSD(false); }, 5000);
     }
     function flashOSD() { showOSD(true); scheduleOSDHide(); }
+
+    function installMediaSessionHandlers() {
+        if (!('mediaSession' in navigator)) return;
+        function ifPlaying(fn) {
+            return function () { if (state.view === 'player') { fn(); flashOSD(); } };
+        }
+        var pairs = [
+            ['play',          ifPlaying(function () { Player.play(); })],
+            ['pause',         ifPlaying(function () { Player.pause(); })],
+            ['stop',          ifPlaying(function () { exitPlayer(); })],
+            ['seekbackward',  ifPlaying(function () { Player.seekRel(-30000); })],
+            ['seekforward',   ifPlaying(function () { Player.seekRel( 30000); })],
+            ['previoustrack', ifPlaying(function () { playPrev(); })],
+            ['nexttrack',     ifPlaying(function () { playNext(false); })]
+        ];
+        for (var i = 0; i < pairs.length; i++) {
+            try { navigator.mediaSession.setActionHandler(pairs[i][0], pairs[i][1]); } catch (e) {}
+        }
+    }
 
     function showSpinner(msg) {
         var sp = document.getElementById('spinner');

--- a/tizen-web-vlc/js/remote.js
+++ b/tizen-web-vlc/js/remote.js
@@ -42,6 +42,10 @@ var Remote = (function () {
             'MediaPlay', 'MediaPause', 'MediaStop',
             'MediaRewind', 'MediaFastForward',
             'MediaPlayPause', 'MediaRecord',
+            /* MediaTrackPrevious / MediaTrackNext land on some Smart Monitor
+             * firmwares that don't ship a full media strip on the remote
+             * (issue #42).  Silently skipped by registerKey if unknown. */
+            'MediaTrackPrevious', 'MediaTrackNext',
             'ColorF0Red', 'ColorF1Green', 'ColorF2Yellow', 'ColorF3Blue',
             'Info', 'Guide',
             'ChannelUp', 'ChannelDown',
@@ -72,6 +76,10 @@ var Remote = (function () {
                 return;
             }
         }
+        /* Log unhandled keycodes so users hitting a remote key that does
+         * nothing (issue #42, Smart Monitor M5) can share the numeric code
+         * with us and we can wire it into globalKeyHandler. */
+        if (typeof Debug !== 'undefined') Debug.key('unhandled ' + code);
     }
 
     /* Listeners are tried in REVERSE registration order (most-recently-pushed


### PR DESCRIPTION
Second half of issue #42.  On the Smart Monitor M5, the remote's dedicated Play / Pause / FF / RW keys don't work in-app — only the OSD scrub-bar buttons do.  The existing handler already maps every standard Tizen TV media keyCode (415/19/10252/412/417), so on this device those keys aren't arriving as keydown events at all.

Two mitigations, on the theory that we don't know yet whether the M5 routes those keys via MediaSession, via non-standard keycodes, or not at all to the app.

- Register navigator.mediaSession action handlers for play/pause/stop/seekbackward/seekforward/prev/next.  On Chromium 63 (Tizen 5.0's engine) this catches hardware media keys the browser intercepts before they reach keydown.  Only fully effective for the HTML5 backend (MP4/HLS); AVPlay files don't own a media element and never become the browser's active media session, so this is best effort.  Guarded on state.view === 'player' so keys pressed elsewhere don't accidentally rewind a paused file.

- Log every unhandled keycode via Debug.key so users on affected hardware can turn on the debug listener, press the offending remote key, and share the numeric code — then we can wire it into globalKeyHandler.  Registered keycode set also gains MediaTrackPrevious/Next on the off chance some monitors deliver media control that way.