### PR TITLE
fix: OK toggles play/pause + BACK on home exits app (#57)

### DIFF
--- a/tizen-web-vlc/index.html
+++ b/tizen-web-vlc/index.html
@@ -60,7 +60,7 @@
     <footer class="hint">
         <span class="key">↑↓←→</span> navigate
         <span class="key">OK</span> select
-        <span class="key">RETURN</span> back
+        <span class="key">RETURN</span> exit app
     </footer>
 </section>
 

--- a/tizen-web-vlc/js/app.js
+++ b/tizen-web-vlc/js/app.js
@@ -780,6 +780,26 @@
         closeTrackMenu();
     }
 
+    /* Cleanly quit the app from the home view (issue #57).  Tizen exposes
+     * this on the current-application object; window.close() is a fallback
+     * for the emulator / desktop-preview environment where the tizen
+     * namespace isn't present.  Player is stopped first so AVPlay isn't
+     * left holding a decoder handle if the user quit mid-playback via
+     * exitPlayer → home → BACK. */
+    function exitApp() {
+        if (typeof Debug !== 'undefined') Debug.action('exit-app');
+        try { Player.stop(); } catch (e) {}
+        try {
+            if (typeof tizen !== 'undefined' && tizen.application) {
+                tizen.application.getCurrentApplication().exit();
+                return;
+            }
+        } catch (e) {
+            if (typeof Debug !== 'undefined') Debug.warn('tizen.application.exit failed: ' + (e.message || e));
+        }
+        try { window.close(); } catch (e) {}
+    }
+
     /* ── OSD show/hide ────────────────────────────────────────────── */
     var osdHideTimer = null;
     function showOSD(visible) {
@@ -1448,10 +1468,14 @@
             case K.ENTER:
                 // In player view: OK activates the focused OSD button if the OSD
                 // is up (so Stop / CC-Audio / etc. are reachable).  If the OSD
-                // is hidden, OK just brings it up.
+                // is hidden, OK toggles play/pause AND brings the OSD up —
+                // matches YouTube-on-TV / Netflix, and gives users whose
+                // remote's dedicated Play/Pause hard key isn't delivered to
+                // the app (Smart Monitor M5 and friends — issues #42, #57)
+                // a working way to pause without opening the OSD first.
                 if (state.view === 'player' && !errorUp && !trackMenuOpen) {
                     if (scrub.active) { commitScrub(); return true; }
-                    if (!osdVisible) { flashOSD(); return true; }
+                    if (!osdVisible) { Player.togglePause(); flashOSD(); return true; }
                     if (!UI.activateFocused()) flashOSD();
                     return true;
                 }
@@ -1465,7 +1489,12 @@
                 if (state.view === 'player')    { exitPlayer();      return true; }
                 if (state.view === 'url')       { backToHome();      return true; }
                 if (state.view === 'settings')  { backToHome();      return true; }
-                return false; /* let TV handle EXIT-from-home */
+                /* Home view: explicitly exit the app rather than trusting the
+                 * TV launcher to intercept an unhandled BACK — that fallback
+                 * doesn't fire on Smart Monitors, leaving the user with no
+                 * way out (issue #57). */
+                if (state.view === 'home')      { exitApp();         return true; }
+                return false;
             case K.PLAY:
             case K.PAUSE:
             case K.PLAYPAUSE:


### PR DESCRIPTION
Closes #57.

## Two independent fixes bundled since they surfaced in the same issue

### 1. Play/Pause responsiveness

**Before:** in player view with the OSD hidden, `OK` only lifted the OSD — you had to press `OK` a second time to actually toggle playback. On remotes whose dedicated Play/Pause hard key isn't delivered to the app (Smart Monitor M5 and family — issue #42), that made the whole app feel unresponsive to the natural "press once to pause" expectation.

**After:** `OK` now toggles pause **AND** lifts the OSD in one press — YouTube-on-TV / Netflix behaviour. When the OSD is already up, `OK` still activates the focused control as before (Stop, CC/Audio, speed etc. stay reachable), so nothing regresses.

### 2. Exit-from-home

**Before:** `BACK` on the home view returned false and relied on the TV launcher to intercept as "exit app". That fallback doesn't fire on Samsung Smart Monitors, leaving users with no way out of the app.

**After:** `BACK` on home explicitly calls `tizen.application.getCurrentApplication().exit()` (with `window.close()` as a fallback for the emulator / desktop preview). Home footer hint updated: `RETURN back` → `RETURN exit app`.

## Test plan

- [ ] Player view, OSD hidden → press OK → playback pauses AND OSD appears.
- [ ] Player view, OSD hidden → press OK on a playing file, then OK again while OSD is up → second OK activates the focused play/pause button (which resumes). No double-toggle regression.
- [ ] Player view, OSD hidden while paused → OK → resumes AND OSD appears.
- [ ] Player view during a scrub → OK still commits the scrub (not toggles pause).
- [ ] Home view → press BACK → app exits cleanly, no black screen / stuck state.
- [ ] Home view footer shows "RETURN exit app".
- [ ] Non-home views → BACK still returns to the parent view as before (regression).