### PR TITLE
fix: playback speed no longer surprises with muted audio (#49) + bump to 1.2.1

### DIFF
--- a/tizen-web-vlc/config.xml
+++ b/tizen-web-vlc/config.xml
@@ -2,7 +2,7 @@
 <widget xmlns:tizen="http://tizen.org/ns/widgets"
         xmlns="http://www.w3.org/ns/widgets"
         id="http://madebypatrick.com/vlctv"
-        version="1.2.0"
+        version="1.2.1"
         viewmodes="maximized">
     <tizen:application id="madebypatk.vlcweb"
                        package="madebypatk"

--- a/tizen-web-vlc/js/app.js
+++ b/tizen-web-vlc/js/app.js
@@ -1190,20 +1190,29 @@
      * because episode 1 was. */
     function openSpeedPicker() {
         var cur = String(Player.getSpeed ? Player.getSpeed() : 1);
+        /* On the AVPlay backend, non-1× rates silence audio (Samsung
+         * hardware-decoder limitation — issue #49).  Note that inline in
+         * the option labels so the user isn't blindsided by a mute the
+         * moment they pick 1.5×. */
+        var avplay = Player.getBackend && Player.getBackend() === 'avplay';
+        var muteNote = avplay ? '  (audio muted)' : '';
         openPicker('Playback speed', [
-            { code: '0.5',  name: '0.5×' },
-            { code: '0.75', name: '0.75×' },
+            { code: '0.5',  name: '0.5×' + muteNote },
+            { code: '0.75', name: '0.75×' + muteNote },
             { code: '1',    name: 'Normal (1×)' },
-            { code: '1.25', name: '1.25×' },
-            { code: '1.5',  name: '1.5×' },
-            { code: '2',    name: '2×' }
+            { code: '1.25', name: '1.25×' + muteNote },
+            { code: '1.5',  name: '1.5×' + muteNote },
+            { code: '2',    name: '2×' + muteNote }
         ], cur, function (val) {
             if (!Player.setSpeed(parseFloat(val))) {
                 UI.toast('Speed change not supported on this stream');
                 return;
             }
             updateSpeedButton();
-            UI.toast('Speed: ' + (val === '1' ? 'normal' : val + '×'));
+            var msg = 'Speed: ' + (val === '1' ? 'normal' : val + '×');
+            if (Player.isSpeedMuted && Player.isSpeedMuted())
+                msg += ' — audio muted (Samsung TV limitation)';
+            UI.toast(msg);
         });
     }
     function updateSpeedButton() {
@@ -1211,7 +1220,11 @@
         if (!btn) return;
         var s = Player.getSpeed ? Player.getSpeed() : 1;
         // Compact label: "1×" / "1.5×" — no trailing zeros so "1.5×" not "1.50×".
-        btn.textContent = (s === Math.floor(s) ? s : (Math.round(s * 100) / 100)) + '×';
+        var label = (s === Math.floor(s) ? s : (Math.round(s * 100) / 100)) + '×';
+        // 🔇 postfix when audio is silenced by the speed change so the OSD
+        // makes the trade-off visible at a glance (issue #49).
+        if (Player.isSpeedMuted && Player.isSpeedMuted()) label += ' 🔇';
+        btn.textContent = label;
     }
     function openAutoPlayPicker() {
         pickerSetting = 'autoPlay';

--- a/tizen-web-vlc/js/player.js
+++ b/tizen-web-vlc/js/player.js
@@ -1501,7 +1501,14 @@ var Player = (function () {
      * stay inside what AVPlay actually supports — anything wilder either
      * silently fails or drops audio.  Last applied speed is remembered so
      * the UI can show the current rate without round-tripping through the
-     * native API (which doesn't have a getter on every firmware). */
+     * native API (which doesn't have a getter on every firmware).
+     *
+     * Audio-muting caveat (issue #49): Samsung's AVPlay implementation
+     * silences audio at any rate != 1.0.  It's a hardware-decoder-level
+     * limitation, not something we can defeat from JS.  The HTML5 <video>
+     * fallback DOES support pitched-audio at non-1× rates on Chromium 63,
+     * as long as preservesPitch is set — we opt into that here so files
+     * that fall through to HTML5 sound natural instead of chipmunky. */
     var currentSpeed = 1;
     function setSpeed(rate) {
         rate = +rate;
@@ -1515,12 +1522,28 @@ var Player = (function () {
                 return false;
             }
         } else if (backend === BACKEND_HTML5) {
-            try { h5el().playbackRate = rate; } catch (e) { return false; }
+            try {
+                var v = h5el();
+                // preservesPitch keeps audio intelligible at 0.5×/1.5×/etc.
+                // instead of pitching it up or down.  webkitPreservesPitch is
+                // the pre-standard name — Chromium 63 (Tizen 5) accepts either.
+                v.preservesPitch       = true;
+                v.webkitPreservesPitch = true;
+                v.playbackRate = rate;
+            } catch (e) { return false; }
         }
         currentSpeed = rate;
         return true;
     }
-    function getSpeed() { return currentSpeed; }
+    function getSpeed()   { return currentSpeed; }
+    function getBackend() { return backend; }
+    /* True when the current backend silences audio at the current rate.
+     * Callers use this to inform the user before they wonder why their
+     * TV suddenly went quiet.  Only AVPlay has this problem — HTML5 with
+     * preservesPitch above keeps audio intact. */
+    function isSpeedMuted() {
+        return backend === BACKEND_AVPLAY && currentSpeed !== 1;
+    }
 
     return {
         setListener:        setListener,
@@ -1541,6 +1564,8 @@ var Player = (function () {
         isBuffering:        isBuffering,
         lastBufferingMs:    lastBufferingMs,
         setSpeed:           setSpeed,
-        getSpeed:           getSpeed
+        getSpeed:           getSpeed,
+        getBackend:         getBackend,
+        isSpeedMuted:       isSpeedMuted
     };
 })();


### PR DESCRIPTION
Closes #49.

## What

Samsung's AVPlay silences audio at any playback rate != 1.0 — it's a hardware-decoder-level limitation and can't be defeated from JS. This PR doesn't unmute AVPlay (nothing can), but it makes the trade-off **visible** instead of the audio just going quiet the moment the user picks 1.5× and them wondering what broke.

## Changes

**HTML5 backend** (network URLs / non-MKV local fallback):
- Explicitly opt into `preservesPitch = true` (+ the pre-standard `webkitPreservesPitch`) before setting `playbackRate`, so audio stays intelligible at 0.5×/1.5× instead of pitching up/down.

**AVPlay backend** (MKV + most files):
- `Player.isSpeedMuted()` reports whether the current backend + rate silences audio.
- Speed picker's options are labelled `"(audio muted)"` inline for non-1× entries when AVPlay is active — user sees the caveat **before** picking.
- Selection toast appends `"— audio muted (Samsung TV limitation)"` when applicable.
- OSD speed button label gets a `🔇` suffix while a muted rate is live.

Also exposes `Player.getBackend()` so `app.js` can make backend-aware UI decisions without leaking backend constants.

## Version bump

Bumps `config.xml` from `1.2.0` → `1.2.1` (patch).

## Not fixed

The actual AVPlay-audio-at-non-1× muting. There is no public AVPlay API to preserve audio at non-1× rates — Samsung's implementation drops audio rather than playing chipmunk audio. If a solution ever surfaces, it plugs into `Player.setSpeed()` and the UI plumbing here stays as-is.

## Test plan

- [ ] MKV file, pick 1.5× → audio drops, toast says "audio muted (Samsung TV limitation)", OSD button shows \`1.5× 🔇\`.
- [ ] MKV file, back to 1× → audio returns, button shows \`1×\` (no 🔇).
- [ ] Network MP4 (HTML5 backend fallback) at 1.5× → audio still plays, natural pitch, no 🔇 postfix, no mute-warning toast.
- [ ] Regression: 1× is still normal for both backends, no visual clutter.