### PR TITLE
Surround passthrough for 5.1 audio, USB files through the transcode server, and codeless pairing

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,42 @@ video untouched and only re-encode audio — quick even on a Raspberry Pi:
 ffmpeg -i input.mkv -c:v copy -c:a ac3 -b:a 640k output.mkv
 ```
 
+## 5.1 surround reaches the soundbar as stereo
+
+A 5.1 FLAC, AAC or PCM track plays fine and still comes out of the soundbar in
+stereo. That's the HDMI link, not the app. ARC and optical carry either LPCM or
+an IEC 61937-framed bitstream, and only Dolby Digital and Dolby Digital Plus
+have that framing — everything else the TV decodes itself, and plain ARC can
+only carry two channels of the resulting LPCM. FLAC has no bitstream form at
+all, on any device: an external player that "sends FLAC 5.1 to the soundbar" is
+decoding it and sending multichannel LPCM over a link that can carry it.
+
+AVPlay gives an app no channel-layout or passthrough control, so no version of
+VLC TV can fix this on the TV. The two things that do work:
+
+- **Let the [transcode server](vlc-transcode-server/) re-encode it.** Point the
+  TV at it with **Settings → Transcode server → Find server on my network** — it
+  sweeps your LAN, pairs, and sorts the share settings out between the two ends
+  by itself. No pairing code, no internet. Then, in the same menu, set
+  **Surround sound** to Dolby Digital Plus 5.1: multichannel tracks get
+  re-encoded into something the TV passes straight through, keeping all six
+  channels. **Play USB files through the server** does the same for files on a
+  USB stick.
+- **Re-encode the file once yourself**, if you'd rather not run anything:
+
+  ```bash
+  ffmpeg -i input.mkv -c:v copy -c:a eac3 -b:a 768k -ac 6 output.mkv
+  ```
+
+Either way it's a lossy re-encode — you keep the channels, not the
+bit-exactness. And set the TV's **Sound → Expert Settings → Digital Output
+Audio Format** to *Pass-through* / Auto, or it will decode the Dolby stream and
+downmix it again on the way out.
+
+In the audio-track picker, a track that will be flattened this way is labelled
+**"TV downmixes to stereo"**, so you can tell it apart from one the TV can't
+decode at all.
+
 ## Cast a link from your phone, tablet or laptop
 
 Typing URLs on a TV remote is painful, so VLC TV lets you paste a stream URL

--- a/tizen-web-vlc/config.xml
+++ b/tizen-web-vlc/config.xml
@@ -2,7 +2,7 @@
 <widget xmlns:tizen="http://tizen.org/ns/widgets"
         xmlns="http://www.w3.org/ns/widgets"
         id="http://madebypatrick.com/vlctv"
-        version="1.3.0"
+        version="1.4.0"
         viewmodes="maximized">
     <tizen:application id="madebypatk.vlcweb"
                        package="madebypatk"

--- a/tizen-web-vlc/index.html
+++ b/tizen-web-vlc/index.html
@@ -280,7 +280,14 @@
         </button>
         <div class="settings-group is-collapsed" id="grp-srv">
             <div class="settings-row"><div class="settings-label">Status</div><div class="settings-value" id="srv-status-val">Not paired</div></div>
-            <button id="srv-pair" class="settings-row"><span class="settings-label">Pair transcode server</span></button>
+            <button id="srv-find" class="settings-row"><span class="settings-label">Find server on my network</span></button>
+            <label class="settings-row settings-row-input"><span class="settings-label">Server address</span><input id="srv-addr" type="text" placeholder="192.168.1.20"></label>
+            <button id="srv-connect" class="settings-row"><span class="settings-label">Connect to this address</span></button>
+            <button id="srv-surround" class="settings-row"><div class="settings-label">Surround sound</div><div class="settings-value" id="srv-surround-val">—</div></button>
+            <button id="srv-local" class="settings-row"><div class="settings-label">Play USB files through the server</div><div class="settings-value" id="srv-local-val">Off</div></button>
+            <button id="srv-adopt" class="settings-row"><span class="settings-label">Get share settings from the server</span></button>
+            <button id="srv-push" class="settings-row"><span class="settings-label">Send my share settings to the server</span></button>
+            <button id="srv-pair" class="settings-row"><span class="settings-label">Pair with a code (needs internet)</span></button>
             <button id="srv-unpair" class="settings-row"><span class="settings-label">Remove transcode server</span></button>
         </div>
 

--- a/tizen-web-vlc/js/app.js
+++ b/tizen-web-vlc/js/app.js
@@ -637,10 +637,27 @@
         // is in an idle state before open() and would error with INVALID_STATE.
         // The proper setDisplayRect happens after prepareAsync succeeds.
         setTimeout(function () {
-            Player.open(uri, {
-                title:     title,
-                subtitles: opts.subtitles || [],
-                file:      opts.file || null
+            // A USB / internal file may be routed through the paired transcode
+            // server (for surround, or a codec the TV can't decode).  That
+            // changes which URL AVPlay opens, not the identity of what's
+            // playing — `uri` stays the key for recents, resume, watched and
+            // subtitle lookup, and the resolver hands back `uri` unchanged
+            // whenever routing isn't on or isn't available.
+            var resolve = (typeof TranscodeServer !== 'undefined' && TranscodeServer.resolvePlaybackUri)
+                ? TranscodeServer.resolvePlaybackUri
+                : function (u, done) { done(u); };
+            resolve(uri, function (openUrl) {
+                // Arming the relay is async; the user may have backed out or
+                // started something else in the meantime.
+                if (state.playingUri !== uri) return;
+                if (openUrl !== uri && typeof Debug !== 'undefined')
+                    Debug.player('routing through transcode server → ' + openUrl);
+                Player.open(openUrl, {
+                    title:     title,
+                    subtitles: opts.subtitles || [],
+                    file:      opts.file || null,
+                    sourceUri: uri
+                });
             });
         }, 50);
 
@@ -1683,7 +1700,12 @@
 
     // Public hooks used by js/smb.js to hand SMB playback back to the app so it
     // reuses next/prev, auto-play, recent & watched tracking.
-    window.VlcApp = { play: playFromList, home: backToHome, openSettings: openSettings };
+    window.VlcApp = {
+        play: playFromList, home: backToHome, openSettings: openSettings,
+        // server.js uses this to let the user choose when a LAN scan turns up
+        // more than one transcode server.
+        openPicker: openPicker
+    };
 
     if (document.readyState === 'loading')
         document.addEventListener('DOMContentLoaded', init);

--- a/tizen-web-vlc/js/player.js
+++ b/tizen-web-vlc/js/player.js
@@ -901,17 +901,22 @@ var Player = (function () {
             var po2 = document.getElementById('player-object');
             if (po2) po2.style.display = 'block';
 
+            // In parallel with avOpen: scan the file for embedded text
+            // subtitle tracks (MP4 / MKV / WebM) and route them through the
+            // working external-subtitle pipeline.  No-op for unsupported
+            // containers.  Keyed off opts.sourceUri rather than url so it
+            // still fires when a local file is being *played* through the
+            // transcode server — then `url` is an HLS manifest with no
+            // container to sniff, while the bytes still come from the Tizen
+            // File handle in opts.file.
+            var subsSourceUri = opts.sourceUri || url;
+            if (isLocalUrl(subsSourceUri)) extractAndAppendEmbeddedSubs(subsSourceUri, opts.file);
+
             // For local files routed to AVPlay (currently: .mkv), supply a
             // fallback so we degrade gracefully to HTML5 if AVPlay can't
             // open the path or never actually decodes. Network URLs get
             // no fallback — they surface errors normally.
             if (isLocalUrl(url)) {
-                // In parallel with avOpen: scan the file for embedded text
-                // subtitle tracks (MP4 / MKV / WebM) and route them through
-                // the working external-subtitle pipeline.  No-op for
-                // unsupported containers.
-                extractAndAppendEmbeddedSubs(url, opts.file);
-
                 avOpen(url, function (reason) {
                     // For MKV there's no point falling back to the HTML5
                     // <video> element — Tizen's chromium can't demux Matroska,
@@ -1070,6 +1075,20 @@ var Player = (function () {
         return /\b(dts|dca|truehd|mlp)/i.test(String(codec || ''));
     }
 
+    /* Audio the TV can decode but can't hand to a soundbar untouched.
+     *
+     * HDMI-ARC / optical carry either LPCM or an IEC 61937-framed bitstream,
+     * and only Dolby Digital / DD+ have that framing here.  Anything else —
+     * FLAC, AAC, PCM, Vorbis, Opus — the TV decodes itself, and what leaves the
+     * set is LPCM, which plain ARC only carries as 2.0.  So a 5.1 FLAC track
+     * plays fine and still arrives at the soundbar as stereo (issue #63).
+     * Nothing on the TV side can change that; the fix is to re-encode to Dolby
+     * upstream, which the transcode server's surround setting does. */
+    function isDownmixedAudio(codec, channels) {
+        if (!(channels > 2)) return false;
+        return !/\b(ac-?3|eac-?3|e-ac-3|ddp?|dolby)/i.test(String(codec || ''));
+    }
+
     /* AVPlay's extra_info field is a JSON string with fields like
      *   { "language":"eng", "channels":2, "fourCC":"AAC", ... }
      * for audio, and similar for subtitles.  Older firmwares hand back
@@ -1084,15 +1103,16 @@ var Player = (function () {
         if (!obj) {
             // Not JSON — use as-is, and look for a 3-letter ISO code in it
             var m = s.match(/\b([a-z]{2,3})\b/i);
-            return { label: s, lang: m ? m[1].toLowerCase() : '', codec: s };
+            return { label: s, lang: m ? m[1].toLowerCase() : '', codec: s, channels: 0 };
         }
         var lang  = (obj.language || obj.lang || obj.track_lang || '').toString().toLowerCase();
         var codec = (obj.fourCC || obj.codec || '').toString();
         var parts = [];
         if (lang) parts.push(lang.toUpperCase());
         if (codec) parts.push(codec);
-        if (obj.channels) parts.push(obj.channels + 'ch');
-        return { label: parts.join(' · ') || s, lang: lang, codec: codec };
+        var channels = parseInt(obj.channels, 10) || 0;
+        if (channels) parts.push(channels + 'ch');
+        return { label: parts.join(' · ') || s, lang: lang, codec: codec, channels: channels };
     }
 
     // AVPlay sometimes exposes better language tags than the MP4 metadata
@@ -1195,15 +1215,25 @@ var Player = (function () {
                     if (t.type === 'VIDEO') continue;
                     if (t.type === 'AUDIO') {
                         var unsupported = isUndecodableAudioCodec(parsed.codec);
+                        // Not silent, just flattened: multichannel audio in a
+                        // format the TV can't bitstream reaches the soundbar as
+                        // stereo however many channels the file has.  Say so in
+                        // the label rather than leaving the user to wonder.
+                        var downmixed = !unsupported &&
+                                        isDownmixedAudio(parsed.codec, parsed.channels);
+                        var note = unsupported ? ' — not supported by TV'
+                                 : downmixed   ? ' — TV downmixes to stereo'
+                                 : '';
                         out.audio.push({
                             index:  t.index,
                             // Flag codecs the TV can't decode right in the
                             // label so the user knows why a track is silent.
-                            name:   (parsed.label || ('Audio ' + t.index)) +
-                                    (unsupported ? ' — not supported by TV' : ''),
+                            name:   (parsed.label || ('Audio ' + t.index)) + note,
                             lang:   parsed.lang || '',
                             codec:  parsed.codec || '',
+                            channels: parsed.channels || 0,
                             unsupported: unsupported,
+                            downmixed: downmixed,
                             type:   'AVPLAY',
                             active: (t.index === activeAudioIdx)
                         });

--- a/tizen-web-vlc/js/server.js
+++ b/tizen-web-vlc/js/server.js
@@ -20,6 +20,8 @@ var TranscodeServer = (function () {
 
     var STORE_KEY = 'vlctv_server_v1';
     var NTFY_BASE = 'https://ntfy.sh';
+    var SVC_BASE  = 'http://127.0.0.1:8127';   // the smbproxy background service
+    var RELAY_KEY = 'vlctv_relay_key_v1';      // random secret guarding the relay
 
     function log(m) { if (typeof Debug !== 'undefined' && Debug.net) Debug.net('[server] ' + m); }
 
@@ -44,11 +46,361 @@ var TranscodeServer = (function () {
         return u;
     }
 
+    /* ── local (USB / internal storage) relay ───────────────────────────────
+     *
+     * A USB drive is plugged into the TV, so the transcode box can't reach it
+     * the way it reaches the SMB share — which is why USB files never got the
+     * surround / unsupported-codec handling that share files get.  The fix is
+     * to point the box back at us: the background service opens a small
+     * read-only HTTP listener on the LAN, and we hand the box a /play?src=…
+     * URL naming it.  The box fetches, transcodes, and streams HLS back.
+     *
+     * Two switches have to be on — this one, and "Accept USB / internal files
+     * from the TV" on the server's setup page — because each side is opening
+     * something it otherwise wouldn't.
+     * ------------------------------------------------------------------- */
+    var relay = null;        // { url } once the service is listening
+    var relayPending = null; // callbacks waiting on an in-flight arm
+
+    function relayEnabled() {
+        return typeof Settings !== 'undefined' && !!Settings.get('localRelay');
+    }
+
+    /* One long random secret per TV, persisted so a restart doesn't invalidate
+     * a relay the box is mid-stream on. */
+    function relaySecret() {
+        var k = '';
+        try { k = localStorage.getItem(RELAY_KEY) || ''; } catch (e) {}
+        if (k) return k;
+        var bytes = new Uint8Array(16);
+        if (window.crypto && window.crypto.getRandomValues) window.crypto.getRandomValues(bytes);
+        else for (var i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 256);
+        for (var j = 0; j < bytes.length; j++) k += ('0' + bytes[j].toString(16)).slice(-2);
+        try { localStorage.setItem(RELAY_KEY, k); } catch (e) {}
+        return k;
+    }
+
+    function xhrPost(url, body, cb) {
+        var done = false;
+        function finish(err, res) { if (done) return; done = true; cb(err, res); }
+        try {
+            var x = new XMLHttpRequest();
+            x.open('POST', url, true);
+            x.timeout = 8000;
+            x.setRequestHeader('Content-Type', 'application/json');
+            x.onreadystatechange = function () {
+                if (x.readyState !== 4) return;
+                var parsed = null;
+                try { parsed = JSON.parse(x.responseText || 'null'); } catch (e) {}
+                if (x.status >= 200 && x.status < 300) finish(null, parsed);
+                else finish(new Error((parsed && parsed.error) || ('HTTP ' + x.status)));
+            };
+            x.ontimeout = function () { finish(new Error('timeout')); };
+            x.onerror = function () { finish(new Error('network')); };
+            x.send(JSON.stringify(body || {}));
+        } catch (e) { finish(e); }
+    }
+
+    /* Start (or re-key) the service's LAN listener. cb(relay|null) — null means
+     * "play this file the normal way", never an error the user has to act on:
+     * a relay that won't come up should cost surround, not playback. */
+    function armRelay(cb) {
+        if (relay) return cb(relay);
+        if (!relayEnabled() || !isPaired()) return cb(null);
+        if (typeof SMB === 'undefined' || !SMB.ensureService) return cb(null);
+        if (typeof Browser === 'undefined' || !Browser.listRoots) return cb(null);
+
+        if (relayPending) { relayPending.push(cb); return; }
+        relayPending = [cb];
+        function settle(r) {
+            relay = r;
+            var waiting = relayPending || [];
+            relayPending = null;
+            for (var i = 0; i < waiting.length; i++) waiting[i](r);
+        }
+
+        // Both ends have to be switched on. Checking the server first means a
+        // user who only flipped the TV switch gets told so, instead of the box
+        // rejecting every /play?src= with a 400 that surfaces as a dead player.
+        serverAcceptsLocal(function (accepts) {
+            if (!accepts) {
+                log('relay: server has "accept USB files" turned off');
+                return settle(null);
+            }
+            SMB.ensureService(function (err) {
+                if (err) { log('relay: service unavailable — ' + err.message); return settle(null); }
+                // The roots come from tizen.filesystem itself, so the service
+                // ends up allowing exactly the drives the browser can see and
+                // nothing else — no guessing at Tizen mount points.
+                Browser.listRoots(function (e2, roots) {
+                    if (e2 || !roots || !roots.length) { log('relay: no roots to share'); return settle(null); }
+                    var paths = [];
+                    for (var i = 0; i < roots.length; i++)
+                        if (roots[i].fullPath) paths.push(roots[i].fullPath);
+                    xhrPost(SVC_BASE + '/local/enable', { key: relaySecret(), roots: paths }, function (e3, res) {
+                        if (e3 || !res || !res.ok || !res.url) {
+                            log('relay: enable failed — ' + (e3 ? e3.message : 'no LAN address'));
+                            return settle(null);
+                        }
+                        log('relay listening on ' + res.url + ' for ' + paths.length + ' root(s)');
+                        settle({ url: res.url });
+                    });
+                });
+            });
+        });
+    }
+
+    /* Ask the paired box whether it will accept files from us. */
+    function serverAcceptsLocal(cb) {
+        var s = get();
+        if (!s || !s.url) return cb(false);
+        xhrGet(s.url.replace(/\/+$/, '') + '/api/status', function (err, text) {
+            if (err) return cb(false);
+            var st = null;
+            try { st = JSON.parse(text || 'null'); } catch (e) {}
+            cb(!!(st && st.localRelay));
+        });
+    }
+
+    function disarmRelay() {
+        relay = null;
+        xhrPost(SVC_BASE + '/local/disable', {}, function () {});
+    }
+
+    /* Wrap a TV-local path in a /play?src=… URL for the box.
+     *
+     * tizen's File.toURI() percent-encodes, so decode once to recover the real
+     * filesystem path before re-encoding it as a query value — otherwise a file
+     * with a space in its name arrives at the service still encoded and
+     * statSync misses it. */
+    function localPlayUrl(fileUri) {
+        var s = get();
+        if (!s || !s.url || !relay) return null;
+        var path = String(fileUri || '').replace(/^file:\/\//, '');
+        try { path = decodeURIComponent(path); } catch (e) {}
+        if (!path) return null;
+        var srcUrl = relay.url + '/local/stream?path=' + encodeURIComponent(path) +
+                     '&key=' + encodeURIComponent(relaySecret());
+        var u = s.url.replace(/\/+$/, '') + '/play?src=' + encodeURIComponent(srcUrl);
+        if (s.token) u += '&token=' + encodeURIComponent(s.token);
+        return u;
+    }
+
+    /* The one entry point app.js needs: given the URI we would have played,
+     * call back with the URI we should actually open.  Falls back to the
+     * original on every failure path, so this can only change which bytes
+     * AVPlay reads — never whether it gets any. */
+    function resolvePlaybackUri(uri, cb) {
+        var isLocalFile = typeof uri === 'string' && uri.indexOf('file://') === 0;
+        if (!isLocalFile || !relayEnabled() || !isPaired()) return cb(uri);
+        armRelay(function (r) {
+            if (!r) return cb(uri);
+            cb(localPlayUrl(uri) || uri);
+        });
+    }
+
     /* Recognise our own play URLs so recent/watched tracking treats two routes
      * to the same file consistently. */
     function isPlayUrl(u) {
         var s = get();
         return !!(s && s.url && typeof u === 'string' && u.indexOf(s.url.replace(/\/+$/, '') + '/play') === 0);
+    }
+
+    /* ── discovery: find the box on the LAN instead of typing a code ────────
+     *
+     * The code dance (mint a code on the TV, read it off one screen, type it
+     * into another, relay through a public ntfy topic) is a lot of ceremony for
+     * two machines on the same switch — and it needs working internet to link
+     * two devices that don't.  The background service knows this TV's address
+     * and netmask, so it can just sweep the subnet and ask whoever answers
+     * whether they're a transcode server.
+     *
+     * The code path below is kept as a fallback for networks where the TV can't
+     * reach the box directly (client isolation, VLANs, a subnet too wide to
+     * sweep).
+     * ------------------------------------------------------------------- */
+    var DEFAULT_PORT = 8200;
+
+    /* "192.168.1.20", "192.168.1.20:8201", "http://box.lan:8200/" → a base URL. */
+    function normalizeServerUrl(raw) {
+        var t = String(raw == null ? '' : raw).trim();
+        if (!t) return '';
+        t = t.replace(/\/+$/, '');
+        if (!/^https?:\/\//i.test(t)) t = 'http://' + t;
+        // Add the default port only when the user didn't give one. The host may
+        // be a bare IPv6 literal in brackets, so match the port at the end.
+        if (!/:\d+$/.test(t)) t += ':' + DEFAULT_PORT;
+        return t;
+    }
+
+    function getJson(url, cb, timeoutMs) {
+        xhrGet(url, function (err, text) {
+            if (err) return cb(err);
+            var j = null;
+            try { j = JSON.parse(text || 'null'); } catch (e) {}
+            if (!j) return cb(new Error('unexpected reply'));
+            cb(null, j);
+        }, timeoutMs);
+    }
+
+    /* Sweep the LAN via the background service. cb(err, servers[]). */
+    function findServers(cb) {
+        if (typeof SMB === 'undefined' || !SMB.ensureService)
+            return cb(new Error('the background service is unavailable on this TV'));
+        SMB.ensureService(function (err) {
+            if (err) return cb(err);
+            // A /24 sweep is ~250 TCP connects at 500 ms worst case, batched 48
+            // at a time — a few seconds; a /22 is four times that. Well past the
+            // default request timeout, so ask for a much longer one.
+            getJson(SVC_BASE + '/discover', function (e2, res) {
+                if (e2) return cb(e2);
+                if (!res.ok) return cb(new Error(res.error || 'scan failed'));
+                cb(null, res.servers || []);
+            }, 45000);
+        });
+    }
+
+    /* Confirm a URL really is a transcode server, then store the pairing. */
+    function connectTo(url, cb) {
+        var base = normalizeServerUrl(url);
+        if (!base) return cb(new Error('enter the server address first'));
+        getJson(base + '/api/hello', function (err, hello) {
+            // Distinguish "nothing there" from "something there, but not us" —
+            // that's the difference between a typo in the address and a typo in
+            // the port, and the user can only fix the one they're told about.
+            if (err) {
+                var answered = /^HTTP /.test(err.message) || err.message === 'unexpected reply';
+                return cb(new Error(answered ? 'something else is running at ' + base
+                                             : 'nothing answered at ' + base));
+            }
+            if (!hello || hello.app !== 'vlc-tv-transcode')
+                return cb(new Error('something else is running at ' + base));
+            // The token lives on /api/status, not /api/hello — hello is the
+            // unauthenticated probe and deliberately carries no secrets.
+            getJson(base + '/api/status', function (e2, st) {
+                if (e2) return cb(e2);
+                set({
+                    url: base, token: (st && st.token) || '',
+                    name: hello.name || 'Transcode server', api: hello.api || 1
+                });
+                log('connected to ' + (hello.name || base) + ' @ ' + base);
+                cb(null, {
+                    url: base, name: hello.name || 'Transcode server',
+                    canAdopt: !!hello.canAdopt, configured: !!hello.configured
+                });
+            });
+        });
+    }
+
+    /* ── the box's own settings, driven from the TV ─────────────────────────
+     *
+     * Surround and the USB-relay permission live on the server but are decided
+     * here: you're sitting in front of the TV when you notice the soundbar is
+     * doing stereo, not in front of a laptop. The server applies only the keys
+     * it's sent, so these patches can't disturb the share config.
+     * ------------------------------------------------------------------- */
+    var serverCfg = null;   // last /api/config we read; null = unknown
+
+    /* Servers older than the discovery API replace their whole SMB block from
+     * whatever body a config POST carries — so sending one a bare
+     * {"surround":"eac3"} would wipe the user's share settings. They also have
+     * no /api/hello, which makes them easy to spot. Check before driving
+     * anything, and remember the answer on the pairing record so it costs one
+     * request per pairing rather than one per press. */
+    function serverApiVersion(cb) {
+        var s = get();
+        if (!s || !s.url) return cb(0);
+        if (s.api) return cb(s.api);
+        getJson(s.url + '/api/hello', function (err, hello) {
+            var v = (!err && hello && hello.app === 'vlc-tv-transcode') ? (hello.api || 1) : 0;
+            if (v) { s.api = v; set(s); }
+            cb(v);
+        });
+    }
+
+    function requireModernServer(cb) {
+        serverApiVersion(function (v) {
+            if (!v) return cb(new Error('this transcode server is too old for that — update it and pair again'));
+            cb(null);
+        });
+    }
+
+    function withToken(path) {
+        var s = get();
+        if (!s || !s.url) return null;
+        var u = s.url + path;
+        if (s.token) u += (path.indexOf('?') >= 0 ? '&' : '?') + 'token=' + encodeURIComponent(s.token);
+        return u;
+    }
+
+    function loadServerConfig(cb) {
+        var u = withToken('/api/config');
+        if (!u) return cb(new Error('not paired'));
+        requireModernServer(function (old) {
+            if (old) return cb(old);
+            getJson(u, function (err, cfg) {
+                if (err) return cb(err);
+                serverCfg = cfg;
+                cb(null, cfg);
+            });
+        });
+    }
+
+    function patchServerConfig(patch, cb) {
+        var u = withToken('/api/config');
+        if (!u) return cb(new Error('not paired'));
+        requireModernServer(function (old) {
+            if (old) return cb(old);
+            xhrPost(u, patch, function (err, res) {
+                if (err) return cb(err);
+                if (res && res.ok === false) return cb(new Error(res.error || 'the server declined'));
+                // Keep the local copy in step rather than re-fetching one field.
+                if (serverCfg) for (var k in patch) serverCfg[k] = patch[k];
+                cb(null);
+            });
+        });
+    }
+
+    /* Send this TV's share settings to a box that hasn't got any. The mirror of
+     * adoptShare: whoever already knows the share tells the other one, so it's
+     * never typed twice. Deliberately never automatic when the server already
+     * has a share configured — clobbering a working server config from a TV
+     * that happens to hold something older would be a nasty surprise. */
+    function pushShare(cb) {
+        var c = (typeof SMB !== 'undefined' && SMB.getCreds) ? SMB.getCreds() : null;
+        if (!c || !c.host || !c.share) return cb(new Error('no share configured on this TV yet'));
+        patchServerConfig({
+            host: c.host, port: c.port || 445, share: c.share,
+            user: c.user || '', pass: c.pass || '',
+            domain: c.domain || '', anonymous: !!c.anonymous
+        }, function (err) {
+            if (err) return cb(err);
+            cb(null, c);
+        });
+    }
+
+    /* Copy the share settings off the box, so they're typed once — there, with
+     * a real keyboard — instead of six fields at a time on a remote.
+     * cb(err, smb). A refusal here is never fatal: the user can still fill the
+     * share in by hand. */
+    function adoptShare(cb) {
+        var s = get();
+        if (!s || !s.url) return cb(new Error('not paired'));
+        var u = s.url + '/api/adopt' + (s.token ? '?token=' + encodeURIComponent(s.token) : '');
+        getJson(u, function (err, res) {
+            if (err) return cb(err);
+            if (!res.ok) return cb(new Error(res.error || 'the server declined'));
+            var smb = res.smb || {};
+            if (!smb.host || !smb.share) return cb(new Error('the server has no share configured'));
+            if (typeof SMB !== 'undefined' && SMB.applyCreds) {
+                SMB.applyCreds({
+                    host: smb.host, port: smb.port || 445, share: smb.share,
+                    user: smb.user || '', pass: smb.pass || '',
+                    domain: smb.domain || '', anonymous: !!smb.anonymous
+                });
+            }
+            cb(null, smb);
+        });
     }
 
     /* ── pairing: pull the server's announcement off the -srv topic ─────── */
@@ -57,13 +409,13 @@ var TranscodeServer = (function () {
         return 'vlctv-' + code + '-srv';
     }
 
-    function xhrGet(url, cb) {
+    function xhrGet(url, cb, timeoutMs) {
         var done = false;
         function finish(err, text) { if (done) return; done = true; cb(err, text); }
         try {
             var x = new XMLHttpRequest();
             x.open('GET', url, true);
-            x.timeout = 10000;
+            x.timeout = timeoutMs || 10000;
             x.onreadystatechange = function () {
                 if (x.readyState !== 4) return;
                 if (x.status >= 200 && x.status < 300) finish(null, x.responseText);
@@ -108,6 +460,8 @@ var TranscodeServer = (function () {
             if (err) return cb(err);
             var ann = parseLatestAnnounce(text);
             if (!ann) return cb(new Error('no server found — open the tool and press Pair there first'));
+            // No api field here: the ntfy announcement predates it, so the
+            // first thing that needs to drive this server will probe for it.
             set({ url: ann.url, token: ann.token || '', name: ann.name || 'Transcode server' });
             log('paired with ' + ann.name + ' @ ' + ann.url);
             cb(null, ann);
@@ -122,20 +476,208 @@ var TranscodeServer = (function () {
         el.textContent = s && s.url ? (s.name || 'Paired') + ' · ' + s.url : 'Not paired';
     }
 
+    function paintRelay() {
+        var el = document.getElementById('srv-local-val');
+        if (el) el.textContent = relayEnabled() ? 'On' : 'Off';
+    }
+
+    var SURROUND_OPTIONS = [
+        { code: 'off',  name: 'Off — only fix audio the TV can\u2019t decode' },
+        { code: 'eac3', name: 'Dolby Digital Plus 5.1 (recommended)' },
+        { code: 'ac3',  name: 'Dolby Digital 5.1 (older receivers)' }
+    ];
+    function surroundName(code) {
+        for (var i = 0; i < SURROUND_OPTIONS.length; i++)
+            if (SURROUND_OPTIONS[i].code === code) return SURROUND_OPTIONS[i].name;
+        return 'Off';
+    }
+    function paintSurround() {
+        var el = document.getElementById('srv-surround-val');
+        if (!el) return;
+        if (!isPaired())  { el.textContent = '—'; return; }
+        if (!serverCfg)   { el.textContent = '—'; return; }
+        el.textContent = surroundName(serverCfg.surround || 'off').split(' —')[0];
+    }
+
+    /* Finish a successful connect: get the share settings agreed between the two
+     * ends, then report. Whichever side already knows the share tells the other,
+     * so it's typed once — and neither direction failing is fatal, because the
+     * pairing that matters already succeeded.
+     *
+     *   server has a share  → copy it down (adopt)
+     *   server has none, TV does → send it up (push)
+     *   neither             → say so; the user fills it in somewhere
+     */
+    function afterConnect(srv) {
+        paintStatus();
+        var addr = document.getElementById('srv-addr');
+        if (addr) addr.value = srv.url.replace(/^https?:\/\//, '');
+        function toast(m) { if (typeof UI !== 'undefined' && UI.toast) UI.toast(m); }
+
+        loadServerConfig(function () { paintSurround(); });
+
+        if (srv.configured && srv.canAdopt) {
+            adoptShare(function (err, smb) {
+                if (err) {
+                    // Usually the ten-minute window on the box has closed. Its
+                    // error says what to do about it, so pass it through rather
+                    // than flattening it to "didn't work".
+                    log('adopt skipped: ' + err.message);
+                    toast('Paired with ' + srv.name + ', but the share settings didn\u2019t come across: ' + err.message);
+                    return;
+                }
+                toast('Paired with ' + srv.name + ' — share settings copied (' +
+                      smb.host + '/' + smb.share + ')');
+            });
+            return;
+        }
+        if (!srv.configured) {
+            pushShare(function (err, c) {
+                if (err) {
+                    log('push skipped: ' + err.message);
+                    toast('Paired with ' + srv.name + ' — now set its share up');
+                    return;
+                }
+                toast('Paired with ' + srv.name + ' — sent it your share (' +
+                      c.host + '/' + c.share + ')');
+            });
+            return;
+        }
+        toast('Paired with ' + srv.name);
+    }
+
+    function runDiscovery() {
+        function toast(m) { if (typeof UI !== 'undefined' && UI.toast) UI.toast(m); }
+        toast('Looking for a transcode server on your network…');
+        findServers(function (err, servers) {
+            if (err) { toast('Search failed: ' + err.message); return; }
+            if (!servers.length) {
+                toast('Nothing found. Check the server is running, or enter its address below.');
+                return;
+            }
+            if (servers.length === 1) {
+                connectTo(servers[0].url, function (e2, srv) {
+                    if (e2) { toast('Could not connect: ' + e2.message); return; }
+                    afterConnect(srv);
+                });
+                return;
+            }
+            // More than one on the LAN — let the user say which.
+            var opts = servers.map(function (sv) {
+                return { code: sv.url, name: sv.name + '  ·  ' + sv.host };
+            });
+            if (!window.VlcApp || !window.VlcApp.openPicker) {
+                toast('Found ' + servers.length + ' servers — enter the address below to pick one');
+                return;
+            }
+            window.VlcApp.openPicker('Choose a transcode server', opts, '', function (url) {
+                connectTo(url, function (e2, srv) {
+                    if (e2) { toast('Could not connect: ' + e2.message); return; }
+                    afterConnect(srv);
+                });
+            });
+        });
+    }
+
     function wireSettings() {
         var pairBtn = document.getElementById('srv-pair');
         var unpairBtn = document.getElementById('srv-unpair');
+        var localBtn = document.getElementById('srv-local');
+        var findBtn = document.getElementById('srv-find');
+        var connectBtn = document.getElementById('srv-connect');
+        var addrInput = document.getElementById('srv-addr');
+        var surroundBtn = document.getElementById('srv-surround');
+        var pushBtn = document.getElementById('srv-push');
+        var adoptBtn = document.getElementById('srv-adopt');
         paintStatus();
+        paintRelay();
+        paintSurround();
+
+        var cur = get();
+        if (addrInput && cur && cur.url) addrInput.value = cur.url.replace(/^https?:\/\//, '');
+        if (isPaired()) loadServerConfig(function () { paintSurround(); });
+
+        function toast(m) { if (typeof UI !== 'undefined' && UI.toast) UI.toast(m); }
+
+        if (surroundBtn) surroundBtn.addEventListener('click', function () {
+            if (!isPaired()) { toast('Pair a transcode server first'); return; }
+            if (!window.VlcApp || !window.VlcApp.openPicker) return;
+            var current = (serverCfg && serverCfg.surround) || 'off';
+            window.VlcApp.openPicker('Surround sound', SURROUND_OPTIONS, current, function (val) {
+                patchServerConfig({ surround: val }, function (err) {
+                    if (err) { toast('Could not change it: ' + err.message); return; }
+                    paintSurround();
+                    toast(val === 'off'
+                        ? 'Surround off — multichannel audio reaches the soundbar as stereo'
+                        : surroundName(val).split(' (')[0] + ' — start the next file to hear it');
+                });
+            });
+        });
+
+        if (adoptBtn) adoptBtn.addEventListener('click', function () {
+            if (!isPaired()) { toast('Pair a transcode server first'); return; }
+            adoptShare(function (err, smb) {
+                if (err) { toast(err.message); return; }
+                toast('Copied ' + smb.host + '/' + smb.share + ' from the transcode server');
+            });
+        });
+
+        if (pushBtn) pushBtn.addEventListener('click', function () {
+            if (!isPaired()) { toast('Pair a transcode server first'); return; }
+            pushShare(function (err, c) {
+                if (err) { toast('Could not send them: ' + err.message); return; }
+                toast('Sent ' + c.host + '/' + c.share + ' to the transcode server');
+            });
+        });
+
+        if (findBtn) findBtn.addEventListener('click', runDiscovery);
+
+        if (connectBtn) connectBtn.addEventListener('click', function () {
+            var toast = function (m) { if (typeof UI !== 'undefined' && UI.toast) UI.toast(m); };
+            var raw = addrInput ? addrInput.value : '';
+            if (!String(raw).trim()) { toast('Type the server\u2019s address first'); return; }
+            toast('Connecting…');
+            connectTo(raw, function (err, srv) {
+                if (err) { toast(err.message); return; }
+                afterConnect(srv);
+            });
+        });
+        if (localBtn) localBtn.addEventListener('click', function () {
+            var on = !relayEnabled();
+            Settings.set('localRelay', on);
+            paintRelay();
+            if (!on) {
+                disarmRelay();
+                // Withdraw the permission too, so the box goes back to reading
+                // only from the share rather than sitting there willing to
+                // accept files nobody is going to send.
+                if (isPaired()) patchServerConfig({ local_relay: false }, function () {});
+                toast('USB files will play directly again');
+                return;
+            }
+            if (!isPaired()) { toast('Pair a transcode server first'); return; }
+            // The box has to agree to accept files from us. Ask for that here
+            // rather than making the user go and find the switch on its page.
+            patchServerConfig({ local_relay: true }, function (err) {
+                if (err) { toast('The server refused: ' + err.message); return; }
+                armRelay(function (r) {
+                    toast(r ? 'USB files will play through the transcode server'
+                            : 'Could not open the relay on this TV — USB files will play directly');
+                });
+            });
+        });
         if (pairBtn) pairBtn.addEventListener('click', function () {
             if (typeof UI !== 'undefined' && UI.toast) UI.toast('Looking for your transcode server…');
-            pair(function (err) {
+            pair(function (err, ann) {
                 if (err) { if (UI && UI.toast) UI.toast('Pairing failed: ' + err.message); return; }
-                paintStatus();
-                if (UI && UI.toast) UI.toast('Transcode server paired');
+                // Same follow-up as the LAN flow: the announcement doesn't say
+                // whether the server will share its share settings, so just ask
+                // — adoptShare reports a refusal as a footnote, not a failure.
+                afterConnect({ url: get().url, name: (ann && ann.name) || 'Transcode server', canAdopt: true });
             });
         });
         if (unpairBtn) unpairBtn.addEventListener('click', function () {
-            clear(); paintStatus();
+            clear(); disarmRelay(); paintStatus();
             if (typeof UI !== 'undefined' && UI.toast) UI.toast('Transcode server removed');
         });
     }
@@ -147,6 +689,10 @@ var TranscodeServer = (function () {
 
     return {
         get: get, set: set, clear: clear, isPaired: isPaired,
-        playUrl: playUrl, isPlayUrl: isPlayUrl, pair: pair
+        playUrl: playUrl, isPlayUrl: isPlayUrl, pair: pair,
+        resolvePlaybackUri: resolvePlaybackUri,
+        findServers: findServers, connectTo: connectTo,
+        adoptShare: adoptShare, pushShare: pushShare,
+        loadServerConfig: loadServerConfig, patchServerConfig: patchServerConfig
     };
 })();

--- a/tizen-web-vlc/js/settings.js
+++ b/tizen-web-vlc/js/settings.js
@@ -16,7 +16,13 @@ var Settings = (function () {
         subtitleSize:     'medium',    // 'small' | 'medium' | 'large' | 'xlarge'
         subtitleFont:     'sans',      // 'sans' | 'serif' | 'mono'
         subtitlePosition: 'bottom',    // 'bottom' | 'middle' | 'top'
-        subtitleBg:       'none'       // 'none' | 'box'  (translucent box behind text)
+        subtitleBg:       'none',      // 'none' | 'box'  (translucent box behind text)
+        // The TV's pairing code (url-drop.js mints it once and persists it
+        // here).  It HAS to be listed: load() rebuilds the cache from this
+        // object, so a key that isn't here is silently dropped on the next
+        // launch — which regenerated the code on every app start and quietly
+        // unpaired every phone that had scanned the QR.
+        urlDropCode:      ''
     };
     var cache = null;
 

--- a/tizen-web-vlc/js/settings.js
+++ b/tizen-web-vlc/js/settings.js
@@ -12,6 +12,11 @@ var Settings = (function () {
         repeatMode:       'off',       // 'off' | 'one'
         autoPlay:         false,       // auto-play the next file in the folder when one finishes
         shuffle:          false,       // randomize playlist order (folder + recent) instead of alphabetical
+        // Route USB / internal-storage files through the paired transcode
+        // server instead of straight into AVPlay.  Off by default: it only
+        // helps when a transcode server is paired, and it costs the embedded
+        // AVPlay fallbacks that direct local playback gets.
+        localRelay:       false,
         // ── Subtitle appearance (applied to the painted overlay) ──────────
         subtitleSize:     'medium',    // 'small' | 'medium' | 'large' | 'xlarge'
         subtitleFont:     'sans',      // 'sans' | 'serif' | 'mono'

--- a/tizen-web-vlc/js/smb.js
+++ b/tizen-web-vlc/js/smb.js
@@ -289,24 +289,44 @@ var SMB = (function () {
     }
 
     /* Wire the Settings form (inputs + Save button) once the DOM is ready. */
-    function wireSettingsForm() {
-        var btn = document.getElementById('smb-save');
-        if (!btn) return;
-        var c = getCreds();
-        var ids = ['host', 'port', 'share', 'user', 'pass', 'domain'];
-        ids.forEach(function (k) {
+    var FORM_IDS = ['host', 'port', 'share', 'user', 'pass', 'domain'];
+
+    // Guest is a toggle button (not a checkbox): the D-pad's geometric nav
+    // can't reliably land on a small right-aligned checkbox, but a full-width
+    // row matches every other setting and gets focus cleanly.  Its state lives
+    // out here so applyCreds() can repaint it when the settings arrive from
+    // somewhere other than this form — e.g. copied off the transcode server.
+    var anonState = false;
+    function paintAnon() {
+        var anonVal = document.getElementById('smb-anon-val');
+        if (anonVal) anonVal.textContent = anonState ? 'On' : 'Off';
+    }
+
+    /* Push a credentials object into the settings form. */
+    function fillSettingsForm(c) {
+        c = c || {};
+        FORM_IDS.forEach(function (k) {
             var el = document.getElementById('smb-' + k);
             if (el && c[k] != null) el.value = c[k];
         });
-
-        // Guest is a toggle button (not a checkbox): the D-pad's geometric nav
-        // can't reliably land on a small right-aligned checkbox, but a
-        // full-width row matches every other setting and gets focus cleanly.
-        var anonBtn = document.getElementById('smb-anon');
-        var anonVal = document.getElementById('smb-anon-val');
-        var anonState = !!c.anonymous;
-        function paintAnon() { if (anonVal) anonVal.textContent = anonState ? 'On' : 'Off'; }
+        anonState = !!c.anonymous;
         paintAnon();
+    }
+
+    /* Store credentials that came from elsewhere and reflect them in the form,
+     * so the user can see what was filled in and correct it if needed. */
+    function applyCreds(c) {
+        setCreds(c);
+        fillSettingsForm(c);
+    }
+
+    function wireSettingsForm() {
+        var btn = document.getElementById('smb-save');
+        if (!btn) return;
+        var ids = FORM_IDS;
+        fillSettingsForm(getCreds());
+
+        var anonBtn = document.getElementById('smb-anon');
         if (anonBtn) anonBtn.addEventListener('click', function () { anonState = !anonState; paintAnon(); });
 
         btn.addEventListener('click', function () {
@@ -333,8 +353,14 @@ var SMB = (function () {
 
     return {
         openBrowser:     openBrowser,
+        // Exposed for server.js: the local-file relay lives in the same
+        // background service, so it needs the same launch-and-wait dance.
+        ensureService:   ensureService,
         getCreds:        getCreds,
         setCreds:        setCreds,
+        // Used by server.js when the share settings are copied off the
+        // transcode server instead of typed in on the remote.
+        applyCreds:      applyCreds,
         streamUrl:       streamUrl,
         dumpServiceLogs: dumpServiceLogs,
         isStreamUrl:     function (u) { return typeof u === 'string' && u.indexOf(BASE + '/smb/stream') === 0; }

--- a/tizen-web-vlc/service/service.js
+++ b/tizen-web-vlc/service/service.js
@@ -11,6 +11,11 @@
  *   GET  /smb/stream?path=/a/b.mkv    → byte stream, honours HTTP Range
  *   GET  /smb/ping                    → { ok:true } liveness check
  *
+ * It also hosts the optional *local relay* (see the block near the bottom):
+ * a second listener, on the LAN rather than loopback, that serves files off
+ * the TV's own USB drive to the transcode server — so USB files can get the
+ * same surround / codec treatment as files on the share.
+ *
  * The web app points AVPlay at  http://127.0.0.1:8127/smb/stream?path=...
  * AVPlay then demuxes / seeks exactly like any other HTTP source; seeking
  * arrives as a Range request which we map to an SMB2 READ at offset/length.
@@ -27,6 +32,8 @@
 var http   = require('http');
 var net    = require('net');
 var crypto = require('crypto');
+var fs     = require('fs');
+var os     = require('os');
 
 /* The TV's Node runtime predates Buffer.alloc / Buffer.from (added in Node
  * 4.5/5.10) — it only has the legacy `new Buffer()` constructor. Without this
@@ -881,6 +888,357 @@ function handleStream(req, res, query) {
     });
 }
 
+/* ── local relay: TV-local files, served to the transcode server ─────────────
+ *
+ * Files on a USB drive are physically at the TV, so the transcode box can't
+ * reach them the way it reaches the SMB share — which is why USB files never
+ * got the surround / unsupported-codec treatment.  This listener closes that
+ * gap by turning the relationship around: the TV serves, the box fetches.
+ *
+ * Deliberately a SECOND http.Server rather than another route on the loopback
+ * one.  The loopback server carries the SMB endpoints, and those hold the
+ * user's share credentials — none of that should become reachable from the LAN
+ * just because someone wants to play a USB file.  This one only knows how to
+ * read a file.
+ *
+ * Three things gate it, all of which must hold:
+ *   - the app armed it (POST /local/enable over loopback, which the LAN
+ *     listener does not route, so only the app on this TV can arm it);
+ *   - the request carries the random key the app minted;
+ *   - the path sits under one of the roots tizen.filesystem itself resolved.
+ * Disarmed, the socket isn't even open.
+ * ------------------------------------------------------------------------ */
+var LOCAL_PORT  = 8128;
+var localKey    = '';    // '' = disarmed
+var localRoots  = [];    // absolute path prefixes we may read from
+var localServer = null;
+
+/* Constant-time-ish compare so the key can't be probed a character at a time. */
+function localKeyOK(k) {
+    k = String(k || '');
+    if (!localKey || k.length !== localKey.length) return false;
+    var diff = 0;
+    for (var i = 0; i < localKey.length; i++) diff |= localKey.charCodeAt(i) ^ k.charCodeAt(i);
+    return diff === 0;
+}
+
+/* Turn the requested path into an absolute path we're allowed to read, or null.
+ * Accepts the file:// URIs the app already carries around as well as bare
+ * paths.  The query parser has already percent-decoded once, so we don't decode
+ * again here — a second pass would let a doubly-encoded path smuggle characters
+ * past this check.  Traversal is rejected outright rather than normalised away;
+ * there's no legitimate '..' in a path that came from tizen.filesystem. */
+function localResolve(p) {
+    var s = String(p || '');
+    s = s.replace(/^file:\/\//, '');
+    if (!s || s.charAt(0) !== '/' || s.indexOf('\0') >= 0) return null;
+    var parts = s.split('/');
+    for (var i = 0; i < parts.length; i++) if (parts[i] === '..') return null;
+    for (var j = 0; j < localRoots.length; j++) {
+        var r = localRoots[j];
+        if (s === r || s.indexOf(r + '/') === 0) return s;
+    }
+    return null;
+}
+
+/* The address to advertise to the transcode server. os.networkInterfaces() is
+ * the honest answer — asking the web layer for the TV's IP means guessing which
+ * of the several Tizen APIs this firmware actually implements, and the process
+ * that's doing the listening already knows. */
+function lanAddress() {
+    var ifs, best = '';
+    try { ifs = os.networkInterfaces() || {}; } catch (e) { return ''; }
+    for (var name in ifs) {
+        var list = ifs[name] || [];
+        for (var i = 0; i < list.length; i++) {
+            var a = list[i];
+            if (!a || a.internal) continue;
+            if (a.family !== 'IPv4' && a.family !== 4) continue;
+            if (!best) best = a.address;
+            if (/^(eth|en)/.test(name)) return a.address;   // wired wins over wlan
+        }
+    }
+    return best;
+}
+
+function localURL() {
+    var ip = lanAddress();
+    return ip ? 'http://' + ip + ':' + LOCAL_PORT : '';
+}
+
+/* GET/HEAD /local/stream?path=…&key=… — the only thing on the LAN listener. */
+function handleLocalStream(req, res, query) {
+    if (!localKeyOK(query.key)) { cors(res, 403, 'text/plain'); return res.end('forbidden'); }
+    var path = localResolve(query.path);
+    if (!path) { log('LOCAL_REJECT', query.path); cors(res, 403, 'text/plain'); return res.end('path not allowed'); }
+
+    var st;
+    try { st = fs.statSync(path); } catch (e) { cors(res, 404, 'text/plain'); return res.end('not found'); }
+    if (!st.isFile()) { cors(res, 404, 'text/plain'); return res.end('not a file'); }
+    var size = st.size;
+
+    var start = 0, end = size - 1, partial = false;
+    var range = req.headers.range;
+    if (range) {
+        var m = /bytes=(\d*)-(\d*)/.exec(range);
+        if (m) {
+            partial = true;
+            if (m[1] !== '') start = parseInt(m[1], 10);
+            if (m[2] !== '') end   = parseInt(m[2], 10);
+            if (m[1] === '' && m[2] !== '') { start = size - parseInt(m[2], 10); end = size - 1; }
+        }
+    }
+    if (start < 0) start = 0;
+    if (end >= size) end = size - 1;
+    if (start > end || start >= size) {
+        cors(res, 416, 'text/plain', { 'Content-Range': 'bytes */' + size });
+        return res.end();
+    }
+
+    var headers = {
+        'Accept-Ranges': 'bytes',
+        'Content-Length': String(end - start + 1),
+        'Content-Type': contentType(path)
+    };
+    if (partial) headers['Content-Range'] = 'bytes ' + start + '-' + end + '/' + size;
+    cors(res, partial ? 206 : 200, headers['Content-Type'], headers);
+    if (req.method === 'HEAD') return res.end();
+
+    // createReadStream handles backpressure and closes the fd on both ends.
+    var stream = fs.createReadStream(path, { start: start, end: end });
+    stream.on('error', function (e) { log('LOCAL_READ_ERR', e && e.message); try { res.end(); } catch (e2) {} });
+    req.on('close', function () { try { stream.destroy(); } catch (e) {} });
+    stream.pipe(res);
+}
+
+/* POST /local/enable { key, roots:[…] } — loopback only, by construction. */
+function handleLocalEnable(req, res) {
+    var raw = '';
+    req.on('data', function (c) { raw += c; });
+    req.on('end', function () {
+        var body;
+        try { body = JSON.parse(raw || '{}'); } catch (e) { return sendJson(res, 400, { ok: false, error: 'bad json' }); }
+        var key = String(body.key || '');
+        if (key.length < 16) return sendJson(res, 400, { ok: false, error: 'key too short' });
+
+        var roots = [];
+        for (var i = 0; i < (body.roots || []).length; i++) {
+            var r = String(body.roots[i] || '').replace(/^file:\/\//, '').replace(/\/+$/, '');
+            if (r.charAt(0) === '/' && r.split('/').indexOf('..') < 0) roots.push(r);
+        }
+        if (!roots.length) return sendJson(res, 400, { ok: false, error: 'no usable roots' });
+
+        localKey = key;
+        localRoots = roots;
+
+        // Re-arming while already listening just swaps the key and roots.
+        if (localServer) return sendJson(res, 200, { ok: true, url: localURL(), roots: roots });
+
+        try {
+            localServer = http.createServer(function (rq, rs) {
+                var u = require('url').parse(rq.url, true);
+                if (rq.method === 'OPTIONS') { cors(rs, 204, 'text/plain'); return rs.end(); }
+                if (u.pathname === '/local/stream' && (rq.method === 'GET' || rq.method === 'HEAD'))
+                    return handleLocalStream(rq, rs, u.query);
+                cors(rs, 404, 'text/plain'); rs.end('Not Found');
+            });
+            localServer.on('error', function (e) {
+                log('LOCAL_LISTEN_ERR', e && e.message);
+                localServer = null;
+            });
+            localServer.listen(LOCAL_PORT, '0.0.0.0', function () {
+                log('LOCAL_RELAY_LISTENING', '0.0.0.0:' + LOCAL_PORT + ' roots=' + roots.join(','));
+                sendJson(res, 200, { ok: true, url: localURL(), roots: roots });
+            });
+        } catch (e) {
+            log('LOCAL_LISTEN_THREW', e && e.message);
+            localServer = null;
+            sendJson(res, 500, { ok: false, error: 'could not open a LAN port: ' + (e && e.message) });
+        }
+    });
+}
+
+function handleLocalDisable(req, res) {
+    localKey = '';
+    localRoots = [];
+    if (localServer) { try { localServer.close(); } catch (e) {} localServer = null; }
+    log('LOCAL_RELAY_STOPPED');
+    sendJson(res, 200, { ok: true });
+}
+
+/* ── LAN discovery: find the transcode server without a pairing code ─────────
+ *
+ * Pairing used to mean reading a random code off one screen and typing it into
+ * another, with a round trip through a public ntfy topic to link two boxes
+ * sitting on the same switch.  The TV can just look instead: this service knows
+ * its own address and netmask, so it can sweep the subnet and ask whoever
+ * answers whether they're a transcode server.
+ *
+ * Two phases, because a full HTTP request per address is wasteful when almost
+ * every address is dead: first a plain TCP connect (a dead host costs one
+ * timeout, a live one answers or refuses immediately), then GET /api/hello only
+ * on the handful that opened.
+ * ------------------------------------------------------------------------- */
+var SCAN_PORT        = 8200;   // the transcode server's default
+var SCAN_BATCH       = 48;     // concurrent sockets; the TV's stack is not generous
+var SCAN_CONNECT_MS  = 500;    // per-address TCP timeout
+var SCAN_HTTP_MS     = 2500;   // per-candidate HTTP timeout
+var SCAN_MAX_HOSTS   = 1024;   // refuse to sweep something enormous
+
+/* Turn "192.168.1.37" + "255.255.255.0" into every host address on that subnet,
+ * minus the network, broadcast and our own address. Returns null when the mask
+ * is too wide to sweep politely — the caller then tells the user to type the
+ * address instead of hammering 65k hosts. */
+function subnetHosts(ip, mask) {
+    function toInt(a) {
+        var p = String(a || '').split('.');
+        if (p.length !== 4) return -1;
+        var n = 0;
+        for (var i = 0; i < 4; i++) {
+            var v = parseInt(p[i], 10);
+            if (!(v >= 0 && v <= 255)) return -1;
+            n = (n * 256) + v;
+        }
+        return n;
+    }
+    // Addresses are kept as plain numbers, not bit patterns: anything from
+    // 128.0.0.0 up exceeds 2^31, and JavaScript's bitwise operators would
+    // silently reinterpret it as a negative int32.  `>>> 0` puts the two
+    // genuinely bitwise steps back into unsigned space; the rest is arithmetic.
+    function toStr(n) {
+        return [Math.floor(n / 16777216) % 256, Math.floor(n / 65536) % 256,
+                Math.floor(n / 256) % 256, n % 256].join('.');
+    }
+    var ipN = toInt(ip), maskN = toInt(mask);
+    if (ipN < 0 || maskN < 0) return null;
+
+    var network = (ipN & maskN) >>> 0;
+    var size = ((~maskN) >>> 0) + 1;        // addresses in the subnet
+    if (size < 4 || size > SCAN_MAX_HOSTS) return null;
+
+    var out = [];
+    for (var i = 1; i < size - 1; i++) {    // skip network + broadcast
+        var addr = network + i;
+        if (addr !== ipN) out.push(toStr(addr));
+    }
+    return out;
+}
+
+/* Our own IPv4 interfaces, as {address, netmask} — the scan origin. */
+function localIPv4s() {
+    var out = [], ifs;
+    try { ifs = os.networkInterfaces() || {}; } catch (e) { return out; }
+    for (var name in ifs) {
+        var list = ifs[name] || [];
+        for (var i = 0; i < list.length; i++) {
+            var a = list[i];
+            if (!a || a.internal) continue;
+            if (a.family !== 'IPv4' && a.family !== 4) continue;
+            out.push({ address: a.address, netmask: a.netmask || '255.255.255.0', name: name });
+        }
+    }
+    return out;
+}
+
+/* Phase 1: is anything listening on host:port? cb(true|false), never throws. */
+function probePort(host, port, cb) {
+    var done = false, sock;
+    function finish(open) {
+        if (done) return;
+        done = true;
+        try { if (sock) sock.destroy(); } catch (e) {}
+        cb(open);
+    }
+    try {
+        sock = net.connect(port, host, function () { finish(true); });
+        sock.setTimeout(SCAN_CONNECT_MS, function () { finish(false); });
+        sock.on('error', function () { finish(false); });
+    } catch (e) { finish(false); }
+}
+
+/* Phase 2: is it one of ours? cb(server|null). */
+function probeHello(host, port, cb) {
+    var done = false, req;
+    function finish(v) { if (done) return; done = true; cb(v); }
+    try {
+        req = http.get({ host: host, port: port, path: '/api/hello', agent: false }, function (res) {
+            if (res.statusCode !== 200) { res.resume(); return finish(null); }
+            var body = '';
+            res.on('data', function (c) { body += c; if (body.length > 8192) finish(null); });
+            res.on('end', function () {
+                var j = null;
+                try { j = JSON.parse(body); } catch (e) {}
+                if (!j || j.app !== 'vlc-tv-transcode') return finish(null);
+                finish({
+                    url:        'http://' + host + ':' + port,
+                    host:       host,
+                    port:       port,
+                    name:       j.name || host,
+                    api:        j.api || 0,
+                    configured: !!j.configured,
+                    canAdopt:   !!j.canAdopt
+                });
+            });
+        });
+        req.setTimeout(SCAN_HTTP_MS, function () { try { req.abort(); } catch (e) {} finish(null); });
+        req.on('error', function () { finish(null); });
+    } catch (e) { finish(null); }
+}
+
+/* Walk `items` SCAN_BATCH at a time, calling work(item, done) for each. */
+function eachLimited(items, limit, work, allDone) {
+    var i = 0, active = 0, finished = false;
+    if (!items.length) return allDone();
+    function pump() {
+        while (active < limit && i < items.length) {
+            active++;
+            work(items[i++], function () {
+                active--;
+                if (i >= items.length && active === 0) {
+                    if (!finished) { finished = true; allDone(); }
+                } else pump();
+            });
+        }
+    }
+    pump();
+}
+
+/* GET /discover[?port=8200] — sweep every local subnet and report what answers. */
+function handleDiscover(req, res, query) {
+    var port = parseInt(query.port, 10) || SCAN_PORT;
+    var ifaces = localIPv4s();
+    if (!ifaces.length) return sendJson(res, 200, { ok: false, error: 'this TV has no LAN address' });
+
+    var hosts = [], skipped = [];
+    for (var i = 0; i < ifaces.length; i++) {
+        var list = subnetHosts(ifaces[i].address, ifaces[i].netmask);
+        if (!list) { skipped.push(ifaces[i].address + '/' + ifaces[i].netmask); continue; }
+        for (var j = 0; j < list.length; j++) if (hosts.indexOf(list[j]) < 0) hosts.push(list[j]);
+    }
+    if (!hosts.length) {
+        return sendJson(res, 200, {
+            ok: false,
+            error: skipped.length ? 'network too large to scan (' + skipped.join(', ') + ')'
+                                  : 'no scannable network found'
+        });
+    }
+
+    log('DISCOVER_START', hosts.length + ' hosts on port ' + port);
+    var open = [];
+    eachLimited(hosts, SCAN_BATCH, function (host, done) {
+        probePort(host, port, function (isOpen) { if (isOpen) open.push(host); done(); });
+    }, function () {
+        log('DISCOVER_OPEN', open.length + ' host(s) listening');
+        var found = [];
+        eachLimited(open, 8, function (host, done) {
+            probeHello(host, port, function (srv) { if (srv) found.push(srv); done(); });
+        }, function () {
+            log('DISCOVER_DONE', found.length + ' server(s)');
+            sendJson(res, 200, { ok: true, servers: found, scanned: hosts.length });
+        });
+    });
+}
+
 var server = http.createServer(function (req, res) {
     var u = require('url').parse(req.url, true);
     if (req.method === 'OPTIONS') { cors(res, 204, 'text/plain'); return res.end(); }
@@ -890,6 +1248,16 @@ var server = http.createServer(function (req, res) {
     if (u.pathname === '/smb/connect' && req.method === 'POST') return handleConnect(req, res);
     if (u.pathname === '/smb/list')        return handleList(req, res, u.query);
     if (u.pathname === '/smb/stream')      return handleStream(req, res, u.query);
+
+    // Local relay control plane — only reachable on loopback, because the LAN
+    // listener above doesn't route these paths.
+    if (u.pathname === '/local/enable' && req.method === 'POST')  return handleLocalEnable(req, res);
+    if (u.pathname === '/local/disable' && req.method === 'POST') return handleLocalDisable(req, res);
+    if (u.pathname === '/local/status')
+        return sendJson(res, 200, { ok: true, enabled: !!localServer, url: localServer ? localURL() : '' });
+
+    // LAN discovery — replaces typing a pairing code between two screens.
+    if (u.pathname === '/discover') return handleDiscover(req, res, u.query);
 
     cors(res, 404, 'text/plain'); res.end('Not Found');
 });

--- a/vlc-transcode-server/README.md
+++ b/vlc-transcode-server/README.md
@@ -116,18 +116,93 @@ binary uses `h264_videotoolbox` via macOS's hardware encoder.
 
 ## Pair with the TV
 
-On the TV: **Settings → Transcode server → Pair**, then enter the code the TV
-shows into the **Pair with TV** box on this page. The server publishes its LAN
-address + a token to the TV (via the same ntfy pairing channel the app already
-uses), and the TV stores it.
+Fill in your SMB share on this page first (host, share, credentials — **Test
+connection** to confirm). Then, on the TV:
 
-From then on the TV browses your SMB share exactly as before — but when you press
-play, the file streams through this box, transcoded as needed. Nothing else in
-the TV's flow changes; if the server is ever unpaired or offline the TV falls
-back to playing directly.
+**Settings → Transcode server → Find server on my network**
 
-> The server must point at the **same share** the TV browses, so the relative
-> paths line up.
+That's the whole flow. The TV sweeps its own subnet, finds this box, stores the
+pairing, and settles the share settings between the two of you — whichever end
+already knows them tells the other:
+
+| Situation | What happens |
+|---|---|
+| This box has a share configured | The TV copies it down (needs **Let a paired TV copy these settings**, on by default, and the pairing window open — see below) |
+| This box is fresh, the TV already had SMB working | The TV sends its settings up here |
+| Neither has one | Fill the share in on either end; **Send my share settings to the server** on the TV pushes it up later |
+
+So if your TV already browses your NAS, you can skip this page entirely: install
+the box, press *Find server on my network*, done. There is no code to read off
+one screen and into another, and nothing leaves your LAN.
+
+From then on the TV browses your share exactly as before; the only change is
+that pressing play streams through this box, transcoded as needed. If the server
+is ever unpaired or offline the TV falls back to playing directly.
+
+> Because the TV copies the share settings from here, both ends point at the
+> **same share** automatically — which is what makes the relative paths line up.
+> If you turn credential copying off, make sure they match by hand.
+
+### If the scan finds nothing
+
+The sweep only covers the TV's own subnet, and only when that subnet is /22 or
+narrower (a wider one would mean thousands of probes). It also needs the TV and
+this box to be able to reach each other — guest Wi-Fi and AP/client isolation
+routinely block that.
+
+Two fallbacks, in order of preference:
+
+1. **Enter the address by hand.** On the TV, type this box's address into
+   **Settings → Transcode server → Server address** (the Status card above shows
+   it) and press **Connect to this address**. Same result as the scan, no
+   discovery needed — this also covers the case where the box is on a different
+   subnet but still routable.
+2. **Pair with a code.** The original method, under *Pair with a code instead*
+   on this page. It relays through ntfy.sh, so both ends need working internet,
+   and the order matters: enter the TV's code here and press **Pair** *before*
+   pressing **Pair with a code** on the TV.
+
+### The pairing window
+
+The share **password** is the one genuinely sensitive thing this box holds, so
+it isn't simply on offer to anything that asks. `/api/adopt` only answers during
+a ten-minute window, which opens when:
+
+- the box starts,
+- you save the share on this page, or
+- you press **Allow pairing for 10 minutes**.
+
+Every legitimate flow happens inside one of those — you pair the TV minutes
+after installing the box or setting the share up. Outside the window the
+password isn't handed out at all, token or no token. If a TV pairs late, the
+setup page tells you the window is closed; press the button and use **Settings →
+Transcode server → Get share settings from the server** on the TV.
+
+Already-paired TVs are unaffected: they stored the settings when they paired and
+never ask again.
+
+> Why a window rather than "only the first TV to pair gets in"? Because the
+> setup page needs the pairing token for every write it makes — including the
+> button that would let a second device in. Locking the token to one device
+> bricks the page and leaves no way back except editing `config.json` by hand. A
+> window has no such dead end.
+
+### What's exposed on your LAN
+
+Worth being explicit, because the scan-based flow makes it visible: **this box
+treats your LAN as trusted.**
+
+Every `/api` endpoint except `/api/hello` and `/api/status` requires the pairing
+token — but `/api/status` is exactly where a TV reads that token from, so
+anything on your network can read it too. The token check stops accidents
+(another tool poking a URL it found, a stray script, a forgotten browser tab),
+not a determined device on your network. That is why the password sits behind
+the window as well as behind the token, and why you can switch credential
+copying off entirely.
+
+Being able to *play* your own media over your own LAN is the risk the token
+covers, and that's the posture the box has always had. Nothing here is reachable
+from outside your network unless you deliberately forward the port — don't.
 
 ## Verify transcoding (before the TV is involved)
 
@@ -148,6 +223,68 @@ serves the live HLS manifest. A DTS/TrueHD file should now play **with sound**.
 | Video + audio both TV-friendly | **Remux only** (copy/copy) |
 | Only audio is DTS/TrueHD | Copy video, transcode audio → AC3 (5.1) / AAC (stereo) |
 | Video codec unsupported | Hardware-transcode video → H.264, fix audio |
+| Multichannel audio, surround on | Copy video, transcode audio → E-AC-3 / AC-3 5.1 |
+
+## Surround sound (5.1 to a soundbar)
+
+A 5.1 FLAC, AAC or PCM track plays on the TV and still arrives at the soundbar
+as **stereo**. That isn't the TV app downmixing — it's the link. HDMI-ARC and
+optical carry either LPCM or an IEC 61937-framed bitstream, and only Dolby
+Digital and Dolby Digital Plus have that framing. Everything else the TV decodes
+itself, and plain ARC can only carry two channels of the resulting LPCM. FLAC in
+particular has no bitstream form at all, on any device — an external player that
+"sends FLAC 5.1 to the soundbar" is really decoding it and sending multichannel
+LPCM over a link that can carry it.
+
+Nothing in a Tizen app can change that: AVPlay has no channel-layout or
+passthrough control. What *can* change it is re-encoding upstream, here, into a
+format the TV will pass straight through.
+
+Set it on the TV, under **Settings → Transcode server → Surround sound** — the
+setting lives on this box but you change it from the sofa, which is where you
+are when you notice the soundbar is doing stereo. This page shows the current
+value under *Playback*.
+
+| Setting | What happens |
+|---|---|
+| **Off** (default) | Only audio the TV can't decode is touched. 5.1 FLAC/AAC still reaches the soundbar as stereo. |
+| **Dolby Digital Plus 5.1** | Any multichannel track that isn't already AC-3/E-AC-3 is re-encoded to E-AC-3 at 768 kbps. Best quality; needs a DD+ capable soundbar. |
+| **Dolby Digital 5.1** | Same, targeting AC-3 at 640 kbps. Use this if your receiver won't take DD+. |
+
+Tracks that are *already* AC-3 or E-AC-3 are copied untouched either way, and
+stereo sources are never re-encoded just because the setting is on.
+
+Two things worth knowing:
+
+- This is a lossy re-encode. A lossless FLAC 5.1 track becomes Dolby 5.1 — you
+  keep the channels, not the bit-exactness. There is no route that keeps both;
+  the TV cannot pass lossless multichannel to a soundbar.
+- Set your TV's **Sound → Expert Settings → Digital Output Audio Format** to
+  *Pass-through* (or Auto), or it will decode the Dolby stream and downmix it
+  again on the way out.
+
+## USB and internal-storage files
+
+Files on a USB stick are physically at the TV, so this box can't read them the
+way it reads the share — which is why they used to miss out on both the
+surround handling and the unsupported-codec handling.
+
+Turn on **Settings → Transcode server → Play USB files through the server** on
+the TV and the direction reverses for those files: the TV app's background
+service opens a small read-only listener on your LAN, and hands this box a URL
+pointing at it. The box fetches, transcodes, and streams HLS back exactly as it
+does for share files.
+
+The TV asks this box for permission as part of that switch, so there's nothing to
+do here — the *Allow the TV to send USB / internal files* toggle on this page is
+how you **revoke** it. It's off until a TV turns it on. The TV's listener is
+armed only while the app is running, only serves paths under the drives
+`tizen.filesystem` itself reported, and requires a random per-TV key that the
+box receives in the URL. On this side, a `src=` URL is only accepted from a
+paired TV, and only when it names a private LAN address — the pairing token
+can't be used to make the box fetch from somewhere else.
+
+If either side is off, USB files simply play the way they always did.
 
 ## Hardware acceleration
 
@@ -179,3 +316,7 @@ ffmpeg reports and falls back to software (`libx264`). Detection order:
   separately).
 - One active stream per file; the box transcodes in real time, so a weak CPU may
   not keep up with software encoding of heavy 4K video.
+- Surround targets 5.1. A 7.1 source is folded down to 5.1 (both AC-3 and E-AC-3
+  encoders top out there), and lossless formats stay lossy after the re-encode.
+- USB relay needs the TV app to be open — it's the app's background service that
+  serves the file, so the box can't pull from a TV sitting in standby.

--- a/vlc-transcode-server/internal/config/config.go
+++ b/vlc-transcode-server/internal/config/config.go
@@ -47,6 +47,30 @@ type Config struct {
 	// auto-detect.
 	Encoder string `json:"encoder,omitempty"`
 
+	// Surround is the multichannel audio target: "off" (default), "eac3"
+	// (Dolby Digital Plus) or "ac3" (Dolby Digital). A TV can only hand a
+	// soundbar audio it can bitstream; anything else it decodes and downmixes
+	// to stereo on the way out, so 5.1 FLAC/AAC/DTS arrives as 2.0. Setting
+	// this re-encodes multichannel tracks into a format that survives the trip.
+	// Off by default so an upgrade never starts re-encoding audio that was
+	// previously copied untouched.
+	Surround string `json:"surround,omitempty"`
+
+	// ShareCredentials lets a paired TV pull the SMB settings below (password
+	// included) so the user fills the share in once, here, with a real
+	// keyboard — instead of typing six fields on a TV remote and hoping they
+	// match. A pointer so an existing config file that predates the field
+	// still ends up defaulting to on rather than to Go's zero value; Load
+	// normalises it.
+	ShareCredentials *bool `json:"share_credentials,omitempty"`
+
+	// LocalRelay allows /play to transcode from a URL the TV hands us instead
+	// of only from the SMB share — that's how files on a USB drive plugged
+	// into the TV reach this box. The TV serves them from its own background
+	// service; we only ever fetch, and only from the LAN address it gives us.
+	// Off by default: it widens what a paired TV can ask the box to fetch.
+	LocalRelay bool `json:"local_relay,omitempty"`
+
 	// Token is a long random secret minted on first run. The TV receives it
 	// during pairing and sends it on /play, so a random LAN device can't drive
 	// the transcoder. It rides in URLs the TV builds automatically — no user
@@ -83,7 +107,8 @@ func (c *Config) EnsureToken() error {
 // Load reads the config file, returning an empty (but usable) Config if it does
 // not exist yet. Only a malformed existing file is an error.
 func Load(path string) (*Config, error) {
-	c := &Config{path: path, SMB: SMB{Port: 445}}
+	on := true
+	c := &Config{path: path, SMB: SMB{Port: 445}, ShareCredentials: &on}
 	b, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -98,7 +123,18 @@ func Load(path string) (*Config, error) {
 	if c.SMB.Port == 0 {
 		c.SMB.Port = 445
 	}
+	if c.ShareCredentials == nil {
+		on := true
+		c.ShareCredentials = &on
+	}
 	return c, nil
+}
+
+// CanShareCredentials reports whether a paired TV may fetch the SMB settings.
+// Absent (an old config, or a hand-written one) means yes — that's the setup
+// the feature exists for.
+func (c *Config) CanShareCredentials() bool {
+	return c.ShareCredentials == nil || *c.ShareCredentials
 }
 
 // Save atomically persists the current config to disk.
@@ -122,13 +158,22 @@ func (c *Config) Save() error {
 
 // View is the JSON shape sent to the web UI — no mutex, password masked.
 type View struct {
-	SMB     SMB    `json:"smb"`
-	Encoder string `json:"encoder,omitempty"`
+	SMB              SMB    `json:"smb"`
+	Encoder          string `json:"encoder,omitempty"`
+	Surround         string `json:"surround"`
+	LocalRelay       bool   `json:"local_relay"`
+	ShareCredentials bool   `json:"share_credentials"`
 }
 
 // Redacted returns a lock-free view safe to send to the web UI.
 func (c *Config) Redacted() View {
-	v := View{SMB: c.SMB, Encoder: c.Encoder}
+	v := View{
+		SMB: c.SMB, Encoder: c.Encoder, Surround: c.Surround,
+		LocalRelay: c.LocalRelay, ShareCredentials: c.CanShareCredentials(),
+	}
+	if v.Surround == "" {
+		v.Surround = "off"
+	}
 	v.SMB.Pass = "" // never leak the stored password
 	return v
 }

--- a/vlc-transcode-server/internal/pair/pair.go
+++ b/vlc-transcode-server/internal/pair/pair.go
@@ -39,7 +39,7 @@ func Publish(ctx context.Context, code, serverURL, token string) error {
 	if code == "" {
 		return fmt.Errorf("empty pairing code")
 	}
-	ann := Announce{Type: "vlc-tv-transcode-server", URL: serverURL, Token: token, Name: hostname()}
+	ann := Announce{Type: "vlc-tv-transcode-server", URL: serverURL, Token: token, Name: Hostname()}
 	body, _ := json.Marshal(ann)
 
 	ctx, cancel := context.WithTimeout(ctx, 12*time.Second)
@@ -86,7 +86,9 @@ func outboundIP() string {
 	return ""
 }
 
-func hostname() string {
+// Hostname is the friendly name shown next to this box — in the pairing
+// announcement, and in the list a scanning TV puts on screen.
+func Hostname() string {
 	h, err := os.Hostname()
 	if err != nil || h == "" {
 		return "VLC TV Transcode Server"

--- a/vlc-transcode-server/internal/transcode/decide.go
+++ b/vlc-transcode-server/internal/transcode/decide.go
@@ -13,6 +13,48 @@ var tvAudioOK = map[string]bool{
 	"mp3": true, "mp2": true,
 }
 
+// bitstreamOK is the set of audio codecs the TV can hand to a soundbar or AVR
+// *untouched* over HDMI-ARC / eARC / optical, because they have an IEC 61937
+// framing. Everything else — FLAC, AAC, PCM, Vorbis, Opus — the TV decodes
+// itself, and what leaves the set is then LPCM, which plain ARC can only carry
+// as 2.0. That's why a 5.1 FLAC file arrives at the soundbar as stereo
+// (issue #63): nothing is broken, the format simply has no multichannel path
+// off the TV. Re-encoding into one of these is the only way to keep 5.1.
+//
+// Deliberately narrower than tvAudioOK: DTS bitstreams fine on receivers, but
+// Samsung dropped DTS decoding, so the TV can't even get it out of the
+// container to pass it on.
+var bitstreamOK = map[string]bool{
+	"ac3": true, "eac3": true,
+}
+
+// Surround modes for Config.Surround — the target the user wants multichannel
+// audio delivered in.
+const (
+	// SurroundOff keeps the historical behaviour: only re-encode audio the TV
+	// cannot decode at all. Multichannel AAC still reaches the soundbar as
+	// PCM 2.0.
+	SurroundOff = "off"
+	// SurroundEAC3 re-encodes any non-bitstreamable multichannel track to
+	// E-AC-3 (Dolby Digital Plus) 5.1. Best quality of the two, supported by
+	// every TV in scope and by ARC/eARC soundbars from ~2015 on.
+	SurroundEAC3 = "eac3"
+	// SurroundAC3 targets plain AC-3 (Dolby Digital) 5.1 instead — lower
+	// ceiling, but the safe pick for older receivers that reject DD+.
+	SurroundAC3 = "ac3"
+)
+
+// NormaliseSurround maps stored/posted values onto a known mode, defaulting to
+// off so an empty config (or a typo) never silently re-encodes anything.
+func NormaliseSurround(mode string) string {
+	switch mode {
+	case SurroundEAC3, SurroundAC3:
+		return mode
+	default:
+		return SurroundOff
+	}
+}
+
 // Plan is the decision for one file.
 type Plan struct {
 	CopyVideo bool   // remux video stream untouched
@@ -29,31 +71,66 @@ type Plan struct {
 //   - only the audio codec is the wall → copy video, re-encode just the audio
 //   - video codec unsupported          → hardware-transcode video + fix audio
 //
-// Re-encoded audio targets AC3 when the source is multichannel (keeps 5.1) and
-// AAC for stereo — both decode on every TV in scope.
-func Decide(mi *MediaInfo) Plan {
+// surround adds a second reason to touch the audio: a track the TV can decode
+// perfectly well still leaves the set as PCM 2.0 unless it's in a format the TV
+// can bitstream, so when the user asks for surround we re-encode multichannel
+// audio into AC-3 / E-AC-3 even though nothing is "broken" about it.
+//
+// With surround off, re-encoded audio targets AC-3 when the source is
+// multichannel (keeps 5.1) and AAC for stereo — both decode on every TV in
+// scope.
+func Decide(mi *MediaInfo, surround string) Plan {
+	surround = NormaliseSurround(surround)
+
 	videoOK := mi.VideoCodec == "" || tvVideoOK[mi.VideoCodec]
 	audioOK := mi.AudioCodec == "" || tvAudioOK[mi.AudioCodec]
+	multichannel := mi.AudioChans > 2
 
-	p := Plan{mi: mi, CopyVideo: videoOK, CopyAudio: audioOK}
-	if !audioOK {
-		if mi.AudioChans > 2 {
+	// A decodable-but-not-bitstreamable multichannel track: playable today,
+	// but downmixed on the way out. Only worth touching when asked.
+	downmixed := surround != SurroundOff && mi.AudioCodec != "" &&
+		multichannel && !bitstreamOK[mi.AudioCodec]
+
+	p := Plan{mi: mi, CopyVideo: videoOK, CopyAudio: audioOK && !downmixed}
+	if !p.CopyAudio && mi.AudioCodec != "" {
+		switch {
+		case surround != SurroundOff && multichannel:
+			p.AudioEnc = surround
+		case multichannel:
 			p.AudioEnc = "ac3"
-		} else {
+		default:
 			p.AudioEnc = "aac"
 		}
 	}
 
 	switch {
-	case videoOK && audioOK:
+	case videoOK && p.CopyAudio:
 		p.Reason = "remux only — both streams TV-compatible"
-	case videoOK && !audioOK:
+	case videoOK && downmixed && audioOK:
+		p.Reason = "copy video, transcode audio " + mi.AudioCodec + "→" + p.AudioEnc +
+			" so the TV can bitstream " + chanLabel(mi.AudioChans) + " instead of downmixing to stereo"
+	case videoOK:
 		p.Reason = "copy video, transcode audio " + mi.AudioCodec + "→" + p.AudioEnc
 	default:
 		p.Reason = "transcode video " + mi.VideoCodec + "→h264"
-		if !audioOK {
+		if !p.CopyAudio {
 			p.Reason += ", audio " + mi.AudioCodec + "→" + p.AudioEnc
 		}
 	}
 	return p
+}
+
+// chanLabel renders a channel count the way a user thinks about it, for log and
+// UI reasons ("6" means nothing; "5.1" does).
+func chanLabel(n int) string {
+	switch n {
+	case 6:
+		return "5.1"
+	case 8:
+		return "7.1"
+	case 7:
+		return "6.1"
+	default:
+		return "multichannel"
+	}
 }

--- a/vlc-transcode-server/internal/transcode/decide_test.go
+++ b/vlc-transcode-server/internal/transcode/decide_test.go
@@ -1,0 +1,73 @@
+package transcode
+
+import "testing"
+
+func TestDecideSurround(t *testing.T) {
+	cases := []struct {
+		name     string
+		mi       MediaInfo
+		surround string
+		copyA    bool
+		enc      string
+	}{
+		// Historical behaviour must be untouched when surround is off.
+		{"stereo aac copied", MediaInfo{VideoCodec: "h264", AudioCodec: "aac", AudioChans: 2}, SurroundOff, true, ""},
+		{"5.1 aac copied", MediaInfo{VideoCodec: "h264", AudioCodec: "aac", AudioChans: 6}, SurroundOff, true, ""},
+		{"dts 5.1 to ac3", MediaInfo{VideoCodec: "h264", AudioCodec: "dts", AudioChans: 6}, SurroundOff, false, "ac3"},
+		{"dts stereo to aac", MediaInfo{VideoCodec: "h264", AudioCodec: "dts", AudioChans: 2}, SurroundOff, false, "aac"},
+
+		// The issue-63 case: a codec the TV decodes fine but can't bitstream.
+		{"flac 5.1 to eac3", MediaInfo{VideoCodec: "h264", AudioCodec: "flac", AudioChans: 6}, SurroundEAC3, false, "eac3"},
+		{"flac 5.1 to ac3", MediaInfo{VideoCodec: "h264", AudioCodec: "flac", AudioChans: 6}, SurroundAC3, false, "ac3"},
+		{"aac 5.1 to eac3", MediaInfo{VideoCodec: "h264", AudioCodec: "aac", AudioChans: 6}, SurroundEAC3, false, "eac3"},
+		{"truehd 7.1 to eac3", MediaInfo{VideoCodec: "hevc", AudioCodec: "truehd", AudioChans: 8}, SurroundEAC3, false, "eac3"},
+
+		// Already bitstreamable, or not multichannel: leave it alone.
+		{"ac3 5.1 stays copied", MediaInfo{VideoCodec: "h264", AudioCodec: "ac3", AudioChans: 6}, SurroundEAC3, true, ""},
+		{"eac3 5.1 stays copied", MediaInfo{VideoCodec: "h264", AudioCodec: "eac3", AudioChans: 6}, SurroundEAC3, true, ""},
+		{"flac stereo to aac", MediaInfo{VideoCodec: "h264", AudioCodec: "flac", AudioChans: 2}, SurroundEAC3, false, "aac"},
+		{"aac stereo stays copied", MediaInfo{VideoCodec: "h264", AudioCodec: "aac", AudioChans: 2}, SurroundEAC3, true, ""},
+
+		// No audio track at all must not produce an encoder.
+		{"video only", MediaInfo{VideoCodec: "h264"}, SurroundEAC3, true, ""},
+
+		// An unknown mode string is treated as off, never as "encode something".
+		{"garbage mode is off", MediaInfo{VideoCodec: "h264", AudioCodec: "flac", AudioChans: 6}, "dts-hd", false, "ac3"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mi := c.mi
+			p := Decide(&mi, c.surround)
+			if p.CopyAudio != c.copyA {
+				t.Errorf("CopyAudio = %v, want %v (reason: %s)", p.CopyAudio, c.copyA, p.Reason)
+			}
+			if p.AudioEnc != c.enc {
+				t.Errorf("AudioEnc = %q, want %q (reason: %s)", p.AudioEnc, c.enc, p.Reason)
+			}
+		})
+	}
+}
+
+// Video handling must be independent of the audio policy.
+func TestDecideVideoUnaffectedBySurround(t *testing.T) {
+	for _, mode := range []string{SurroundOff, SurroundAC3, SurroundEAC3} {
+		mi := MediaInfo{VideoCodec: "vp9", AudioCodec: "flac", AudioChans: 6}
+		if p := Decide(&mi, mode); p.CopyVideo {
+			t.Errorf("surround=%s: vp9 should be transcoded, not copied", mode)
+		}
+		mi = MediaInfo{VideoCodec: "h264", AudioCodec: "flac", AudioChans: 6}
+		if p := Decide(&mi, mode); !p.CopyVideo {
+			t.Errorf("surround=%s: h264 should be copied", mode)
+		}
+	}
+}
+
+// Changing the policy must not reuse a session cached under the old one.
+func TestIDForIncludesSurround(t *testing.T) {
+	a := idFor("smb:Movies/x.mkv", SurroundOff)
+	b := idFor("smb:Movies/x.mkv", SurroundEAC3)
+	if a == b {
+		t.Fatalf("session id ignored the surround policy: %s", a)
+	}
+}

--- a/vlc-transcode-server/internal/transcode/manager.go
+++ b/vlc-transcode-server/internal/transcode/manager.go
@@ -23,18 +23,25 @@ const idleTimeout = 90 * time.Second
 // (Injected so this package doesn't import the web/http layer.)
 type RawURLFunc func(smbPath string) string
 
+// SurroundFunc reports the currently configured surround mode. It's a func
+// rather than a value because the setting is web-editable while the server
+// runs, and we want the next play to honour the new setting without a restart.
+type SurroundFunc func() string
+
 // Manager owns the working directory and the live session set.
 type Manager struct {
-	caps    *Caps
-	workDir string
-	rawURL  RawURLFunc
+	caps     *Caps
+	workDir  string
+	rawURL   RawURLFunc
+	surround SurroundFunc
 
 	mu       sync.Mutex
 	sessions map[string]*session
 }
 
-// NewManager wires the manager and starts the idle-reaper goroutine.
-func NewManager(caps *Caps, workDir string, rawURL RawURLFunc) (*Manager, error) {
+// NewManager wires the manager and starts the idle-reaper goroutine. surround
+// may be nil, in which case the surround policy is permanently off.
+func NewManager(caps *Caps, workDir string, rawURL RawURLFunc, surround SurroundFunc) (*Manager, error) {
 	if err := os.MkdirAll(workDir, 0o755); err != nil {
 		return nil, err
 	}
@@ -43,20 +50,68 @@ func NewManager(caps *Caps, workDir string, rawURL RawURLFunc) (*Manager, error)
 	for _, e := range entries {
 		os.RemoveAll(e)
 	}
-	m := &Manager{caps: caps, workDir: workDir, rawURL: rawURL, sessions: map[string]*session{}}
+	m := &Manager{caps: caps, workDir: workDir, rawURL: rawURL, surround: surround, sessions: map[string]*session{}}
 	go m.reap()
 	return m, nil
+}
+
+// Source is what one session reads from. Exactly one of the two fields is set:
+// SMBPath for a file on the configured share (bridged through /raw), or URL for
+// a file the box can already fetch over HTTP — currently the TV's own USB/local
+// relay, so files sitting on a drive plugged into the TV get the same treatment
+// as files on the share.
+type Source struct {
+	SMBPath string
+	URL     string
+}
+
+// SMBSource / HTTPSource are the two constructors, so callers can't build a
+// Source with both (or neither) field set by accident.
+func SMBSource(path string) Source { return Source{SMBPath: path} }
+func HTTPSource(url string) Source { return Source{URL: url} }
+
+// key identifies the source for the session map and the work directory.
+func (s Source) key() string {
+	if s.URL != "" {
+		return "url:" + s.URL
+	}
+	return "smb:" + s.SMBPath
+}
+
+// Label is the short human form used in logs and error messages.
+func (s Source) Label() string {
+	if s.URL != "" {
+		return s.URL
+	}
+	return s.SMBPath
+}
+
+// input resolves what ffmpeg actually opens.
+func (m *Manager) input(s Source) string {
+	if s.URL != "" {
+		return s.URL
+	}
+	return m.rawURL(s.SMBPath)
+}
+
+// surroundMode reads the live setting, normalised.
+func (m *Manager) surroundMode() string {
+	if m.surround == nil {
+		return SurroundOff
+	}
+	return NormaliseSurround(m.surround())
 }
 
 // Caps exposes the probed capabilities (for the status page).
 func (m *Manager) Caps() *Caps { return m.caps }
 
-// EnsureSession returns a ready session for the given SMB path, starting ffmpeg
+// EnsureSession returns a ready session for the given source, starting ffmpeg
 // (after probing + deciding) if one isn't already running. It blocks until the
 // first segment exists so the caller can immediately redirect AVPlay to the
 // playlist.
-func (m *Manager) EnsureSession(ctx context.Context, smbPath string) (*session, error) {
-	id := idFor(smbPath)
+func (m *Manager) EnsureSession(ctx context.Context, src Source) (*session, error) {
+	surround := m.surroundMode()
+	id := idFor(src.key(), surround)
 
 	m.mu.Lock()
 	if s, ok := m.sessions[id]; ok && !s.isDone() {
@@ -69,15 +124,16 @@ func (m *Manager) EnsureSession(ctx context.Context, smbPath string) (*session, 
 	}
 	m.mu.Unlock()
 
-	in := m.rawURL(smbPath)
+	in := m.input(src)
 
 	// Probe + decide before committing to a session.
 	mi, err := m.caps.Inspect(ctx, in)
 	if err != nil {
 		return nil, fmt.Errorf("probe failed: %w", err)
 	}
-	plan := Decide(mi)
-	log.Printf("transcode %q: %s (codec v=%s a=%s/%dch)", smbPath, plan.Reason, mi.VideoCodec, mi.AudioCodec, mi.AudioChans)
+	plan := Decide(mi, surround)
+	log.Printf("transcode %q: %s (codec v=%s a=%s/%dch, surround=%s)",
+		src.Label(), plan.Reason, mi.VideoCodec, mi.AudioCodec, mi.AudioChans, surround)
 
 	dir := filepath.Join(m.workDir, id)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -86,7 +142,7 @@ func (m *Manager) EnsureSession(ctx context.Context, smbPath string) (*session, 
 
 	sctx, cancel := context.WithCancel(context.Background())
 	s := &session{
-		ID: id, SrcPath: smbPath, Dir: dir, Plan: plan,
+		ID: id, SrcPath: src.Label(), Dir: dir, Plan: plan,
 		cancel: cancel, logTail: newRing(60), lastAccess: nowFn(),
 	}
 

--- a/vlc-transcode-server/internal/transcode/session.go
+++ b/vlc-transcode-server/internal/transcode/session.go
@@ -16,7 +16,7 @@ import (
 // Segments land in Dir; index.m3u8 is the playlist AVPlay loads.
 type session struct {
 	ID       string
-	SrcPath  string // SMB-relative path, for logs
+	SrcPath  string // source label (SMB path or relay URL), for logs
 	Dir      string
 	Plan     Plan
 	cmd      *exec.Cmd
@@ -91,14 +91,20 @@ func (c *Caps) buildArgs(in string, p Plan, dir string) []string {
 	// ── audio ──────────────────────────────────────────────────────────
 	if p.CopyAudio {
 		a = append(a, "-c:a", "copy")
-	} else if p.AudioEnc == "ac3" {
-		ch := p.mi.AudioChans
-		if ch == 0 || ch > 6 {
-			ch = 6 // AC-3 tops out at 5.1
-		}
-		a = append(a, "-c:a", "ac3", "-b:a", "640k", "-ac", fmt.Sprintf("%d", ch))
-	} else { // aac
+	} else if p.AudioEnc == "aac" {
 		a = append(a, "-c:a", "aac", "-b:a", "256k")
+	} else { // ac3 / eac3 — the two the TV can bitstream to a soundbar
+		ch := p.mi.AudioChans
+		if ch <= 0 || ch > 6 {
+			ch = 6 // both encoders top out at 5.1; 7.1 sources fold down
+		}
+		// AC-3's ceiling is 640k. E-AC-3 has headroom above that and is only
+		// ever chosen here for multichannel, so spend it.
+		br := "640k"
+		if p.AudioEnc == "eac3" {
+			br = "768k"
+		}
+		a = append(a, "-c:a", p.AudioEnc, "-b:a", br, "-ac", fmt.Sprintf("%d", ch))
 	}
 
 	// ── HLS muxer: growing ("event") VOD playlist, keep every segment so the
@@ -135,9 +141,12 @@ func (c *Caps) videoEncodeArgs() []string {
 	}
 }
 
-// idFor derives a stable session id from the source path.
-func idFor(path string) string {
-	h := sha1.Sum([]byte(path))
+// idFor derives a stable session id from the source and the audio policy that
+// produced it. The policy is part of the key because it is web-editable at
+// runtime: without it, flipping surround on would keep serving the stereo
+// session already sitting in the work dir for that file.
+func idFor(src, surround string) string {
+	h := sha1.Sum([]byte(src + "\x00" + surround))
 	return hex.EncodeToString(h[:])[:16]
 }
 

--- a/vlc-transcode-server/internal/web/manifest_test.go
+++ b/vlc-transcode-server/internal/web/manifest_test.go
@@ -11,3 +11,53 @@ func TestRewriteManifest(t *testing.T) {
 		t.Fatalf("rewrite mismatch:\n got: %q\nwant: %q", out, want)
 	}
 }
+
+// The src parameter is the one place a paired TV can name an arbitrary URL for
+// ffmpeg to open, so the guard around it is worth pinning down.
+func TestValidateRelayURL(t *testing.T) {
+	ok := []string{
+		"http://192.168.1.42:8128/local/stream?path=/opt/usr/media/x.mkv&key=abc",
+		"http://10.0.0.5:8128/local/stream?path=/a.mkv",
+		"http://172.16.3.9:8128/local/stream?path=/a.mkv",
+		"https://192.168.0.2:8128/local/stream?path=/a.mkv",
+		"http://169.254.7.7:8128/local/stream?path=/a.mkv", // link-local, e.g. no DHCP
+	}
+	for _, u := range ok {
+		if err := validateRelayURL(u); err != nil {
+			t.Errorf("validateRelayURL(%q) = %v, want nil", u, err)
+		}
+	}
+
+	bad := []string{
+		"http://127.0.0.1:8200/api/config",  // the box's own admin API
+		"http://localhost:8200/api/config",  // same, by name
+		"http://[::1]:8200/api/config",      // same, IPv6
+		"http://0.0.0.0:8200/",              // unspecified
+		"http://example.com/x.mkv",          // off-LAN, and DNS-resolvable
+		"http://8.8.8.8/x.mkv",              // public IP
+		"http://tv.local:8128/local/stream", // hostname, so rebindable
+		"file:///etc/passwd",                // not HTTP at all
+		"ftp://192.168.1.42/x.mkv",          // ditto
+		"",                                  // empty
+	}
+	for _, u := range bad {
+		if err := validateRelayURL(u); err == nil {
+			t.Errorf("validateRelayURL(%q) = nil, want an error", u)
+		}
+	}
+}
+
+func TestIsLoopback(t *testing.T) {
+	yes := []string{"127.0.0.1:54321", "[::1]:8200", "127.0.0.1", "127.1.2.3:9"}
+	for _, a := range yes {
+		if !isLoopback(a) {
+			t.Errorf("isLoopback(%q) = false, want true", a)
+		}
+	}
+	no := []string{"192.168.1.5:54321", "10.0.0.1:1", "[fe80::1]:80", "", "garbage"}
+	for _, a := range no {
+		if isLoopback(a) {
+			t.Errorf("isLoopback(%q) = true, want false", a)
+		}
+	}
+}

--- a/vlc-transcode-server/internal/web/server.go
+++ b/vlc-transcode-server/internal/web/server.go
@@ -7,13 +7,18 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/PatrickSt1991/vlc-tizen-tv/vlc-transcode-server/internal/config"
@@ -25,18 +30,56 @@ import (
 //go:embed static/*
 var staticFS embed.FS
 
+// adoptWindow is how long the box stays willing to hand its SMB password to a
+// pairing TV.
+//
+// The token that guards /api/adopt is readable from /api/status by anything on
+// the LAN, so on its own it doesn't keep the share password out of anyone's
+// hands. Locking the token down instead (first device to pair keeps it) breaks
+// the setup page, which needs that same token for every write — including the
+// button that would let another device in. A time window has neither problem:
+// the legitimate flows all happen within minutes of a setup action, and after
+// that the password simply isn't on offer any more, token or not.
+const adoptWindow = 10 * time.Minute
+
 // Server bundles the dependencies the handlers need.
 type Server struct {
 	cfg  *config.Config
 	smb  *smb.Client
 	mgr  *transcode.Manager
 	port int
+
+	mu         sync.Mutex
+	adoptUntil time.Time // credentials are on offer until this moment
 }
 
 // New constructs the HTTP server glue. The manager is wired afterwards via
 // SetManager because it needs this server's RawURL builder at construction.
+//
+// The adopt window starts open: a box that has just been started is a box
+// someone is setting up, and that's the moment the TV pairs.
 func New(cfg *config.Config, smbc *smb.Client, mgr *transcode.Manager, port int) *Server {
-	return &Server{cfg: cfg, smb: smbc, mgr: mgr, port: port}
+	return &Server{cfg: cfg, smb: smbc, mgr: mgr, port: port, adoptUntil: time.Now().Add(adoptWindow)}
+}
+
+// openAdoptWindow (re)starts the window. Called on the events that mean "a human
+// is setting this up right now": startup, saving the share, and the explicit
+// button on the setup page.
+func (s *Server) openAdoptWindow() {
+	s.mu.Lock()
+	s.adoptUntil = time.Now().Add(adoptWindow)
+	s.mu.Unlock()
+}
+
+// adoptSecondsLeft is 0 once the window has closed.
+func (s *Server) adoptSecondsLeft() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	d := time.Until(s.adoptUntil)
+	if d <= 0 {
+		return 0
+	}
+	return int(d.Seconds())
 }
 
 // SetManager injects the transcode manager once it has been built.
@@ -62,6 +105,9 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/api/browse", s.handleBrowse)
 	mux.HandleFunc("/api/status", s.handleStatus)
 	mux.HandleFunc("/api/pair", s.handlePair)
+	mux.HandleFunc("/api/hello", s.handleHello) // LAN discovery probe
+	mux.HandleFunc("/api/adopt", s.handleAdopt) // hand the share settings to a paired TV
+	mux.HandleFunc("/api/allow-adopt", s.handleAllowAdopt)
 
 	// Media plane.
 	mux.HandleFunc("/raw", s.handleRaw)   // ffmpeg input (localhost only)
@@ -74,7 +120,17 @@ func (s *Server) Handler() http.Handler {
 // ── media plane ─────────────────────────────────────────────────────────────
 
 // handleRaw streams an SMB file with Range support so ffmpeg can seek it.
+//
+// RawURL only ever builds a 127.0.0.1 address, but "we only call it from
+// localhost" isn't the same as "only localhost can call it" — the handler is on
+// the same LAN-facing mux as everything else, and without this check it would
+// serve any file on the share to anyone who guessed the path, no token needed.
+// Enforce what the URL builder assumes.
 func (s *Server) handleRaw(w http.ResponseWriter, r *http.Request) {
+	if !isLoopback(r.RemoteAddr) {
+		http.Error(w, "this endpoint is internal to the server", http.StatusForbidden)
+		return
+	}
 	p := r.URL.Query().Get("path")
 	if p == "" {
 		http.Error(w, "missing path", http.StatusBadRequest)
@@ -102,17 +158,17 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "unauthorized — pair the TV first", http.StatusForbidden)
 		return
 	}
-	p := r.URL.Query().Get("path")
-	if p == "" {
-		http.Error(w, "missing path", http.StatusBadRequest)
+	src, err := s.sourceFor(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 35*time.Second)
 	defer cancel()
 
-	sess, err := s.mgr.EnsureSession(ctx, p)
+	sess, err := s.mgr.EnsureSession(ctx, src)
 	if err != nil {
-		log.Printf("play %q failed: %v", p, err)
+		log.Printf("play %q failed: %v", src.Label(), err)
 		http.Error(w, "transcode failed: "+err.Error(), http.StatusBadGateway)
 		return
 	}
@@ -125,6 +181,68 @@ func (s *Server) handlePlay(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/vnd.apple.mpegurl")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Write(rewriteManifest(raw, "/hls/"+sess.ID+"/"))
+}
+
+// isLoopback reports whether a net/http RemoteAddr is the machine itself.
+func isLoopback(remoteAddr string) bool {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		host = remoteAddr
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// sourceFor turns the /play query into the thing ffmpeg should read.
+//
+//	?path=Movies/x.mkv   a file on the configured SMB share (the original mode)
+//	?src=http://<tv>/…   a file the TV is serving us — its USB drive or internal
+//	                     storage, relayed by the app's background service
+//
+// The src form only exists so USB files get the same treatment as share files.
+// It's off unless the user enables it, and the URL is validated below.
+func (s *Server) sourceFor(r *http.Request) (transcode.Source, error) {
+	q := r.URL.Query()
+	if raw := q.Get("src"); raw != "" {
+		if !s.cfg.LocalRelay {
+			return transcode.Source{}, errors.New("local relay is disabled — enable it on the server's setup page")
+		}
+		if err := validateRelayURL(raw); err != nil {
+			return transcode.Source{}, err
+		}
+		return transcode.HTTPSource(raw), nil
+	}
+	if p := q.Get("path"); p != "" {
+		return transcode.SMBSource(p), nil
+	}
+	return transcode.Source{}, errors.New("missing path")
+}
+
+// validateRelayURL keeps the src parameter from turning the pairing token into a
+// general-purpose fetch primitive. A paired TV is trusted to say "here is a file
+// on me", not to make the box read its own admin API or wander off the LAN, so
+// we require plain HTTP(S) to a literal IP address that is private and not
+// loopback. Refusing hostnames as well as public IPs means there's no DNS
+// rebinding step to worry about either.
+func validateRelayURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("bad src URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return errors.New("src must be http or https")
+	}
+	ip := net.ParseIP(u.Hostname())
+	if ip == nil {
+		return errors.New("src must address the TV by IP, not by name")
+	}
+	if ip.IsLoopback() || ip.IsUnspecified() {
+		return errors.New("src must not point back at this server")
+	}
+	if !ip.IsPrivate() && !ip.IsLinkLocalUnicast() {
+		return errors.New("src must be a LAN address")
+	}
+	return nil
 }
 
 // rewriteManifest prefixes bare segment filenames with the absolute HLS path so
@@ -147,6 +265,24 @@ func rewriteManifest(m3u8 []byte, prefix string) []byte {
 func (s *Server) checkToken(r *http.Request) bool {
 	want := s.cfg.Token
 	return want == "" || r.URL.Query().Get("token") == want
+}
+
+// guard is checkToken plus the 403, for the handlers that all reject the same
+// way. Everything under /api needs it except /api/hello and /api/status, which
+// are what a TV uses to find us and to learn the token in the first place.
+//
+// Worth being clear about what this is and isn't: since /api/status hands the
+// token to anything on the LAN, this is not an authentication boundary. It
+// stops accidents — another tool on the network poking a URL it found, a stray
+// script, a browser tab left open on someone else's machine — from rewriting
+// your share config. A hostile device on your LAN can still read the token and
+// walk straight through. Treat the LAN as the real boundary.
+func (s *Server) guard(w http.ResponseWriter, r *http.Request) bool {
+	if s.checkToken(r) {
+		return true
+	}
+	http.Error(w, "unauthorized — this endpoint needs the pairing token", http.StatusForbidden)
+	return false
 }
 
 // handleHLS serves the playlist and segments from a session's working dir.
@@ -179,28 +315,84 @@ func (s *Server) handleHLS(w http.ResponseWriter, r *http.Request) {
 
 // ── setup API ────────────────────────────────────────────────────────────────
 
+// smbFields are the flat keys the setup page has always posted. Their presence
+// in the body is what tells handleConfig that the caller means to set the share
+// — see the partial-update note there.
+var smbFields = []string{"host", "port", "share", "user", "pass", "domain", "anonymous"}
+
 func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
+	if !s.guard(w, r) {
+		return
+	}
 	switch r.Method {
 	case http.MethodGet:
 		writeJSON(w, s.cfg.Redacted())
 	case http.MethodPost:
-		var in config.SMB
-		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		// Partial updates matter here: the TV sets surround without knowing or
+		// caring about the share, and the setup page saves the share without
+		// touching playback. Decoding into a struct alone can't tell "absent"
+		// from "zero", so an absent share block would silently wipe a working
+		// one. Look at which keys the body actually carries, and only apply
+		// those. The playback options use pointers for the same reason.
+		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		if err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		var present map[string]json.RawMessage
+		if err := json.Unmarshal(body, &present); err != nil {
 			http.Error(w, "bad json", http.StatusBadRequest)
 			return
 		}
-		// An empty password on save means "keep the stored one" so the masked
-		// form round-trips without wiping credentials.
-		if in.Pass == "" {
-			in.Pass = s.cfg.SMB.Pass
+		// The SMB fields are inlined (the form has always posted them flat);
+		// the playback options are pointers so a client that doesn't know
+		// about them can't reset them by omission.
+		var in struct {
+			config.SMB
+			Surround         *string `json:"surround"`
+			LocalRelay       *bool   `json:"local_relay"`
+			ShareCredentials *bool   `json:"share_credentials"`
 		}
-		if in.Port == 0 {
-			in.Port = 445
+		if err := json.Unmarshal(body, &in); err != nil {
+			http.Error(w, "bad json", http.StatusBadRequest)
+			return
 		}
-		s.cfg.SMB = in
+		hasSMB := false
+		for _, k := range smbFields {
+			if _, ok := present[k]; ok {
+				hasSMB = true
+				break
+			}
+		}
+		if hasSMB {
+			// An empty password on save means "keep the stored one" so the
+			// masked form round-trips without wiping credentials.
+			if in.Pass == "" {
+				in.Pass = s.cfg.SMB.Pass
+			}
+			if in.Port == 0 {
+				in.Port = 445
+			}
+			s.cfg.SMB = in.SMB
+		}
+		if in.Surround != nil {
+			s.cfg.Surround = transcode.NormaliseSurround(*in.Surround)
+		}
+		if in.LocalRelay != nil {
+			s.cfg.LocalRelay = *in.LocalRelay
+		}
+		if in.ShareCredentials != nil {
+			s.cfg.ShareCredentials = in.ShareCredentials
+		}
 		if err := s.cfg.Save(); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
+		}
+		// Setting the share up is itself a setup action — otherwise a box that
+		// has been running for a week, whose share you only just configured,
+		// would refuse to hand it to the TV you're about to pair.
+		if hasSMB && s.cfg.Configured() {
+			s.openAdoptWindow()
 		}
 		writeJSON(w, map[string]bool{"ok": true})
 	default:
@@ -209,6 +401,9 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleTest(w http.ResponseWriter, r *http.Request) {
+	if !s.guard(w, r) {
+		return
+	}
 	if err := s.smb.Probe(); err != nil {
 		writeJSON(w, map[string]any{"ok": false, "error": err.Error()})
 		return
@@ -217,6 +412,9 @@ func (s *Server) handleTest(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleBrowse(w http.ResponseWriter, r *http.Request) {
+	if !s.guard(w, r) {
+		return
+	}
 	entries, err := s.smb.List(r.URL.Query().Get("path"))
 	if err != nil {
 		writeJSON(w, map[string]any{"ok": false, "error": err.Error()})
@@ -228,19 +426,94 @@ func (s *Server) handleBrowse(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	caps := s.mgr.Caps()
 	writeJSON(w, map[string]any{
+		"app":        AppID,
 		"configured": s.cfg.Configured(),
 		"encoder":    caps.VideoEncoder,
 		"hwaccel":    caps.HWAccel,
 		"share":      s.cfg.SMB.Host + "/" + s.cfg.SMB.Share,
+		"surround":   transcode.NormaliseSurround(s.cfg.Surround),
+		"localRelay": s.cfg.LocalRelay,
+		"canAdopt":   s.cfg.CanShareCredentials(),
+		"adoptLeft":  s.adoptSecondsLeft(),
 		"token":      s.cfg.Token, // LAN-trusted UI; used to build the test link
 		"serverURL":  pair.LocalURL(s.port),
 		"lastPair":   s.cfg.LastPair, // nil until the first successful pair publish
 	})
 }
 
+// AppID is what a LAN scan looks for. The TV sweeps its own subnet for anything
+// answering on the server port, and needs one unambiguous "yes, that's me"
+// before it offers to pair — a bare 200 from some other service on 8200 isn't
+// good enough.
+const AppID = "vlc-tv-transcode"
+
+// APIVersion lets a future TV app tell an old server from a new one without
+// probing endpoint by endpoint. Bump it when the pairing contract changes.
+const APIVersion = 1
+
+// handleHello is the discovery probe: unauthenticated, cheap, and carrying no
+// secrets — just enough for a scanning TV to recognise us and show a name.
+// The token deliberately isn't here; that stays on /api/status.
+func (s *Server) handleHello(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, map[string]any{
+		"app":        AppID,
+		"api":        APIVersion,
+		"name":       pair.Hostname(),
+		"port":       s.port,
+		"configured": s.cfg.Configured(),
+		"canAdopt":   s.cfg.CanShareCredentials() && s.cfg.Configured(),
+	})
+}
+
+// handleAdopt hands the SMB settings — password included — to a TV that already
+// holds the pairing token, so the share is typed once here rather than six
+// fields at a time on a remote.
+//
+// The honest trust model: the token is readable from /api/status by anything on
+// the LAN, so this is "the LAN is trusted", not "this is authenticated". That's
+// the posture the box has always had, and the TV stores the same credentials
+// unencrypted anyway — but it's a deliberate widening, so it's a setting the
+// user can turn off.
+func (s *Server) handleAdopt(w http.ResponseWriter, r *http.Request) {
+	if !s.guard(w, r) {
+		return
+	}
+	if !s.cfg.CanShareCredentials() {
+		writeJSON(w, map[string]any{"ok": false, "error": "the server is set not to share its share settings"})
+		return
+	}
+	if !s.cfg.Configured() {
+		writeJSON(w, map[string]any{"ok": false, "error": "no share configured on the server yet"})
+		return
+	}
+	if s.adoptSecondsLeft() == 0 {
+		writeJSON(w, map[string]any{"ok": false, "error": "the pairing window has closed — press \"Allow pairing\" on the server's setup page, or restart the box, then try again"})
+		return
+	}
+	writeJSON(w, map[string]any{"ok": true, "smb": s.cfg.SMB})
+}
+
+// handleAllowAdopt reopens the window from the setup page. Token-gated like
+// every other write — and reachable, because the page reads that token off
+// /api/status, which the window never touches.
+func (s *Server) handleAllowAdopt(w http.ResponseWriter, r *http.Request) {
+	if !s.guard(w, r) {
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "method", http.StatusMethodNotAllowed)
+		return
+	}
+	s.openAdoptWindow()
+	writeJSON(w, map[string]any{"ok": true, "seconds": s.adoptSecondsLeft()})
+}
+
 // handlePair publishes this server's LAN URL + token to the TV's pairing topic.
 // The user enters the code shown on the TV; the TV then pulls the announcement.
 func (s *Server) handlePair(w http.ResponseWriter, r *http.Request) {
+	if !s.guard(w, r) {
+		return
+	}
 	if r.Method != http.MethodPost {
 		http.Error(w, "method", http.StatusMethodNotAllowed)
 		return

--- a/vlc-transcode-server/internal/web/static/app.js
+++ b/vlc-transcode-server/internal/web/static/app.js
@@ -3,6 +3,23 @@
 
 const $ = (id) => document.getElementById(id);
 let anon = false;
+let localRelay = false;
+let adopt = true;
+
+// Every /api endpoint except /api/hello and /api/status needs the pairing
+// token. This page is served by the same box, so it just reads the token off
+// /api/status like a TV would; see the note on guard() in server.go for what
+// that check is and isn't worth.
+let token = '';
+let lastAdoptLeft = 0;   // so the switch can repaint the window line without a fetch
+const api = (path) => path + (token ? (path.includes('?') ? '&' : '?') + 'token=' + encodeURIComponent(token) : '');
+
+// Human labels for the read-only playback pills.
+const SURROUND_LABEL = {
+  off:  'off — stereo out',
+  eac3: 'Dolby Digital Plus 5.1',
+  ac3:  'Dolby Digital 5.1',
+};
 
 function setMsg(text, kind) {
   const m = $('msg');
@@ -13,6 +30,32 @@ function setMsg(text, kind) {
 function paintAnon() {
   $('anon').classList.toggle('on', anon);
   $('creds').style.opacity = anon ? .4 : 1;
+}
+
+function paintLocalRelay() {
+  $('localrelay').classList.toggle('on', localRelay);
+}
+
+function paintAdopt() {
+  $('adopt').classList.toggle('on', adopt);
+}
+
+// The share password is only on offer inside the window; say plainly whether a
+// TV pairing right now would get it.
+function paintAdoptWindow(secondsLeft) {
+  const el = $('adopt-state');
+  if (!adopt)          { el.textContent = 'switched off — the TV will never get these'; return; }
+  if (secondsLeft <= 0) { el.textContent = 'closed — a TV pairing now must be given the share by hand'; return; }
+  const mins = Math.ceil(secondsLeft / 60);
+  el.textContent = 'open for another ' + (mins === 1 ? 'minute' : mins + ' minutes');
+}
+
+async function allowAdopt() {
+  const r = await fetch(api('/api/allow-adopt'), { method: 'POST' });
+  if (!r.ok) { setMsg('Could not reopen the pairing window.', 'err'); return; }
+  const j = await r.json();
+  paintAdoptWindow(j.seconds || 0);
+  setMsg('Pairing window open — pair the TV now.', 'ok');
 }
 
 // Format a UTC ISO timestamp as "just now / N min ago / today at HH:MM /
@@ -39,10 +82,17 @@ function formatAgo(iso) {
 async function loadStatus() {
   try {
     const s = await (await fetch('/api/status')).json();
+    token = s.token || '';
     $('st-enc').textContent = s.encoder || '—';
     $('st-hw').textContent = s.hwaccel === 'none' ? 'software' : (s.hwaccel || '—');
     $('st-share').textContent = s.configured ? s.share : 'not configured';
+    $('pb-surround').textContent = SURROUND_LABEL[s.surround] || SURROUND_LABEL.off;
+    $('pb-relay').textContent = s.localRelay ? 'accepted' : 'not accepted';
+    lastAdoptLeft = s.adoptLeft || 0;
+    paintAdoptWindow(lastAdoptLeft);
     $('st-url').textContent = s.serverURL || '—';
+    // The address to type on the TV when the LAN scan can't reach this box.
+    $('pair-addr').textContent = s.serverURL ? s.serverURL.replace(/^https?:\/\//, '') : "this box's address";
     $('hdot').style.background = s.configured ? 'var(--ok)' : 'var(--mut)';
     if (s.configured && s.serverURL && s.token) {
       $('testcard').style.display = '';
@@ -66,7 +116,7 @@ async function pair() {
   const code = $('code').value.trim();
   if (!code) { $('pairmsg').textContent = 'Enter the code shown on the TV.'; $('pairmsg').className = 'msg err'; return; }
   $('pairmsg').textContent = 'Pairing…'; $('pairmsg').className = 'msg';
-  const res = await (await fetch('/api/pair', {
+  const res = await (await fetch(api('/api/pair'), {
     method: 'POST', headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ code }),
   })).json();
@@ -82,7 +132,7 @@ async function pair() {
 }
 
 async function loadConfig() {
-  const c = await (await fetch('/api/config')).json();
+  const c = await (await fetch(api('/api/config'))).json();
   const smb = c.smb || c.SMB || {};
   $('host').value = smb.host || '';
   $('port').value = smb.port || 445;
@@ -91,6 +141,17 @@ async function loadConfig() {
   $('domain').value = smb.domain || '';
   anon = !!smb.anonymous;
   paintAnon();
+  localRelay = !!c.local_relay;
+  paintLocalRelay();
+  adopt = c.share_credentials !== false;
+  paintAdopt();
+}
+
+// Status carries the token, so it has to land before anything else is fetched.
+async function boot() {
+  await loadStatus();
+  await loadConfig();
+  setInterval(loadStatus, 5000);
 }
 
 function readForm() {
@@ -102,29 +163,51 @@ function readForm() {
     pass: $('pass').value,        // blank = keep stored
     domain: $('domain').value.trim(),
     anonymous: anon,
+    share_credentials: adopt,
   };
 }
 
-async function save() {
-  const r = await fetch('/api/config', {
+async function postConfig(body) {
+  return fetch(api('/api/config'), {
     method: 'POST', headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(readForm()),
+    body: JSON.stringify(body),
   });
+}
+
+async function save() {
+  const r = await postConfig(readForm());
   if (r.ok) { setMsg('Saved.', 'ok'); $('pass').value = ''; loadStatus(); }
   else setMsg('Save failed.', 'err');
+}
+
+// Posts only the relay permission — the server applies just the keys it's sent,
+// so this can't disturb the share settings sitting in the form above.
+async function savePlayback() {
+  const m = $('pbmsg');
+  const r = await postConfig({ local_relay: localRelay });
+  if (r.ok) {
+    m.textContent = localRelay
+      ? 'Saved. The TV may now send files from its USB drive.'
+      : 'Saved. The box will only read from the share again.';
+    m.className = 'msg ok';
+    loadStatus();
+  } else {
+    m.textContent = 'Save failed.';
+    m.className = 'msg err';
+  }
 }
 
 async function test() {
   setMsg('Testing…');
   await save();
-  const res = await (await fetch('/api/test', { method: 'POST' })).json();
+  const res = await (await fetch(api('/api/test'), { method: 'POST' })).json();
   if (res.ok) setMsg('Connected to the share ✓', 'ok');
   else setMsg('Could not connect: ' + (res.error || 'unknown'), 'err');
 }
 
 async function browse(path) {
   setMsg('Loading ' + (path || 'root') + '…');
-  const res = await (await fetch('/api/browse?path=' + encodeURIComponent(path || ''))).json();
+  const res = await (await fetch(api('/api/browse?path=' + encodeURIComponent(path || '')))).json();
   const ul = $('list');
   ul.innerHTML = '';
   if (!res.ok) { setMsg('Browse failed: ' + (res.error || 'unknown'), 'err'); return; }
@@ -151,11 +234,13 @@ async function browse(path) {
 }
 
 $('anon').onclick = () => { anon = !anon; paintAnon(); };
+$('localrelay').onclick = () => { localRelay = !localRelay; paintLocalRelay(); };
+$('adopt').onclick = () => { adopt = !adopt; paintAdopt(); paintAdoptWindow(lastAdoptLeft); };
+$('allow-adopt').onclick = allowAdopt;
+$('save-playback').onclick = savePlayback;
 $('save').onclick = save;
 $('test').onclick = test;
 $('browse').onclick = async () => { await save(); browse(''); };
 $('pair').onclick = pair;
 
-loadConfig();
-loadStatus();
-setInterval(loadStatus, 5000);
+boot();

--- a/vlc-transcode-server/internal/web/static/index.html
+++ b/vlc-transcode-server/internal/web/static/index.html
@@ -89,6 +89,21 @@
       </div>
       <label>Password</label><input type="password" id="pass" placeholder="••••••• (blank = unchanged)">
     </div>
+    <div class="toggle" style="margin-top:14px">
+      <span>Let a paired TV copy these settings</span>
+      <div class="switch" id="adopt"><i></i></div>
+    </div>
+    <p class="sub" style="margin:8px 0 0">
+      Saves typing the share, username and password again on a TV remote — the TV
+      pulls them from here when it pairs. They're only on offer for ten minutes
+      after this box starts, after you save the share, or after you press the
+      button below; outside that window the password isn't handed out at all.
+      Turn the switch off to never hand it out.
+    </p>
+    <div class="bar">
+      <button class="ghost" id="allow-adopt">Allow pairing for 10 minutes</button>
+      <span class="sub" id="adopt-state" style="align-self:center">…</span>
+    </div>
     <div class="bar">
       <button class="primary" id="save">Save</button>
       <button class="ghost" id="test">Test connection</button>
@@ -99,13 +114,59 @@
   </div>
 
   <div class="card">
-    <h2>Pair with TV</h2>
-    <p class="sub" style="margin:0 0 10px">On the TV: <b>Settings → Transcode server → Pair</b>. Enter the code it shows here.</p>
-    <div class="row">
-      <div><label>TV pairing code</label><input type="text" id="code" placeholder="e.g. 7gk2p9qx1m"></div>
-      <div style="flex:0 0 auto;display:flex;align-items:flex-end"><button class="primary" id="pair">Pair</button></div>
+    <h2>Playback</h2>
+    <p class="sub" style="margin:0 0 12px">
+      Playback settings live on the TV, under
+      <b>Settings → Transcode server</b> — that's where you are when you notice the
+      sound is wrong. They're shown here so you can see what the box is doing.
+    </p>
+    <div class="kv"><span>Surround sound</span><span class="pill" id="pb-surround">…</span></div>
+    <div class="kv"><span>USB files from the TV</span><span class="pill" id="pb-relay">…</span></div>
+
+    <div class="toggle" style="margin-top:16px">
+      <span>Allow the TV to send USB / internal files</span>
+      <div class="switch" id="localrelay"><i></i></div>
     </div>
-    <div class="msg" id="pairmsg"></div>
+    <p class="sub" style="margin:8px 0 0">
+      A paired TV turns this on for itself when you enable
+      <b>Play USB files through the server</b> there. Switch it off here to revoke
+      that — the box will stop accepting files from the TV and go back to reading
+      only from the share.
+    </p>
+    <div class="bar">
+      <button class="primary" id="save-playback">Save</button>
+    </div>
+    <div class="msg" id="pbmsg"></div>
+  </div>
+
+  <div class="card">
+    <h2>Pair with TV</h2>
+    <p class="sub" style="margin:0 0 6px">
+      Nothing to do here. On the TV, open
+      <b>Settings → Transcode server → Find server on my network</b> — it sweeps
+      your LAN, finds this box, pairs, and copies the share settings above.
+    </p>
+    <p class="sub" style="margin:0 0 14px">
+      If the scan comes up empty (guest Wi-Fi, VLANs, a subnet wider than /22),
+      pick <b>Enter server address</b> on the TV and type
+      <b id="pair-addr">this box's address</b>.
+    </p>
+
+    <details>
+      <summary style="cursor:pointer;color:var(--mut);font-size:13px">Pair with a code instead</summary>
+      <p class="sub" style="margin:10px 0">
+        The original method, kept for networks where the TV can't reach this box
+        directly. It relays through ntfy.sh, so it needs internet on both ends.
+        On the TV: <b>Settings → Transcode server → Pair with a code</b>, then
+        type the code it shows here <i>before</i> pressing Pair on the TV.
+      </p>
+      <div class="row">
+        <div><label>TV pairing code</label><input type="text" id="code" placeholder="e.g. 7gk2p9qx1m"></div>
+        <div style="flex:0 0 auto;display:flex;align-items:flex-end"><button class="primary" id="pair">Pair</button></div>
+      </div>
+      <div class="msg" id="pairmsg"></div>
+    </details>
+
     <!-- Persisted across restarts so the user can see "yes, a TV is paired"
          rather than wondering if they need to re-pair after every upgrade. -->
     <p class="sub" id="lastpair" style="margin:8px 0 0;display:none"></p>

--- a/vlc-transcode-server/main.go
+++ b/vlc-transcode-server/main.go
@@ -59,7 +59,7 @@ func main() {
 	// The manager needs to know how to build the localhost raw-bridge URL, which
 	// lives in the web layer — wire it after constructing the server.
 	srv := web.New(cfg, smbClient, nil, port)
-	mgr, err := transcode.NewManager(caps, workDir, srv.RawURL)
+	mgr, err := transcode.NewManager(caps, workDir, srv.RawURL, func() string { return cfg.Surround })
 	if err != nil {
 		log.Fatalf("manager: %v", err)
 	}


### PR DESCRIPTION
Closes #63.

**This touches both halves of the repo** — the Tizen app (`tizen-web-vlc/`) and the transcode server (`vlc-transcode-server/`) — and they need releasing together. A new app talking to an old server refuses to drive it (see *Compatibility* below), so nothing breaks, but nothing new works either until both are out.

## Why 5.1 arrives as stereo

The reporter plays FLAC 5.1 and the soundbar gets PCM 2.0. That isn't the app downmixing.

HDMI-ARC and optical carry either LPCM or an IEC 61937-framed bitstream, and only Dolby Digital and DD+ have that framing here. Everything else the TV decodes itself, and plain ARC can only carry two channels of the resulting LPCM. FLAC has no bitstream form at all, on any device — an external player that "sends FLAC 5.1 to the soundbar" is decoding it and sending multichannel LPCM over a link that can carry it.

On top of that AVPlay exposes no channel-layout or passthrough control, so no version of this app can fix it on the TV. Re-encoding upstream can, which is what the transcode server is for.

## What changed

### Surround (the fix)

`decide.go` conflated *"the TV can decode this"* with *"the TV can pass this on"*. Those are different sets — AAC 5.1 is perfectly decodable, so it was copied, and landed on the soundbar as stereo for exactly the same reason FLAC did.

Added a `bitstreamOK` set and a surround policy, set from the TV under **Settings → Transcode server → Surround sound**:

| Setting | Effect |
|---|---|
| Off (default) | Unchanged behaviour — only audio the TV can't decode is touched |
| Dolby Digital Plus 5.1 | Multichannel tracks that aren't already AC-3/E-AC-3 → E-AC-3 @ 768k |
| Dolby Digital 5.1 | Same, targeting AC-3 @ 640k, for receivers that won't take DD+ |

Tracks that are already AC-3/E-AC-3 are copied untouched; stereo is never re-encoded. Session ids now include the policy so flipping it doesn't serve the stale stereo session.

It's a lossy re-encode — you keep the channels, not FLAC's bit-exactness. There is no route that keeps both; the TV cannot pass lossless multichannel to a soundbar. The audio-track picker now labels affected tracks **"TV downmixes to stereo"**, so they're distinguishable from ones the TV can't decode at all.

### USB and internal-storage files

Those files sit at the TV, so the box couldn't reach them and they missed out on surround *and* codec handling. The direction is now reversed for them: the app's background service opens a LAN listener and the box fetches from it via `/play?src=`.

That listener is a **second** `http.Server`, deliberately not another route on the loopback one — that one carries your SMB credentials, and none of it should become LAN-reachable just because someone wants to play a USB file. Three gates: armed only over loopback, a random per-TV key, and paths restricted to the roots `tizen.filesystem` itself reported. Server-side, `src=` must name a private LAN address, so the pairing token can't be turned into a general fetch primitive.

### Pairing without a code

Reading a random code off one screen into another, relayed through a public ntfy topic, to link two boxes on the same switch — and needing internet to do it. Replaced with a LAN sweep: the service knows its own address and netmask, TCP-probes the subnet, then asks `/api/hello` only on what answered. Wider than /22 is refused in favour of typing the address.

The two ends then settle the share between them, whichever one already knows it:

| Situation | What happens |
|---|---|
| Box has a share configured | TV copies it down |
| Box is fresh, TV already had SMB working | TV sends it up |
| Neither | Fill it in either side; **Send my share settings to the server** pushes it later |

So if your TV already browses your NAS, you never open the setup page: install the box, press *Find server on my network*, done. Manual address entry and the old code flow both remain as fallbacks.

Playback settings moved to the TV, where you actually are when you notice the sound is wrong. The page keeps status, first-run setup, and the two permissions that genuinely belong to the box.

## Hardening found along the way

- **`POST /api/config` replaced the whole SMB block** from whatever body it got. A TV sending `{"surround":"eac3"}` would have wiped host, share and password. It now applies only the keys the body actually carries.
- **Everything under `/api`** except `/api/hello` and `/api/status` now requires the pairing token. Being straight about what that's worth: `/api/status` is where a TV *reads* that token, so anything on the LAN can read it too. This stops accidents — another tool poking a URL it found, a stray script, a forgotten tab — not a determined device. Documented that way rather than dressed up.
- **The share password sits behind more than the token.** `/api/adopt` only answers for ten minutes after the box starts, after the share is saved, or after an explicit *Allow pairing* press. Locking the token to the first device instead would have bricked the setup page, which needs that same token for the very button that lets a second device in — a window has no such dead end, and already-paired TVs never ask again so they're unaffected.
- **`/raw` claimed to be loopback-only in a comment but never checked.** Anyone on the LAN could read any file on the share by guessing paths. Now enforced on `RemoteAddr`.

## Compatibility

- **New server + old app** — fine. Code pairing and `/play?path=` are unchanged.
- **New app + old server** — the app refuses to drive it ("this transcode server is too old for that — update it and pair again"). This matters: old servers replace their whole SMB block on any config POST, so a bare `{"surround":...}` would have wiped the user's share settings. Verified against a stand-in old server that its config survives untouched.
- Already-paired TVs keep working across all of it; they stored the settings when they paired and never ask again.

## Testing

No Samsung TV in the loop, so everything testable was tested off-device:

- `decide_test.go` — the FLAC / AAC / AC-3 / DTS / 7.1 / no-audio / bad-mode matrix, plus that video handling is independent of the audio policy and that session ids include it.
- `validateRelayURL` and `isLoopback` tables — loopback, unspecified, public IPs, hostnames, non-HTTP schemes.
- Subnet enumeration against /24, /22, /30, and that /20 and /16 are refused. **This caught a real bug:** JS bitwise operators are signed 32-bit, so `192.168.1.37 & 255.255.255.0` went negative and the sweep would have probed `193.169.2.x`.
- Ran the real `service.js` in Node with a faked interface and a real server alongside: discovery finds it, `/api/hello` matches, `/api/adopt` delivers.
- Drove the real `server.js` (XHR shim) through the whole negotiation: push when the box is empty, adopt when it isn't, surround and relay patches that leave the share untouched, and both connect-error branches.
- Adopt window lifecycle with the constant temporarily at 3s: open on start, reopened by saving the share, closed on expiry with the right error, reopened by the button, 403 without a token — and confirmed a `{"surround":...}` patch does *not* reopen it.
- Existing suites: `go build`, `go vet`, `go test`, and `mp4-subs.test.js` (5/5).

**Not verified:** binding `0.0.0.0` from a Tizen service app. The Node runtime there isn't WebView-sandboxed and already opens outbound sockets, so it should work, but it needs a real TV. It fails soft — a toast and direct playback, never a broken player.

## Also in here

A separate one-line fix, committed on its own: **the TV's pairing code was regenerated on every app launch.** `urlDropCode` wasn't listed in `Settings.defaults`, and `load()` rebuilds its cache from that object, so the stored code was dropped on read. Every phone that had scanned the QR was posting to a dead ntfy topic. Reproduced by running the real `settings.js` + `url-drop.js` through two simulated launches; codes already stored are preserved by the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
