### PR TITLE
Stop transcode-server releases from taking the "Latest" badge

### DIFF
--- a/.github/workflows/transcode-server-native.yml
+++ b/.github/workflows/transcode-server-native.yml
@@ -140,3 +140,8 @@ jobs:
           tag_name: ${{ github.ref_name }}
           # Don't overwrite the body/title the maintainer set on the tag.
           generate_release_notes: false
+          # The "Latest" badge belongs to the TV app — that's what people come
+          # to the releases page for. Without this, GitHub hands it to whatever
+          # was published most recently, so every transcode-v* tag quietly stole
+          # it from the .wgt release.
+          make_latest: false


### PR DESCRIPTION
Tagging `transcode-v1.4.0` moved the **Latest** badge off the TV app and onto the server binaries — GitHub marks the most recently published release as Latest unless the release step says otherwise, and ours didn't.

The releases page is where people go for the `.wgt`. The transcode server is a companion download and shouldn't outrank it, so `make_latest: false` pins the badge to whatever `build-wgt.yml` published.

I've already moved the badge back by hand on the current releases; this stops it recurring on the next `transcode-v*` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)