### PR TITLE
fix(transcode-server): bump build toolchain to Go 1.25

### DIFF
--- a/.github/workflows/transcode-server-native.yml
+++ b/.github/workflows/transcode-server-native.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25'
           cache-dependency-path: vlc-transcode-server/go.sum
 
       - name: Cross-compile

--- a/vlc-transcode-server/Dockerfile
+++ b/vlc-transcode-server/Dockerfile
@@ -2,7 +2,7 @@
 # Pure-Go (go-smb2 needs no cgo), so we cross-compile a fully static binary for
 # the target arch on the native build arch — no QEMU emulation for the Go step,
 # which keeps multi-arch builds fast.
-FROM --platform=$BUILDPLATFORM golang:1.23-bookworm AS build
+FROM --platform=$BUILDPLATFORM golang:1.25-bookworm AS build
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /src


### PR DESCRIPTION
## Why

Dependabot commit e38629e (`Bump golang.org/x/crypto in /vlc-transcode-server`) pushed `go.mod`'s minimum to `1.25.0`, but the container image and native-binary workflow stayed pinned to 1.23. Every transcode-server build since has failed at the very first Docker step with:

```
go: go.mod requires go >= 1.25.0 (running go 1.23.12; GOTOOLCHAIN=local)
```

## What

- `vlc-transcode-server/Dockerfile`: `golang:1.23-bookworm` → `golang:1.25-bookworm`
- `.github/workflows/transcode-server-native.yml`: setup-go `go-version: '1.23'` → `'1.25'`

Now matches go.mod. No code changes; runtime image is unchanged (final stage is the same debian:bookworm-slim + ffmpeg + our binary).