### PR TITLE
feat: move Recently Played to leftmost home tile (#56)

### DIFF
--- a/tizen-web-vlc/index.html
+++ b/tizen-web-vlc/index.html
@@ -30,7 +30,15 @@
     </header>
 
     <nav class="home-tiles">
-        <button class="tile" data-action="open-url" data-focus>
+        <!-- Recently Played is intentionally the leftmost tile so the D-pad
+             lands on it first — the common return-visit action is "resume
+             what I was watching", not "browse from scratch" (issue #56). -->
+        <button class="tile" data-action="browse-recent" data-focus>
+            <div class="tile-icon">★</div>
+            <div class="tile-label">Recently Played</div>
+            <div class="tile-sub">Quick access to past media</div>
+        </button>
+        <button class="tile" data-action="open-url">
             <div class="tile-icon">URL</div>
             <div class="tile-label">Open Network Stream</div>
             <div class="tile-sub">HTTP · HLS · DASH · RTSP · RTMP</div>
@@ -44,11 +52,6 @@
             <div class="tile-icon">SMB</div>
             <div class="tile-label">Browse SMB Share</div>
             <div class="tile-sub">Network files over your LAN</div>
-        </button>
-        <button class="tile" data-action="browse-recent">
-            <div class="tile-icon">★</div>
-            <div class="tile-label">Recently Played</div>
-            <div class="tile-sub">Quick access to past media</div>
         </button>
         <button class="tile" data-action="open-settings">
             <div class="tile-icon">⚙</div>


### PR DESCRIPTION
Closes #56.

## What

Reorders the home-screen tiles so **Recently Played** is first (leftmost) and moves `data-focus` onto it, so the D-pad lands on it the moment the home view opens.

New order: **Recent → URL → USB → SMB → Settings**.

## Why

The most common return-visit action is "resume what I was watching", not "browse from scratch". Making Recent the default focus turns the common flow into a single OK press.

## Test plan

- [ ] Fresh app open → focus lands on Recently Played.
- [ ] Pressing OK on the default focus opens the Recently Played view.
- [ ] D-pad Right walks through URL → USB → SMB → Settings in that order.
- [ ] Recently Played still shows the recent list correctly (regression).