### PR TITLE
Support large MP4 embedded subtitle extraction

### DIFF
--- a/.github/workflows/tizen-web-vlc-tests.yml
+++ b/.github/workflows/tizen-web-vlc-tests.yml
@@ -1,0 +1,29 @@
+name: Test Tizen Web VLC
+
+on:
+  pull_request:
+    paths:
+      - 'tizen-web-vlc/**'
+      - 'tests/tizen-web-vlc/**'
+      - '.github/workflows/tizen-web-vlc-tests.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'tizen-web-vlc/**'
+      - 'tests/tizen-web-vlc/**'
+      - '.github/workflows/tizen-web-vlc-tests.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Run MP4 subtitle tests
+        run: node --test tests/tizen-web-vlc/mp4-subs.test.js

--- a/tests/tizen-web-vlc/mp4-subs.test.js
+++ b/tests/tizen-web-vlc/mp4-subs.test.js
@@ -1,0 +1,294 @@
+'use strict';
+
+var assert = require('assert');
+var test = require('node:test');
+var Mp4Subs = require('../../tizen-web-vlc/js/mp4-subs.js');
+
+function bytes() {
+    var parts = Array.prototype.slice.call(arguments);
+    var total = 0;
+    var offset = 0;
+
+    for (var i = 0; i < parts.length; i++) total += parts[i].length;
+
+    var out = new Uint8Array(total);
+    for (var j = 0; j < parts.length; j++) {
+        out.set(parts[j], offset);
+        offset += parts[j].length;
+    }
+
+    return out;
+}
+
+function ascii(value) {
+    var out = new Uint8Array(value.length);
+    for (var i = 0; i < value.length; i++) out[i] = value.charCodeAt(i) & 255;
+    return out;
+}
+
+function u32(value) {
+    return new Uint8Array([
+        (value >>> 24) & 255,
+        (value >>> 16) & 255,
+        (value >>> 8) & 255,
+        value & 255
+    ]);
+}
+
+function u16(value) {
+    return new Uint8Array([(value >>> 8) & 255, value & 255]);
+}
+
+function box(type, body) {
+    return bytes(u32(body.length + 8), ascii(type), body);
+}
+
+function fullBox(type, body) {
+    return box(type, bytes(new Uint8Array([0, 0, 0, 0]), body));
+}
+
+function packedLang(lang) {
+    return ((lang.charCodeAt(0) - 0x60) << 10) |
+           ((lang.charCodeAt(1) - 0x60) << 5) |
+           (lang.charCodeAt(2) - 0x60);
+}
+
+function textSample(value) {
+    var encoded = new TextEncoder().encode(value);
+    return bytes(u16(encoded.length), encoded);
+}
+
+function makeTrack(sampleOffsets, sampleSizes) {
+    var tkhd = fullBox('tkhd', bytes(
+        u32(0),
+        u32(0),
+        u32(7)
+    ));
+    var mdhd = fullBox('mdhd', bytes(
+        u32(0),
+        u32(0),
+        u32(1000),
+        u32(4000),
+        u16(packedLang('eng')),
+        u16(0)
+    ));
+    var hdlr = fullBox('hdlr', bytes(
+        u32(0),
+        ascii('text'),
+        u32(0),
+        u32(0),
+        u32(0),
+        ascii('SubtitleHandler\0')
+    ));
+    var stsd = fullBox('stsd', bytes(
+        u32(1),
+        u32(8),
+        ascii('tx3g')
+    ));
+    var stts = fullBox('stts', bytes(
+        u32(2),
+        u32(1), u32(1500),
+        u32(1), u32(2500)
+    ));
+    var stsc = fullBox('stsc', bytes(
+        u32(1),
+        u32(1), u32(1), u32(1)
+    ));
+    var stsz = fullBox('stsz', bytes(
+        u32(0),
+        u32(sampleSizes.length),
+        u32(sampleSizes[0]),
+        u32(sampleSizes[1])
+    ));
+    var stco = fullBox('stco', bytes(
+        u32(sampleOffsets.length),
+        u32(sampleOffsets[0]),
+        u32(sampleOffsets[1])
+    ));
+    var stbl = box('stbl', bytes(stsd, stts, stsc, stsz, stco));
+    var minf = box('minf', stbl);
+    var mdia = box('mdia', bytes(mdhd, hdlr, minf));
+
+    return box('trak', bytes(tkhd, mdia));
+}
+
+function fixture() {
+    var ftyp = box('ftyp', bytes(ascii('isom'), u32(0), ascii('isom')));
+    var samples = [textSample('Hello from a huge MP4'), textSample('Second cue')];
+    var filler = new Uint8Array(12);
+    var firstSampleOffset = ftyp.length + 8 + filler.length;
+    var secondSampleOffset = firstSampleOffset + samples[0].length;
+    var mdat = box('mdat', bytes(filler, samples[0], samples[1]));
+    var moov = box('moov', makeTrack(
+        [firstSampleOffset, secondSampleOffset],
+        [samples[0].length, samples[1].length]
+    ));
+
+    return bytes(ftyp, mdat, moov);
+}
+
+function fixtureWithBadTailBoxBeforeMoov() {
+    var data = fixture();
+    var ftypSize = new DataView(data.buffer, data.byteOffset, data.byteLength).getUint32(0);
+    var mdatSize = new DataView(data.buffer, data.byteOffset + ftypSize, data.byteLength - ftypSize).getUint32(0);
+    var moovOffset = ftypSize + mdatSize;
+    var badTailBox = bytes(u32(0x7fffffff), ascii('free'), new Uint8Array([1, 2, 3, 4]));
+
+    return bytes(
+        data.subarray(0, moovOffset),
+        badTailBox,
+        data.subarray(moovOffset)
+    );
+}
+
+function fixtureWithBadTailBoxAndTrailingJunk() {
+    return bytes(
+        fixtureWithBadTailBoxBeforeMoov(),
+        new Uint8Array(96 * 1024)
+    );
+}
+
+function MockRangeReader(data, virtualSize, internalChunk, delay) {
+    this.data = data;
+    this.size = virtualSize || data.length;
+    this.internalChunk = internalChunk || 3;
+    this.delay = delay || 0;
+    this.closed = false;
+    this.maxRequested = 0;
+    this.requests = [];
+    this.failRanges = [];
+}
+
+MockRangeReader.prototype.getSize = function (cb) {
+    var self = this;
+    setTimeout(function () {
+        cb(self.closed ? Error('closed') : null, self.size);
+    }, this.delay);
+};
+
+MockRangeReader.prototype.readRange = function (offset, length, cb) {
+    var self = this;
+    this.maxRequested = Math.max(this.maxRequested, length);
+    this.requests.push({ offset: offset, length: length });
+
+    setTimeout(function () {
+        if (self.closed) {
+            cb(Error('closed'));
+            return;
+        }
+        for (var i = 0; i < self.failRanges.length; i++) {
+            var range = self.failRanges[i];
+            if (offset < range.end && offset + length > range.start) {
+                cb(Error('configured read failure'));
+                return;
+            }
+        }
+        if (offset + length > self.data.length) {
+            cb(Error('fixture read out of range'));
+            return;
+        }
+
+        var out = new Uint8Array(length);
+        var written = 0;
+        while (written < length) {
+            var take = Math.min(self.internalChunk, length - written);
+            out.set(self.data.subarray(offset + written, offset + written + take), written);
+            written += take;
+        }
+
+        cb(null, out.buffer);
+    }, this.delay);
+};
+
+MockRangeReader.prototype.close = function () {
+    this.closed = true;
+};
+
+function incremental(reader, options) {
+    return new Promise(function (resolve, reject) {
+        var eventOrder = [];
+        var extractOptions = options || {};
+
+        extractOptions.chunkSize = extractOptions.chunkSize || 64 * 1024;
+        extractOptions.onTracks = function (tracks) {
+            eventOrder.push('tracks');
+            assert.strictEqual(tracks[0].cues.length, 0);
+        };
+        extractOptions.onCues = function () {
+            eventOrder.push('cues');
+        };
+        extractOptions.onComplete = function (tracks) {
+            resolve({ tracks: tracks, eventOrder: eventOrder });
+        };
+        extractOptions.onError = reject;
+
+        Mp4Subs.extractIncremental(reader, extractOptions);
+    });
+}
+
+test('extracts a virtual 22 GB MP4 with bounded reads', async function () {
+    var data = fixture();
+    var twentyTwoGbReader = new MockRangeReader(data, 22 * 1024 * 1024 * 1024, 3);
+    var result = await incremental(twentyTwoGbReader);
+    var tracks = result.tracks;
+
+    assert.strictEqual(tracks.length, 1, 'one embedded MP4 text track');
+    assert.strictEqual(tracks[0].id, 7);
+    assert.strictEqual(tracks[0].lang, 'eng');
+    assert.strictEqual(tracks[0].codec, 'tx3g');
+    assert.strictEqual(tracks[0].cues.length, 2);
+    assert.strictEqual(tracks[0].cues[0].start, 0);
+    assert.strictEqual(tracks[0].cues[0].end, 1.5);
+    assert.strictEqual(tracks[0].cues[0].text, 'Hello from a huge MP4');
+    assert.strictEqual(tracks[0].cues[1].start, 1.5);
+    assert.strictEqual(tracks[0].cues[1].end, 4);
+    assert.strictEqual(tracks[0].cues[1].text, 'Second cue');
+    assert.ok(
+        result.eventOrder.indexOf('tracks') < result.eventOrder.indexOf('cues'),
+        'metadata is published before sample extraction'
+    );
+    assert.ok(twentyTwoGbReader.maxRequested <= 64 * 1024, 'reads stay bounded independent of virtual 22 GB size');
+    assert.ok(twentyTwoGbReader.closed, 'reader closed on success');
+});
+
+test('keeps the legacy full-buffer parser working', function () {
+    var data = fixture();
+    var fullBufferTracks = Mp4Subs._extractCueLists(data.buffer);
+    assert.strictEqual(fullBufferTracks.length, 1, 'legacy full-buffer parser regression');
+    assert.strictEqual(fullBufferTracks[0].cues[1].text, 'Second cue');
+});
+
+test('finds moov with tail fallback after a malformed top-level box', async function () {
+    var badTailData = fixtureWithBadTailBoxBeforeMoov();
+    var fallbackResult = await incremental(new MockRangeReader(badTailData));
+    assert.strictEqual(fallbackResult.tracks.length, 1, 'tail fallback finds moov after a malformed box');
+    assert.strictEqual(fallbackResult.tracks[0].cues[0].text, 'Hello from a huge MP4');
+});
+
+test('tail fallback searches beyond the final chunk', async function () {
+    var multiChunkTailData = fixtureWithBadTailBoxAndTrailingJunk();
+    var multiChunkResult = await incremental(new MockRangeReader(multiChunkTailData), {
+        chunkSize: 64 * 1024,
+        maxTailSearchBytes: 256 * 1024,
+        tailSearchChunkBytes: 32 * 1024
+    });
+    assert.strictEqual(multiChunkResult.tracks.length, 1, 'tail fallback searches beyond the final chunk');
+    assert.strictEqual(multiChunkResult.tracks[0].cues[1].text, 'Second cue');
+});
+
+test('cancels in-flight extraction without publishing callbacks', async function () {
+    var data = fixture();
+    var callbackCount = 0;
+    var delayedReader = new MockRangeReader(data, data.length, 3, 5);
+    var job = Mp4Subs.extractIncremental(delayedReader, {
+        onTracks: function () { callbackCount++; },
+        onComplete: function () { callbackCount++; },
+        onError: function () { callbackCount++; }
+    });
+
+    job.cancel('test');
+    await new Promise(function (resolve) { setTimeout(resolve, 25); });
+
+    assert.strictEqual(callbackCount, 0, 'cancelled scans cannot publish callbacks');
+    assert.ok(delayedReader.closed, 'reader closed on cancellation');
+});

--- a/tizen-web-vlc/js/app.js
+++ b/tizen-web-vlc/js/app.js
@@ -482,7 +482,7 @@
             // that auto-play and next/prev walk through.
             var playlist = entries
                 .filter(function (e) { return e.playable; })
-                .map(function (e) { return { uri: e.uri, title: e.name, subtitles: e.subtitles }; });
+                .map(function (e) { return { uri: e.uri, title: e.name, subtitles: e.subtitles, file: e.file }; });
 
             entries.forEach(function (e) {
                 if (e.isDir === false && !e.playable) return; // hide non-media files
@@ -567,6 +567,9 @@
                 uri:       state.playingUri,
                 title:     state.playingTitle,
                 subtitles: subs,
+                // Preserve the live Tizen File object for standby resumes;
+                // it carries size/path APIs used by incremental extraction.
+                file:      cur && cur.file ? cur.file : null,
                 pos:       Player.currentTime() || 0,
                 paused:    Player.state() === 'PAUSED'
             };
@@ -583,6 +586,7 @@
                 Debug.player('visibility=visible: restoring ' + ss.uri + ' at ' + ss.pos + 'ms');
             playUri(ss.uri, ss.title, {
                 subtitles: ss.subtitles,
+                file:      ss.file,
                 resume:    { pos: ss.pos, paused: ss.paused }
             });
         }
@@ -635,7 +639,8 @@
         setTimeout(function () {
             Player.open(uri, {
                 title:     title,
-                subtitles: opts.subtitles || []
+                subtitles: opts.subtitles || [],
+                file:      opts.file || null
             });
         }, 50);
 
@@ -710,7 +715,7 @@
         }
         var item = state.playlist[state.playlistIndex];
         if (!item) return;
-        playUri(item.uri, item.title, item.subtitles ? { subtitles: item.subtitles } : undefined);
+        playUri(item.uri, item.title, { subtitles: item.subtitles || [], file: item.file || null });
     }
     function playNext(isAuto) {
         var ni = state.playlistIndex + 1;
@@ -718,7 +723,7 @@
         var item = state.playlist[ni];
         state.playlistIndex = ni;
         if (isAuto) UI.toast('Up next: ' + item.title);
-        playUri(item.uri, item.title, item.subtitles ? { subtitles: item.subtitles } : undefined);
+        playUri(item.uri, item.title, { subtitles: item.subtitles || [], file: item.file || null });
         return true;
     }
     function playPrev() {
@@ -726,7 +731,7 @@
         var pi = state.playlistIndex - 1;
         var item = state.playlist[pi];
         state.playlistIndex = pi;
-        playUri(item.uri, item.title, item.subtitles ? { subtitles: item.subtitles } : undefined);
+        playUri(item.uri, item.title, { subtitles: item.subtitles || [], file: item.file || null });
         return true;
     }
     /* Dim the prev/next OSD buttons when there's nothing on that side. */

