### PR TITLE
chore: bump version to 1.3.0

### DIFF
--- a/tizen-web-vlc/config.xml
+++ b/tizen-web-vlc/config.xml
@@ -2,7 +2,7 @@
 <widget xmlns:tizen="http://tizen.org/ns/widgets"
         xmlns="http://www.w3.org/ns/widgets"
         id="http://madebypatrick.com/vlctv"
-        version="1.2.1"
+        version="1.3.0"
         viewmodes="maximized">
     <tizen:application id="madebypatk.vlcweb"
                        package="madebypatk"


### PR DESCRIPTION
Minor bump — 1.2.1 → 1.3.0.

Rolls up:
- #58 Move Recently Played to leftmost home tile (issue #56)
- #59 OK toggles play/pause + BACK exits app from home (issue #57)

Merging this triggers the auto-release workflow which will cut `v1.3.0-<date>` with the fresh .wgt.