--- a/tizen-web-vlc/js/mp4-subs.js
+++ b/tizen-web-vlc/js/mp4-subs.js
@@ -8,9 +8,16 @@
  * each text-subtitle track to its own SRT in wgt-private-tmp, and treat
  * those generated SRTs as if they were external siblings.
  *
- * Codecs supported: tx3g (3GPP timed text) and mov_text (MP4 text).
+ * Codecs supported: tx3g (3GPP timed text) and mov_text / text tracks.
  * Sample format for both: u16be length + UTF-8 text.  Modifier boxes
  * after the text (style, colour, etc.) are skipped.
+ *
+ * Large-file flow:
+ *   1. Open a generic range reader for the local file.
+ *   2. Walk top-level MP4 boxes by declared size until moov is found.
+ *   3. Parse moov track/sample tables to locate supported text tracks.
+ *   4. Range-read only subtitle samples and append cues to live tracks.
+ * This keeps memory bounded by metadata/sample size, not movie size.
  */
 
 var Mp4Subs = (function () {
@@ -298,14 +305,11 @@ var Mp4Subs = (function () {
      *   file: a Tizen File object (with .toURI()) OR a string file URI
      *   cb:   function(err, [{id, lang, cues, srt}])
      *
-     * Reads the whole file as ArrayBuffer via XHR.  For large files we could
-     * later switch to Range-request partial reads, but for ≤2 GB MP4s this
-     * is simple and correct. */
-    /* Hard cap on whole-file loading.  Anything bigger gets skipped — we'd
-     * blow the TV's RAM trying to ArrayBuffer a 4 GB movie.  Proper fix is
-     * Range-based partial reads (moov + per-sample mdat ranges) but that
-     * needs to be validated against Tizen Chromium's file:// behaviour
-     * first.  TODO: implement partial reads. */
+     * Reads the whole file as ArrayBuffer via XHR. Kept for compatibility
+     * with small-file callers; Player uses extractIncremental() when it can
+     * pass a local Tizen File object. */
+    /* Hard cap on whole-file loading. Anything bigger gets skipped here;
+     * large local files should use extractIncremental() instead. */
     var MAX_FULL_LOAD_BYTES = 200 * 1024 * 1024;       // 200 MB
 
     function extract(file, cb) {
@@ -344,6 +348,890 @@ var Mp4Subs = (function () {
             if (!aborted) cb(new Error('XHR failed loading ' + uri));
         };
         xhr.send();
+    }
+
+    /* ── Incremental local-file extractor ────────────────────────────── */
+
+    var DEFAULT_CHUNK_BYTES = 4 * 1024 * 1024;
+    var DEFAULT_INTERNAL_READ_BYTES = 256 * 1024;
+    var DEFAULT_MAX_MOOV_BYTES = 64 * 1024 * 1024;
+    var DEFAULT_MAX_SAMPLE_BYTES = 2 * 1024 * 1024;
+    var DEFAULT_MAX_TAIL_SEARCH_BYTES = 512 * 1024 * 1024;
+    var DEFAULT_TAIL_SEARCH_CHUNK_BYTES = 64 * 1024;
+    var DEFAULT_XHR_RANGE_TIMEOUT_MS = 30000;
+    var MAX_CHUNK_BYTES = 16 * 1024 * 1024;
+    var MIN_CHUNK_BYTES = 64 * 1024;
+    var MIN_INTERNAL_READ_BYTES = 16 * 1024;
+    var MP4_HEADER_READ_BYTES = 16;
+    var SAFE_TIZEN_SEEK_STEP_BYTES = 1024 * 1024 * 1024;
+    var TAIL_SEARCH_OVERLAP_BYTES = 32;
+
+    function later(fn) {
+        setTimeout(fn, 0);
+    }
+
+    function log(message) {
+        if (typeof Debug !== 'undefined') Debug.player('MP4 sub scan: ' + message);
+    }
+
+    function warn(message) {
+        if (typeof Debug !== 'undefined') Debug.warn('MP4 sub scan: ' + message);
+    }
+
+    function filePathOf(file) {
+        if (file && file.fullPath) return file.fullPath;
+
+        var path = String(file || '');
+        if (path.indexOf('file://') === 0) path = path.slice(7);
+
+        try { path = decodeURIComponent(path); } catch (e) {}
+        return path;
+    }
+
+    function isValidRange(offset, length, size) {
+        return Number.isSafeInteger(offset) &&
+               Number.isSafeInteger(length) &&
+               offset >= 0 &&
+               length >= 0 &&
+               offset <= size;
+    }
+
+    // Wrap Tizen's newer openFile()/FileHandle API in the generic range-reader
+    // interface used by the incremental MP4 parser.
+    function makeModernReader(handle, size, internalReadSize) {
+        var closed = false;
+        var position = 0;
+        var positionKnown = false;
+
+        function seekTo(offset) {
+            if (!Number.isSafeInteger(offset) || offset < 0 || offset > size) {
+                throw Error('invalid seek offset');
+            }
+
+            if (positionKnown && offset === position) return;
+
+            var canSeekForwardFromHere = positionKnown &&
+                                         offset > position &&
+                                         offset - position <= SAFE_TIZEN_SEEK_STEP_BYTES;
+            if (!canSeekForwardFromHere) {
+                if (offset <= SAFE_TIZEN_SEEK_STEP_BYTES) {
+                    handle.seek(offset, 'BEGIN');
+                    position = offset;
+                    positionKnown = true;
+                    return;
+                }
+
+                handle.seek(0, 'BEGIN');
+                position = 0;
+                positionKnown = true;
+            }
+
+            var remaining = offset - position;
+            while (remaining > 0) {
+                var step = Math.min(remaining, SAFE_TIZEN_SEEK_STEP_BYTES);
+                handle.seek(step, 'CURRENT');
+                position += step;
+                remaining -= step;
+            }
+        }
+
+        return {
+            implementation: 'Tizen FileHandle (chunked seek)',
+
+            getSize: function (cb) {
+                later(function () { cb(null, size); });
+            },
+
+            readRange: function (offset, length, cb) {
+                if (closed || !isValidRange(offset, length, size)) {
+                    later(function () { cb(Error('invalid/closed range')); });
+                    return;
+                }
+
+                length = Math.min(length, size - offset);
+                var out = new Uint8Array(length);
+                var written = 0;
+
+                try {
+                    seekTo(offset);
+                } catch (e) {
+                    positionKnown = false;
+                    cb(e);
+                    return;
+                }
+
+                function readNextPart() {
+                    if (closed) {
+                        cb(Error('reader closed'));
+                        return;
+                    }
+                    if (written === length) {
+                        cb(null, out.buffer);
+                        return;
+                    }
+
+                    var take = Math.min(internalReadSize, length - written);
+
+                    function appendChunk(chunk) {
+                        chunk = chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk || []);
+                        if (!chunk.length) {
+                            cb(Error('unexpected EOF'));
+                            return;
+                        }
+
+                        var copied = Math.min(chunk.length, take);
+                        out.set(chunk.subarray(0, copied), written);
+                        written += copied;
+                        position += copied;
+                        positionKnown = true;
+                        later(readNextPart);
+                    }
+
+                    try {
+                        if (handle.readDataNonBlocking) {
+                            handle.readDataNonBlocking(appendChunk, cb, take);
+                        } else {
+                            appendChunk(handle.readData(take));
+                        }
+                    } catch (e) {
+                        cb(e);
+                    }
+                }
+
+                later(readNextPart);
+            },
+
+            close: function () {
+                if (closed) return;
+                closed = true;
+                try { handle.close(); } catch (e) {}
+            }
+        };
+    }
+
+    // Prefer browser byte-range requests for file:// URIs when available;
+    // they can read large-file offsets without loading the whole movie.
+    function makeXhrRangeReader(uri, size, timeoutMs) {
+        return {
+            implementation: 'XHR Range',
+
+            getSize: function (cb) {
+                later(function () { cb(null, size); });
+            },
+
+            readRange: function (offset, length, cb) {
+                if (!isValidRange(offset, length, size)) {
+                    later(function () { cb(Error('invalid range')); });
+                    return;
+                }
+                if (!length) {
+                    later(function () { cb(null, new ArrayBuffer(0)); });
+                    return;
+                }
+
+                length = Math.min(length, size - offset);
+
+                var xhr = new XMLHttpRequest();
+                var aborted = false;
+                var maxAcceptedLoad = Math.max(length + 65536, 1024 * 1024);
+
+                function fail(err) {
+                    if (aborted) return;
+                    aborted = true;
+                    try { xhr.abort(); } catch (e) {}
+                    cb(err instanceof Error ? err : Error(String(err)));
+                }
+
+                try {
+                    xhr.open('GET', uri, true);
+                    xhr.timeout = timeoutMs;
+                    xhr.responseType = 'arraybuffer';
+                    xhr.setRequestHeader('Range', 'bytes=' + offset + '-' + (offset + length - 1));
+                } catch (e) {
+                    fail(e);
+                    return;
+                }
+
+                xhr.onprogress = function (e) {
+                    if (aborted) return;
+
+                    if (e && e.lengthComputable && e.total > maxAcceptedLoad) {
+                        fail(Error('XHR range ignored; response total=' + e.total +
+                                   ' requested=' + length));
+                    } else if (e && e.loaded > maxAcceptedLoad) {
+                        fail(Error('XHR range exceeded bounded read; loaded=' + e.loaded +
+                                   ' requested=' + length));
+                    }
+                };
+                xhr.onload = function () {
+                    if (aborted) return;
+
+                    var buffer = xhr.response;
+                    if (!buffer) {
+                        fail(Error('empty XHR range response'));
+                        return;
+                    }
+
+                    if (buffer.byteLength !== length) {
+                        fail(Error('XHR range returned ' + buffer.byteLength +
+                                   ' bytes for requested ' + length));
+                        return;
+                    }
+
+                    cb(null, buffer);
+                };
+                xhr.onerror = function () {
+                    fail(Error('XHR range failed'));
+                };
+                xhr.ontimeout = function () {
+                    fail(Error('XHR range timed out'));
+                };
+                xhr.send();
+            },
+
+            close: function () {}
+        };
+    }
+
+    // Fallback for older Tizen FileStream objects. It is limited to 32-bit
+    // offsets, so it can only serve small/local files safely.
+    function makeLegacyReader(stream, size, internalReadSize) {
+        var closed = false;
+
+        return {
+            implementation: 'Tizen FileStream (legacy)',
+
+            getSize: function (cb) {
+                later(function () { cb(null, size); });
+            },
+
+            readRange: function (offset, length, cb) {
+                if (offset > 0x7fffffff) {
+                    later(function () { cb(Error('legacy FileStream cannot address offsets above 2 GiB')); });
+                    return;
+                }
+                if (closed || !isValidRange(offset, length, size)) {
+                    later(function () { cb(Error('invalid/closed range')); });
+                    return;
+                }
+
+                length = Math.min(length, size - offset);
+                var out = new Uint8Array(length);
+                var written = 0;
+
+                try {
+                    stream.position = offset;
+                } catch (e) {
+                    cb(e);
+                    return;
+                }
+
+                function readNextPart() {
+                    if (closed) {
+                        cb(Error('reader closed'));
+                        return;
+                    }
+                    if (written === length) {
+                        cb(null, out.buffer);
+                        return;
+                    }
+
+                    try {
+                        var chunk = stream.readBytes(Math.min(internalReadSize, length - written));
+                        if (!chunk.length) {
+                            cb(Error('unexpected EOF'));
+                            return;
+                        }
+
+                        out.set(chunk, written);
+                        written += chunk.length;
+                        later(readNextPart);
+                    } catch (e) {
+                        cb(e);
+                    }
+                }
+
+                later(readNextPart);
+            },
+
+            close: function () {
+                if (closed) return;
+                closed = true;
+                try { stream.close(); } catch (e) {}
+            }
+        };
+    }
+
+    function openIncrementalReader(file, options, cb) {
+        if (file && file.readRange && file.getSize) {
+            later(function () { cb(null, file); });
+            return;
+        }
+
+        if (typeof tizen === 'undefined' || !tizen.filesystem) {
+            later(function () { cb(Error('Tizen filesystem unavailable')); });
+            return;
+        }
+
+        var path = filePathOf(file);
+        var uri = file && typeof file.toURI === 'function' ? file.toURI() : String(file || '');
+        var size = file && Number(file.fileSize);
+        var internalReadSize = Math.min(options.internalReadSize, options.chunkSize);
+
+        function tryXhrRangeReader(onUnavailable) {
+            if (typeof XMLHttpRequest === 'undefined' || !uri || uri.indexOf('file://') !== 0 ||
+                !Number.isSafeInteger(size)) {
+                onUnavailable();
+                return;
+            }
+
+            var xhrReader = makeXhrRangeReader(uri, size, options.xhrRangeTimeoutMs);
+            xhrReader.readRange(0, MP4_HEADER_READ_BYTES, function (err, buffer) {
+                if (!err && buffer && buffer.byteLength === MP4_HEADER_READ_BYTES) {
+                    cb(null, xhrReader);
+                    return;
+                }
+
+                onUnavailable();
+            });
+        }
+
+        function openTizenReader(resolvedFile) {
+            if (tryModernReader()) return;
+
+            if (resolvedFile) {
+                openLegacyReader(resolvedFile);
+            } else if (file && file.openStream) {
+                openLegacyReader(file);
+            } else {
+                cb(Error('no usable local file reader'));
+            }
+        }
+
+        function tryModernReader() {
+            if (!tizen.filesystem.openFile) return false;
+            if (!Number.isSafeInteger(size)) return false;
+
+            var handle;
+            try {
+                handle = tizen.filesystem.openFile(path, 'r');
+            } catch (e) {
+                return false;
+            }
+
+            cb(null, makeModernReader(handle, size, internalReadSize));
+            return true;
+        }
+
+        function openLegacyReader(resolvedFile) {
+            size = Number(resolvedFile.fileSize);
+            try {
+                resolvedFile.openStream(
+                    'r',
+                    function (stream) { cb(null, makeLegacyReader(stream, size, internalReadSize)); },
+                    cb
+                );
+            } catch (e) {
+                cb(e);
+            }
+        }
+
+        if (Number.isSafeInteger(size)) {
+            tryXhrRangeReader(function () { openTizenReader(file && file.openStream ? file : null); });
+            return;
+        }
+
+        try {
+            tizen.filesystem.resolve(
+                path,
+                function (resolvedFile) {
+                    size = Number(resolvedFile.fileSize);
+                    path = resolvedFile.fullPath;
+                    if (typeof resolvedFile.toURI === 'function') uri = resolvedFile.toURI();
+
+                    tryXhrRangeReader(function () { openTizenReader(resolvedFile); });
+                },
+                cb,
+                'r'
+            );
+        } catch (e) {
+            cb(e);
+        }
+    }
+
+    function normalizeIncrementalOptions(handlerOptions) {
+        var chunkSize = Math.max(
+            MIN_CHUNK_BYTES,
+            Math.min(handlerOptions.chunkSize || DEFAULT_CHUNK_BYTES, MAX_CHUNK_BYTES)
+        );
+
+        return {
+            chunkSize: chunkSize,
+            internalReadSize: Math.max(
+                MIN_INTERNAL_READ_BYTES,
+                handlerOptions.internalReadSize || DEFAULT_INTERNAL_READ_BYTES
+            ),
+            maxMoovBytes: handlerOptions.maxMoovBytes || DEFAULT_MAX_MOOV_BYTES,
+            maxTailSearchBytes: handlerOptions.maxTailSearchBytes || DEFAULT_MAX_TAIL_SEARCH_BYTES,
+            xhrRangeTimeoutMs: handlerOptions.xhrRangeTimeoutMs || DEFAULT_XHR_RANGE_TIMEOUT_MS,
+            tailSearchChunkBytes: Math.max(
+                MP4_HEADER_READ_BYTES,
+                Math.min(handlerOptions.tailSearchChunkBytes || DEFAULT_TAIL_SEARCH_CHUNK_BYTES, chunkSize)
+            ),
+            maxSampleBytes: Math.min(
+                handlerOptions.maxSampleBytes || DEFAULT_MAX_SAMPLE_BYTES,
+                chunkSize
+            )
+        };
+    }
+
+    function readBoxHeader(reader, offset, fileSize, cb) {
+        if (offset >= fileSize) {
+            cb(null, null);
+            return;
+        }
+
+        reader.readRange(offset, Math.min(MP4_HEADER_READ_BYTES, fileSize - offset), function (err, buffer) {
+            if (err) {
+                cb(err);
+                return;
+            }
+
+            try {
+                var view = new DataView(buffer);
+                if (view.byteLength < 8) throw Error('truncated MP4 box header');
+
+                var size = view.getUint32(0);
+                var type = String.fromCharCode(
+                    view.getUint8(4), view.getUint8(5),
+                    view.getUint8(6), view.getUint8(7)
+                );
+                var headerSize = 8;
+
+                if (size === 1) {
+                    if (view.byteLength < 16) throw Error('truncated extended MP4 box header');
+                    var hi = view.getUint32(8);
+                    var lo = view.getUint32(12);
+                    size = hi * 0x100000000 + lo;
+                    headerSize = 16;
+                } else if (size === 0) {
+                    size = fileSize - offset;
+                }
+
+                var remaining = fileSize - offset;
+                var boxDetails = 'type=' + JSON.stringify(type) +
+                                 ' size=' + size +
+                                 ' remaining=' + remaining;
+
+                if (size < headerSize) throw Error('invalid MP4 box size (' + boxDetails + ')');
+                if (offset + size > fileSize) throw Error('MP4 box exceeds file (' + boxDetails + ')');
+
+                cb(null, {
+                    type: type,
+                    start: offset,
+                    body: offset + headerSize,
+                    size: size,
+                    end: offset + size
+                });
+            } catch (e) {
+                cb(Error('MP4 box header at ' + offset + ': ' + e.message));
+            }
+        });
+    }
+
+    function isSupportedTextTrack(track) {
+        var isSubtitleHandler = track.handler === 'subt' ||
+                                track.handler === 'sbtl' ||
+                                track.handler === 'text';
+        var isSupportedCodec = track.codec === 'tx3g' ||
+                               track.codec === 'text' ||
+                               track.codec === 'mov_';
+
+        return isSubtitleHandler &&
+               isSupportedCodec &&
+               track.timescale &&
+               track.sampleSizes &&
+               track.sampleSizes.length &&
+               track.chunkOffsets &&
+               track.chunkOffsets.length &&
+               track.stsc &&
+               track.stsc.length;
+    }
+
+    function makeIncrementalTrack(track) {
+        return {
+            id: track.id,
+            lang: track.lang || '',
+            codec: track.codec,
+            cues: []
+        };
+    }
+
+    function extractIncremental(file, handlers) {
+        handlers = handlers || {};
+
+        var cancelled = false;
+        var finished = false;
+        var reader = null;
+        var fileSize = 0;
+        var published = false;
+        var lastLoggedPercent = -5;
+        var triedTailMoovSearch = false;
+        var options = normalizeIncrementalOptions(handlers);
+
+        function safeCallback(name) {
+            if (cancelled || typeof handlers[name] !== 'function') return;
+
+            try {
+                handlers[name].apply(null, [].slice.call(arguments, 1));
+            } catch (e) {
+                warn(name + ' callback: ' + e.message);
+            }
+        }
+
+        function closeReader() {
+            if (!reader) return;
+
+            try { reader.close(); } catch (e) {}
+            reader = null;
+        }
+
+        function fail(err) {
+            if (cancelled || finished) return;
+
+            finished = true;
+            closeReader();
+            warn('parse error: ' + (err.message || err));
+            safeCallback('onError', err instanceof Error ? err : Error(String(err)));
+        }
+
+        function reportProgress(processed, total) {
+            safeCallback('onProgress', processed, total || fileSize);
+
+            var denominator = total || fileSize;
+            var percent = denominator ? Math.floor(processed * 100 / denominator) : 100;
+            if (percent >= lastLoggedPercent + 5) {
+                lastLoggedPercent = percent;
+                log('processed ' + percent + '%');
+            }
+        }
+
+        function publishTracksOnce(tracks) {
+            if (published) return;
+
+            published = true;
+            log('discovered ' + tracks.length + ' supported text track(s)');
+            safeCallback('onTracks', tracks);
+        }
+
+        function finish(tracks) {
+            if (cancelled || finished) return;
+
+            finished = true;
+            closeReader();
+            log('complete: ' + tracks.map(function (track) {
+                return track.id + '=' + track.cues.length;
+            }).join(', '));
+            safeCallback('onComplete', tracks);
+        }
+
+        function readMoovBox(moovBox) {
+            if (moovBox.size > options.maxMoovBytes) {
+                fail(Error('moov box too large for bounded metadata read: ' + moovBox.size + ' bytes'));
+                return;
+            }
+
+            reader.readRange(moovBox.body, moovBox.end - moovBox.body, function (err, buffer) {
+                if (err) {
+                    fail(err);
+                    return;
+                }
+
+                var textTrackMetadata;
+                try {
+                    textTrackMetadata = parseMp4(buffer).filter(isSupportedTextTrack);
+                } catch (e) {
+                    fail(e);
+                    return;
+                }
+
+                var liveTracks = textTrackMetadata.map(makeIncrementalTrack);
+                publishTracksOnce(liveTracks);
+
+                if (!liveTracks.length) {
+                    finish(liveTracks);
+                    return;
+                }
+
+                extractTrackSamples(textTrackMetadata, liveTracks);
+            });
+        }
+
+        function findMoovInBuffer(buffer, baseOffset) {
+            var view = new DataView(buffer);
+
+            for (var typeOffset = view.byteLength - 4; typeOffset >= 4; typeOffset--) {
+                if (view.getUint8(typeOffset) !== 0x6D ||     // m
+                    view.getUint8(typeOffset + 1) !== 0x6F || // o
+                    view.getUint8(typeOffset + 2) !== 0x6F || // o
+                    view.getUint8(typeOffset + 3) !== 0x76) { // v
+                    continue;
+                }
+
+                var boxStart = typeOffset - 4;
+                var size = view.getUint32(boxStart);
+                var headerSize = 8;
+
+                if (size === 1) {
+                    if (boxStart + 16 > view.byteLength) continue;
+
+                    var hi = view.getUint32(boxStart + 8);
+                    var lo = view.getUint32(boxStart + 12);
+                    size = hi * 0x100000000 + lo;
+                    headerSize = 16;
+                } else if (size === 0) {
+                    size = view.byteLength - boxStart;
+                }
+
+                var absoluteStart = baseOffset + boxStart;
+                var absoluteEnd = absoluteStart + size;
+                if (size < headerSize || absoluteEnd > fileSize) continue;
+
+                return {
+                    type: 'moov',
+                    start: absoluteStart,
+                    body: absoluteStart + headerSize,
+                    size: size,
+                    end: absoluteEnd
+                };
+            }
+
+            return null;
+        }
+
+        function bufferContainsBoxType(buffer, type) {
+            var view = new DataView(buffer);
+            var a = type.charCodeAt(0);
+            var b = type.charCodeAt(1);
+            var c = type.charCodeAt(2);
+            var d = type.charCodeAt(3);
+
+            for (var i = 0; i <= view.byteLength - 4; i++) {
+                if (view.getUint8(i) === a &&
+                    view.getUint8(i + 1) === b &&
+                    view.getUint8(i + 2) === c &&
+                    view.getUint8(i + 3) === d) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        function findMoovNearTail(originalErr) {
+            if (triedTailMoovSearch) {
+                fail(originalErr || Error('moov box not found'));
+                return;
+            }
+            triedTailMoovSearch = true;
+
+            var searchBytes = Math.min(options.maxTailSearchBytes, fileSize);
+            var searchStart = fileSize - searchBytes;
+            var sawMoof = false;
+
+            function failAfterTailSearch() {
+                var originalMessage = originalErr && (originalErr.message || originalErr);
+                fail(Error('moov box not found after top-level scan and tail search' +
+                           (sawMoof ? ' (saw fragmented MP4 boxes)' : '') +
+                           (originalMessage ? '; original error: ' + originalMessage : '')));
+            }
+
+            function searchChunk(chunkEnd) {
+                if (cancelled) return;
+
+                if (chunkEnd <= searchStart) {
+                    failAfterTailSearch();
+                    return;
+                }
+
+                var chunkStart = Math.max(searchStart, chunkEnd - options.tailSearchChunkBytes);
+                reader.readRange(chunkStart, chunkEnd - chunkStart, function (err, buffer) {
+                    if (err) {
+                        fail(err);
+                        return;
+                    }
+
+                    sawMoof = sawMoof || bufferContainsBoxType(buffer, 'moof');
+
+                    var moovBox = findMoovInBuffer(buffer, chunkStart);
+                    if (moovBox) {
+                        log('found moov by tail search at ' + moovBox.start + ' size=' + moovBox.size);
+                        readMoovBox(moovBox);
+                        return;
+                    }
+
+                    if (chunkStart === searchStart) {
+                        failAfterTailSearch();
+                        return;
+                    }
+
+                    later(function () {
+                        searchChunk(chunkStart + TAIL_SEARCH_OVERLAP_BYTES);
+                    });
+                });
+            }
+
+            searchChunk(fileSize);
+        }
+
+        function extractTrackSamples(metadataTracks, liveTracks) {
+            var trackIndex = 0;
+
+            function nextTrack() {
+                if (cancelled) return;
+                if (trackIndex >= metadataTracks.length) {
+                    finish(liveTracks);
+                    return;
+                }
+
+                extractOneTrack(metadataTracks[trackIndex], liveTracks[trackIndex], function (err) {
+                    if (err) fail(err);
+                    else {
+                        trackIndex++;
+                        later(nextTrack);
+                    }
+                });
+            }
+
+            nextTrack();
+        }
+
+        function extractOneTrack(metadata, liveTrack, cb) {
+            var offsets = computeSampleOffsets(
+                metadata.stsc,
+                metadata.chunkOffsets,
+                metadata.sampleSizes.length,
+                metadata.sampleSizes
+            );
+            var times = expandStts(metadata.stts, metadata.sampleSizes.length);
+            var sampleIndex = 0;
+
+            function nextSample() {
+                if (cancelled) return;
+                if (sampleIndex >= metadata.sampleSizes.length) {
+                    safeCallback('onCues', liveTrack.id, liveTrack.cues);
+                    cb(null);
+                    return;
+                }
+
+                var size = metadata.sampleSizes[sampleIndex];
+                var offset = offsets[sampleIndex];
+                var time = times[sampleIndex];
+                var currentSample = sampleIndex;
+                sampleIndex++;
+
+                reportProgress(sampleIndex, metadata.sampleSizes.length);
+
+                if (!size) {
+                    later(nextSample);
+                    return;
+                }
+                if (!Number.isSafeInteger(offset) || offset < 0 || offset + size > fileSize) {
+                    cb(Error('subtitle sample points outside file at index ' + currentSample));
+                    return;
+                }
+                if (size > options.maxSampleBytes) {
+                    warn('skipping oversized subtitle sample at ' + offset);
+                    later(nextSample);
+                    return;
+                }
+
+                reader.readRange(offset, size, function (err, buffer) {
+                    if (err) {
+                        cb(err);
+                        return;
+                    }
+
+                    var text = decodeTextSample(buffer, 0, buffer.byteLength).trim();
+                    if (text) {
+                        liveTrack.cues.push({
+                            start: time.start / metadata.timescale,
+                            end: time.end / metadata.timescale,
+                            text: text
+                        });
+
+                        safeCallback('onCues', liveTrack.id, liveTrack.cues);
+                    }
+
+                    later(nextSample);
+                });
+            }
+
+            nextSample();
+        }
+
+        function findMoov(offset) {
+            if (cancelled) return;
+
+            readBoxHeader(reader, offset, fileSize, function (err, box) {
+                if (err) {
+                    findMoovNearTail(err);
+                    return;
+                }
+                if (!box) {
+                    findMoovNearTail(Error('moov box not found'));
+                    return;
+                }
+
+                if (box.type === 'moov') {
+                    log('found moov at ' + box.start + ' size=' + box.size);
+                    readMoovBox(box);
+                } else {
+                    reportProgress(box.end, fileSize);
+                    later(function () { findMoov(box.end); });
+                }
+            });
+        }
+
+        openIncrementalReader(file, options, function (err, openedReader) {
+            if (cancelled) {
+                if (openedReader) openedReader.close();
+                return;
+            }
+            if (err) {
+                fail(err);
+                return;
+            }
+
+            reader = openedReader;
+            reader.getSize(function (sizeErr, size) {
+                if (sizeErr) {
+                    fail(sizeErr);
+                    return;
+                }
+
+                fileSize = Number(size);
+                if (!Number.isSafeInteger(fileSize)) {
+                    fail(Error('invalid file size'));
+                    return;
+                }
+
+                log('file size=' + fileSize +
+                    ' reader=' + (reader.implementation || 'custom') +
+                    ' chunk=' + options.chunkSize);
+                findMoov(0);
+            });
+        });
+
+        return {
+            cancel: function (reason) {
+                if (cancelled || finished) return;
+
+                cancelled = true;
+                closeReader();
+                log('cancelled' + (reason ? ': ' + reason : ''));
+            }
+        };
     }
 
     /* Write an SRT string into wgt-private-tmp and call cb with a record:
@@ -390,7 +1278,13 @@ var Mp4Subs = (function () {
 
     return {
         extract:       extract,
+        extractIncremental: extractIncremental,
         cuesToSrt:     cuesToSrt,
+        _extractCueLists: extractCueLists,
         writeSrtToTmp: writeSrtToTmp
     };
 })();
+
+// CommonJS export is ignored by Tizen/browser builds, but lets Node tests
+// require this parser directly.
+if (typeof module !== 'undefined' && module.exports) module.exports = Mp4Subs;

--- a/tizen-web-vlc/js/player.js
+++ b/tizen-web-vlc/js/player.js
@@ -253,6 +253,15 @@ var Player = (function () {
      * is unreliable. */
     function startExternalSubtitle(sub) {
         stopExternalSubtitle();
+        // Incremental embedded tracks publish one stable cue array up front.
+        // Keep that reference so the poller automatically sees cues appended
+        // by the background scanner without rewriting a growing SRT file.
+        if (sub && Array.isArray(sub.cues)) {
+            extCues = sub.cues;
+            extLastCueIdx = -1;
+            extPollTimer = setInterval(extPoll, 250);
+            return;
+        }
         if (!sub || typeof Browser === 'undefined' || !Browser.readSubtitleText) return;
         Browser.readSubtitleText(sub, function (err, text) {
             if (err) {
@@ -579,6 +588,7 @@ var Player = (function () {
                      * own renderer silent so only our overlay shows.  (The CC
                      * menu and applyLanguagePreferences use the same path
                      * mid-playback.) */
+                    applyAvSubtitleLanguageHintsToExtractedMp4();
                     if (typeof Settings !== 'undefined') {
                         var pref = Settings.get('subtitleLang');
                         var sub  = pickBestExternalSubtitle(pref);
@@ -723,7 +733,15 @@ var Player = (function () {
      * extracted, we apply it after the fact via applyExternalSubtitleLive(),
      * which renders without seeking the playhead. */
     var lastExtractToken = 0;
-    function extractAndAppendEmbeddedSubs(url) {
+    var activeEmbeddedSubExtraction = null;
+    function cancelEmbeddedSubExtraction(reason) {
+        ++lastExtractToken;
+        if (activeEmbeddedSubExtraction && activeEmbeddedSubExtraction.cancel) {
+            activeEmbeddedSubExtraction.cancel(reason);
+        }
+        activeEmbeddedSubExtraction = null;
+    }
+    function extractAndAppendEmbeddedSubs(url, file) {
         var lower = String(url || '').toLowerCase().split('?')[0];
         var extractor, label;
         if (/\.mp4$|\.m4v$|\.mov$/.test(lower) && typeof Mp4Subs !== 'undefined') {
@@ -736,6 +754,65 @@ var Player = (function () {
 
         var token = ++lastExtractToken;
         if (typeof Debug !== 'undefined') Debug.player(label + ' sub extract: starting on ' + url);
+
+        if (extractor.extractIncremental) {
+            var entriesByTrack = {};
+            activeEmbeddedSubExtraction = extractor.extractIncremental(file || url, {
+                onTracks: function (tracks) {
+                    if (token !== lastExtractToken) return;
+                    var languageHints = label === 'MP4' ? getAvSubtitleLanguageHints() : [];
+                    if (languageHints.length !== tracks.length) languageHints = [];
+
+                    for (var i = 0; i < tracks.length; i++) {
+                        var s = tracks[i];
+                        var hintedLang = languageHints[i] && languageHints[i].lang;
+                        var entry = {
+                            name: 'Embedded subtitle ' + (i + 1) + ' (' + label + ', scanning)',
+                            lang: hintedLang || s.lang || '',
+                            ext: 'srt',
+                            _extracted: true,
+                            _incremental: true,
+                            _containerLabel: label,
+                            _trackId: s.id,
+                            _nativeTextIndex: languageHints[i] && languageHints[i].index,
+                            _cueCount: 0,
+                            cues: s.cues
+                        };
+                        entriesByTrack[s.id] = entry;
+                        playerSubtitles.push(entry);
+                    }
+                    h5Subtitles = playerSubtitles;
+                    emit('onsubsupdated');
+                    // The language preference may select the live track now;
+                    // its poller will begin rendering as cues arrive.
+                    if (tracks.length) onMp4SubExtractionDone();
+                },
+                onCues: function (trackId, cues) {
+                    if (token !== lastExtractToken) return;
+                    var entry = entriesByTrack[trackId];
+                    if (entry) entry._cueCount = cues.length;
+                },
+                onComplete: function () {
+                    if (token !== lastExtractToken) return;
+                    activeEmbeddedSubExtraction = null;
+                    for (var key in entriesByTrack) {
+                        var entry = entriesByTrack[key];
+                        entry.name = entry.name.replace(/, scanning(?: \d+%)?/, '');
+                        entry._cueCount = entry.cues.length;
+                    }
+                    emit('onsubsupdated');
+                },
+                onError: function (err) {
+                    if (token !== lastExtractToken) return;
+                    activeEmbeddedSubExtraction = null;
+                    for (var key in entriesByTrack)
+                        entriesByTrack[key].name = entriesByTrack[key].name.replace(/, scanning(?: \d+%)?/, ', partial');
+                    emit('onsubsupdated');
+                    if (typeof Debug !== 'undefined') Debug.warn(label + ' incremental sub extract failed: ' + (err.message || err));
+                }
+            });
+            return;
+        }
         extractor.extract(url, function (err, subs) {
             if (token !== lastExtractToken) return;
             if (err) {
@@ -765,6 +842,7 @@ var Player = (function () {
                             uri:        rec.uri,
                             fullPath:   rec.fullPath,
                             _extracted: true,
+                            _containerLabel: label,
                             _cueCount:  s.cues.length
                         });
                         if (typeof Debug !== 'undefined')
@@ -802,6 +880,7 @@ var Player = (function () {
 
     function open(url, opts) {
         opts = opts || {};
+        cancelEmbeddedSubExtraction('opening another file');
         playerSubtitles = (opts.subtitles) ? opts.subtitles.slice() : [];
         h5Subtitles = playerSubtitles;
         stopExternalSubtitle();    // clear any previous file's poller
@@ -831,7 +910,7 @@ var Player = (function () {
                 // subtitle tracks (MP4 / MKV / WebM) and route them through
                 // the working external-subtitle pipeline.  No-op for
                 // unsupported containers.
-                extractAndAppendEmbeddedSubs(url);
+                extractAndAppendEmbeddedSubs(url, opts.file);
 
                 avOpen(url, function (reason) {
                     // For MKV there's no point falling back to the HTML5
@@ -882,6 +961,7 @@ var Player = (function () {
     }
     function stop() {
         clearTimeout(h5OpenWatchdog);
+        cancelEmbeddedSubExtraction('playback stopped');
         stopExternalSubtitle();
         hideSubtitleText();
         currentExternalSub = null;
@@ -1006,13 +1086,66 @@ var Player = (function () {
             var m = s.match(/\b([a-z]{2,3})\b/i);
             return { label: s, lang: m ? m[1].toLowerCase() : '', codec: s };
         }
-        var lang  = (obj.language || obj.lang || '').toString().toLowerCase();
+        var lang  = (obj.language || obj.lang || obj.track_lang || '').toString().toLowerCase();
         var codec = (obj.fourCC || obj.codec || '').toString();
         var parts = [];
         if (lang) parts.push(lang.toUpperCase());
         if (codec) parts.push(codec);
         if (obj.channels) parts.push(obj.channels + 'ch');
         return { label: parts.join(' · ') || s, lang: lang, codec: codec };
+    }
+
+    // AVPlay sometimes exposes better language tags than the MP4 metadata
+    // parser sees. Use these only as labels for extracted tracks.
+    function getAvSubtitleLanguageHints() {
+        var hints = [];
+        try {
+            var info = av().getTotalTrackInfo();
+
+            for (var i = 0; i < info.length; i++) {
+                var t = info[i];
+                if (t.type !== 'TEXT' && t.type !== 'SUBTITLE') continue;
+
+                var parsed = parseAvExtraInfo(t.extra_info);
+                hints.push({
+                    index: t.index,
+                    lang: parsed.lang || '',
+                    codec: parsed.codec || ''
+                });
+            }
+        } catch (e) {}
+
+        return hints;
+    }
+
+    function applyAvSubtitleLanguageHintsToExtractedMp4() {
+        if (!playerSubtitles || !playerSubtitles.length) return;
+
+        var hints = getAvSubtitleLanguageHints();
+        if (!hints.length) return;
+
+        var hintIndex = 0;
+        var mp4ExtractedCount = 0;
+        for (var c = 0; c < playerSubtitles.length; c++) {
+            if (playerSubtitles[c] && playerSubtitles[c]._extracted &&
+                playerSubtitles[c]._containerLabel === 'MP4') {
+                mp4ExtractedCount++;
+            }
+        }
+        if (hints.length !== mp4ExtractedCount) return;
+
+        for (var i = 0; i < playerSubtitles.length; i++) {
+            var sub = playerSubtitles[i];
+            if (!sub || !sub._extracted || sub._containerLabel !== 'MP4') continue;
+
+            var hint = hints[hintIndex++];
+            if (!hint) continue;
+
+            sub._nativeTextIndex = hint.index;
+            if (hint.lang && sub.lang !== hint.lang) {
+                sub.lang = hint.lang;
+            }
+        }
     }
 
     /* ── Track info ─────────────────────────────────────────────────────


### PR DESCRIPTION
So to be upfront this is very much a vibe coded MR. I have a lot of IT experience. But it is not with video files or with tv's :) 
Im aware of the current Open source AI vibe, and if you dont want to deal with AI merge requests then no hard feelings.

That said this fixed a huge annoyance for me with sub's and big files on my `Samsung Neo QLED QN90F`. I specifically tested this with a  huge 20 GB mp4 and it worked like a charm after testing many different approaches to fix the issue.

I think it could also help other people, so if there is anything i can improve to have it be better quality let me know.
And otherwise if you dont feel like bothering with AI MR's, I get it, no hard feelings and ill just keep this version for myself thanks to the power of Opensource

# Actual MR stuff

Adds bounded-memory extraction for embedded MP4 text subtitles in large local files.

Previously, MP4 subtitle extraction used whole-file XHR loading, which cannot work safely for multi-GB videos. This adds an incremental path that:

- reads MP4 top-level boxes to find moov without scanning or loading mdat
- range-reads only subtitle metadata and subtitle samples
- supports tx3g/text tracks
- starts playback through AVPlay while subtitle extraction runs in the background
- renders extracted cues through the existing JS subtitle overlay
- cancels stale extraction when opening or stopping playback
- falls back safely if a device does not expose the preferred range/file APIs

The change keeps the existing whole-file extraction path for small-file compatibility and adds synthetic MP4 parser tests so no large media file is needed.

CI:

- .github/workflows/tizen-web-vlc-tests.yml runs node --test tests/tizen-web-vlc/mp4-subs.test.js on PRs and main pushes touching the web app or its tests.
