### PR TITLE
Vietnamese subtitles, an aspect-ratio control, and a scrollable track menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ with VLC-inspired UI and TV remote-friendly navigation.
   embedded MP4/MKV text tracks, painted by the app (AVPlay can't render text
   subs on this firmware), with **customisable size, font, position and
   background** under Settings → Subtitle appearance
+- **Aspect ratio / zoom** — fit, fill (crop the sides), 110% / 125% zoom for
+  bars burned into the picture, or stretch; from the OSD button or
+  Settings → Video aspect ratio
 - **No native code** — pure HTML/CSS/JS so it runs on any Tizen TV with a
   Public-tier developer cert. No partner-cert or platform-side requirements.
 

--- a/tests/tizen-web-vlc/language-match.test.js
+++ b/tests/tizen-web-vlc/language-match.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+var assert = require('assert');
+var test = require('node:test');
+var Settings = require('../../tizen-web-vlc/js/settings.js');
+var LanguageList = Settings.LanguageList;
+var AspectRatio  = Settings.AspectRatio;
+
+function codes(list) { return list.map(function (l) { return l.code; }); }
+
+/* ── The picker lists ─────────────────────────────────────────────────── */
+
+test('Vietnamese is offered for both audio and subtitles', function () {
+    assert.ok(codes(LanguageList.forAudio()).indexOf('vi') >= 0);
+    assert.ok(codes(LanguageList.forSubtitle()).indexOf('vi') >= 0);
+    assert.strictEqual(LanguageList.nameFor('vi'), 'Tiếng Việt');
+});
+
+test('the subtitle list keeps Off in front of the languages', function () {
+    assert.strictEqual(LanguageList.forSubtitle()[0].code, 'off');
+    assert.strictEqual(LanguageList.nameFor('off'), 'Off');
+});
+
+/* ── matchScore ───────────────────────────────────────────────────────── */
+
+test('a language tag wins outright, in either ISO spelling', function () {
+    assert.strictEqual(LanguageList.matchScore('vi', 'vie', 'Subtitle 3'), 100);
+    assert.strictEqual(LanguageList.matchScore('vi', 'vi',  'Subtitle 3'), 100);
+    assert.strictEqual(LanguageList.matchScore('vi', 'vi-VN', 'Subtitle 3'), 100);
+    assert.strictEqual(LanguageList.matchScore('de', 'ger', 'Track 2'), 100);
+    assert.strictEqual(LanguageList.matchScore('nl', 'dut', 'Track 2'), 100);
+});
+
+test('untagged tracks match on the spelled-out name', function () {
+    assert.ok(LanguageList.matchScore('vi', '', 'Vietnamese (SDH)') > 0);
+    assert.ok(LanguageList.matchScore('vi', '', 'Tiếng Việt') > 0);
+    assert.ok(LanguageList.matchScore('zh', '', '简体中文') > 0);
+    assert.ok(LanguageList.matchScore('ko', '', 'Korean forced') > 0);
+});
+
+test('a bracketed code counts, and beats a bare word match', function () {
+    var bracketed = LanguageList.matchScore('fr', '', 'Subtitle [fre]');
+    var word      = LanguageList.matchScore('fr', '', 'French subtitles');
+    assert.ok(bracketed > 0 && word > 0);
+    assert.ok(bracketed > word);
+});
+
+test('a two-letter code matches only as its own word', function () {
+    // The bug this guards: "Movie.2019.1080p" is not a Vietnamese track.
+    assert.strictEqual(LanguageList.matchScore('vi', '', 'Movie.2019.1080p'), 0);
+    assert.ok(LanguageList.matchScore('vi', '', 'Show.S01E02.vi.srt') > 0);
+});
+
+test('a mismatched language scores nothing', function () {
+    assert.strictEqual(LanguageList.matchScore('vi', 'eng', 'English'), 0);
+    assert.strictEqual(LanguageList.matchScore('en', 'vie', 'Tiếng Việt'), 0);
+});
+
+test('no preference and Off never match a track', function () {
+    assert.strictEqual(LanguageList.matchScore('',    'vie', 'Vietnamese'), 0);
+    assert.strictEqual(LanguageList.matchScore('off', 'vie', 'Vietnamese'), 0);
+});
+
+/* ── Aspect modes ─────────────────────────────────────────────────────── */
+
+test('fit is the default aspect mode and keeps the letterbox', function () {
+    var fit = AspectRatio.find('fit');
+    assert.strictEqual(AspectRatio.forList()[0].code, 'fit');
+    assert.strictEqual(fit.av, 'PLAYER_DISPLAY_MODE_LETTER_BOX');
+    assert.strictEqual(fit.fit, 'contain');
+    assert.strictEqual(fit.zoom, 1);
+});
+
+test('fill crops instead of distorting, stretch distorts', function () {
+    assert.strictEqual(AspectRatio.find('fill').av, 'PLAYER_DISPLAY_MODE_CROPPED_FULL');
+    assert.strictEqual(AspectRatio.find('fill').fit, 'cover');
+    assert.strictEqual(AspectRatio.find('stretch').av, 'PLAYER_DISPLAY_MODE_FULL_SCREEN');
+    assert.strictEqual(AspectRatio.find('stretch').fit, 'fill');
+});
+
+test('the zoom modes scale past the frame edge', function () {
+    assert.ok(AspectRatio.find('zoom110').zoom > 1);
+    assert.ok(AspectRatio.find('zoom125').zoom > AspectRatio.find('zoom110').zoom);
+});
+
+test('an unknown mode falls back to fit, and next() cycles', function () {
+    assert.strictEqual(AspectRatio.find('nonsense').code, 'fit');
+    var seen = {}, code = 'fit';
+    for (var i = 0; i < AspectRatio.forList().length; i++) {
+        assert.ok(!seen[code], 'cycle repeats before visiting every mode');
+        seen[code] = true;
+        code = AspectRatio.next(code);
+    }
+    assert.strictEqual(code, 'fit', 'cycle returns to the start');
+    // Every mode carries an OSD label short enough for the round button.
+    AspectRatio.forList().forEach(function (m) {
+        assert.ok(m.short.length <= 4, m.code + ' label too long: ' + m.short);
+    });
+});

--- a/tizen-web-vlc/css/style.css
+++ b/tizen-web-vlc/css/style.css
@@ -588,9 +588,30 @@ button:focus { outline: none; }
     padding: 32px;
     min-width: 480px;
     max-width: 600px;
+    /* Grows upward from bottom:240px, so cap it well short of the top of
+     * the screen.  Rips with 20+ subtitle tracks used to push the first
+     * entries off-screen where the D-pad could reach them but nothing was
+     * visible; the list now scrolls inside .track-menu-body instead. */
+    max-height: calc(100vh - 320px);
+    display: flex;
+    flex-direction: column;
     box-shadow: var(--shadow);
     pointer-events: auto;
     text-align: left;
+}
+.track-menu-body {
+    flex: 1 1 auto;
+    min-height: 0;              /* required for a flex child to actually scroll */
+    overflow-y: auto;
+    /* Room for the focus ring on the right-hand edge of a focused row. */
+    padding-right: 6px;
+}
+/* The scrollbar is decoration on a TV — nobody drags it — but a visible
+ * track is the only cue that there's more list below. */
+.track-menu-body::-webkit-scrollbar { width: 8px; }
+.track-menu-body::-webkit-scrollbar-thumb {
+    background: var(--bg-3);
+    border-radius: 4px;
 }
 .track-menu h2 {
     margin: 0 0 20px;
@@ -637,9 +658,14 @@ button:focus { outline: none; }
     margin: 0 4px;
 }
 
-/* ── Repeat / shuffle buttons (active state highlight) ───────────── */
+/* Word/percentage labels ("Fit", "125%") in the round OSD buttons need a
+ * smaller type size than the glyph controls to stay inside the circle. */
+.ctrl.ctrl-text { font-size: 18px; }
+
+/* ── Repeat / shuffle / aspect buttons (active state highlight) ──── */
 .ctrl.repeat-on,
-.ctrl.shuffle-on {
+.ctrl.shuffle-on,
+.ctrl.aspect-on {
     color: var(--accent);
     background: var(--accent-soft);
 }

--- a/tizen-web-vlc/index.html
+++ b/tizen-web-vlc/index.html
@@ -156,7 +156,8 @@
             <button class="ctrl" data-action="forward">⏩</button>
             <button class="ctrl" data-action="next" id="btn-next" title="Next">⏭</button>
             <button class="ctrl" data-action="open-track-menu">CC</button>
-            <button class="ctrl" data-action="open-speed-picker" id="btn-speed" title="Playback speed">1×</button>
+            <button class="ctrl ctrl-text" data-action="open-speed-picker" id="btn-speed" title="Playback speed">1×</button>
+            <button class="ctrl ctrl-text" data-action="open-aspect-picker" id="btn-aspect" title="Aspect ratio / zoom">Fit</button>
             <button class="ctrl" data-action="toggle-repeat" id="btn-repeat" title="Repeat">↻</button>
             <button class="ctrl" data-action="toggle-shuffle" id="btn-shuffle" title="Shuffle">🔀</button>
             <span class="ctrl-sep" aria-hidden="true"></span>
@@ -167,13 +168,18 @@
     <!-- Track selection overlay -->
     <div class="track-menu hidden" id="track-menu">
         <h2>Tracks</h2>
-        <div class="track-section">
-            <h3>Audio</h3>
-            <ul id="audio-tracks"></ul>
-        </div>
-        <div class="track-section">
-            <h3>Subtitle</h3>
-            <ul id="subtitle-tracks"></ul>
+        <!-- The lists scroll inside this box: a Netflix-style rip can carry
+             20+ subtitle tracks, and an unbounded menu grew straight off the
+             top of the screen with the extra entries unreachable. -->
+        <div class="track-menu-body" id="track-menu-body">
+            <div class="track-section">
+                <h3 id="audio-tracks-title">Audio</h3>
+                <ul id="audio-tracks"></ul>
+            </div>
+            <div class="track-section">
+                <h3 id="subtitle-tracks-title">Subtitle</h3>
+                <ul id="subtitle-tracks"></ul>
+            </div>
         </div>
         <button class="btn ghost" data-action="close-track-menu" data-focus>Close</button>
     </div>
@@ -215,6 +221,10 @@
             <button class="settings-row" data-action="setting-shuffle">
                 <div class="settings-label">Shuffle playlist</div>
                 <div class="settings-value" id="setting-shuffle-value">Off</div>
+            </button>
+            <button class="settings-row" data-action="setting-aspect-mode">
+                <div class="settings-label">Video aspect ratio</div>
+                <div class="settings-value" id="setting-aspect-mode-value">Fit screen (keep black bars)</div>
             </button>
         </div>
 

--- a/tizen-web-vlc/js/app.js
+++ b/tizen-web-vlc/js/app.js
@@ -309,6 +309,7 @@
         UI.showView('view-home');
         updateRepeatButton();        // reflect saved repeat preference on OSD
         updateShuffleButton();       // reflect saved shuffle preference on OSD
+        updateAspectButton();        // reflect saved aspect/zoom mode on OSD
         SubtitleStyle.apply();       // push saved subtitle appearance onto the overlay
     }
 
@@ -340,6 +341,7 @@
             case 'toggle-repeat':      toggleRepeat(); break;
             case 'toggle-shuffle':     toggleShuffle(); break;
             case 'open-speed-picker':  openSpeedPicker(); break;
+            case 'open-aspect-picker': openAspectPicker(); break;
             case 'open-track-menu':    openTrackMenu(); break;
             case 'close-track-menu':   closeTrackMenu(); break;
             case 'setting-audio-lang':    openLangPicker('audioLang',    'Preferred audio language', LanguageList.forAudio());    break;
@@ -347,6 +349,7 @@
             case 'setting-repeat-mode':   openRepeatPicker(); break;
             case 'setting-auto-play':     openAutoPlayPicker(); break;
             case 'setting-shuffle':       openShufflePicker(); break;
+            case 'setting-aspect-mode':   openAspectPicker(); break;
             case 'setting-subtitle-size':     openSubtitlePicker('subtitleSize',     'Subtitle size',       SubtitleStyle.forSize());     break;
             case 'setting-subtitle-font':     openSubtitlePicker('subtitleFont',     'Subtitle font',       SubtitleStyle.forFont());     break;
             case 'setting-subtitle-position': openSubtitlePicker('subtitlePosition', 'Subtitle position',   SubtitleStyle.forPosition()); break;
@@ -1110,12 +1113,14 @@
         document.getElementById('setting-repeat-mode-value').textContent   = (Settings.get('repeatMode') === 'one') ? 'Repeat one' : 'Off';
         document.getElementById('setting-auto-play-value').textContent     = Settings.get('autoPlay') ? 'On' : 'Off';
         document.getElementById('setting-shuffle-value').textContent       = Settings.get('shuffle')  ? 'On' : 'Off';
+        document.getElementById('setting-aspect-mode-value').textContent   = AspectRatio.nameFor(Settings.get('aspectMode'));
         document.getElementById('setting-subtitle-size-value').textContent     = SubtitleStyle.nameForSize(Settings.get('subtitleSize'));
         document.getElementById('setting-subtitle-font-value').textContent     = SubtitleStyle.nameForFont(Settings.get('subtitleFont'));
         document.getElementById('setting-subtitle-position-value').textContent = SubtitleStyle.nameForPosition(Settings.get('subtitlePosition'));
         document.getElementById('setting-subtitle-bg-value').textContent       = SubtitleStyle.nameForBg(Settings.get('subtitleBg'));
-        // Mirror repeat state to the OSD button if visible
+        // Mirror repeat + aspect state to the OSD buttons if visible
         updateRepeatButton();
+        updateAspectButton();
     }
     function renderTvInfo() {
         var box  = document.getElementById('tvinfo');
@@ -1268,6 +1273,30 @@
         if (Player.isSpeedMuted && Player.isSpeedMuted()) label += ' 🔇';
         btn.textContent = label;
     }
+    /* Video aspect / zoom (user request: "remove the black bars").  Unlike
+     * playback speed this IS persisted — someone who wants a filled screen
+     * wants it for every file, not just the one that's open.  Applying it
+     * mid-playback is safe on both backends, so the OSD button and the
+     * settings row share this one picker. */
+    function openAspectPicker() {
+        var cur = Settings.get('aspectMode');
+        openPicker('Video aspect ratio', AspectRatio.forList(), cur, function (val) {
+            Settings.set('aspectMode', val);
+            Player.applyAspect();
+            updateAspectButton();
+            refreshSettingsValues();
+            UI.toast('Aspect: ' + AspectRatio.nameFor(val));
+        });
+    }
+    function updateAspectButton() {
+        var btn = document.getElementById('btn-aspect');
+        if (!btn) return;
+        var mode = Settings.get('aspectMode');
+        btn.textContent = AspectRatio.shortFor(mode);
+        // Highlight whenever the picture is NOT in the default fit mode, so
+        // a cropped/stretched picture is never a mystery.
+        btn.classList.toggle('aspect-on', mode !== 'fit');
+    }
     function openAutoPlayPicker() {
         pickerSetting = 'autoPlay';
         var cur = Settings.get('autoPlay') ? 'on' : 'off';
@@ -1336,11 +1365,24 @@
     }
 
     /* ── Track menu ───────────────────────────────────────────────── */
+    /* "Audio" / "Subtitle (23)" — the count is what tells a user with a
+     * 20-track rip that the list they're looking at is complete and simply
+     * scrolls, rather than truncated. */
+    function setTrackSectionTitle(id, label, count) {
+        var h = document.getElementById(id);
+        if (h) h.textContent = count > 1 ? (label + ' (' + count + ')') : label;
+    }
     function openTrackMenu() {
         var t = Player.getTracks();
         var aUL = document.getElementById('audio-tracks');
         var sUL = document.getElementById('subtitle-tracks');
         aUL.innerHTML = ''; sUL.innerHTML = '';
+        setTrackSectionTitle('audio-tracks-title', 'Audio', t.audio.length);
+        // Count only real, selectable tracks: not the synthetic "Off" row and
+        // not the "+N can't be drawn" note.
+        var subCount = 0;
+        t.subtitle.forEach(function (tr) { if (!tr.off && !tr.muted) subCount++; });
+        setTrackSectionTitle('subtitle-tracks-title', 'Subtitle', subCount);
 
         if (!t.audio.length) {
             aUL.innerHTML = '<li class="muted">Only one audio track</li>';
@@ -1363,6 +1405,10 @@
             var li = document.createElement('li');
             li.textContent = tr.name;
             if (tr.active) li.classList.add('active');
+            // Informational rows (e.g. "+3 embedded tracks this TV can't
+            // draw") are shown but not selectable — .muted keeps them out of
+            // the focus order too.
+            if (tr.muted) { li.classList.add('muted'); sUL.appendChild(li); return; }
             li.addEventListener('click', function () {
                 Player.setSubtitleTrack(tr.off ? -1 : tr.index);
                 UI.toast('Subtitle: ' + tr.name);
@@ -1559,12 +1605,10 @@
         var pref = (Settings.get('audioLang') || '').toLowerCase();
         function langMatches(t) {
             if (!pref) return false;
-            var l = (t.lang || '').toLowerCase();
-            var nm = (t.name || '').toLowerCase();
-            return l === pref ||
-                   (l && pref.length === 2 && l.indexOf(pref) === 0) ||
-                   (l && l.length === 2 && pref.indexOf(l) === 0) ||
-                   nm.indexOf(pref) >= 0;
+            // Shared with the subtitle picker: matches the language tag, the
+            // ISO 639-2 spelling ('ger', 'vie'), the English name and the
+            // endonym — see LanguageList.matchScore in settings.js.
+            return LanguageList.matchScore(pref, t.lang, t.name) > 0;
         }
         function firstSupported(list) {
             for (var i = 0; i < list.length; i++) if (!list[i].unsupported) return list[i];
@@ -1633,16 +1677,9 @@
             for (var j = 0; j < tracks.subtitle.length; j++) {
                 var st = tracks.subtitle[j];
                 if (st.off) continue;
-                var sn   = (st.name || '').toLowerCase();
-                var lang = (st.lang || '').toLowerCase();
 
-                var sc = 0;
-                if      (lang === wantSub)                                                sc = 100;
-                else if (lang && wantSub.length === 2 && lang.indexOf(wantSub) === 0)     sc = 90;
-                else if (lang && lang.length    === 2 && wantSub.indexOf(lang)    === 0)  sc = 90;
-                else if (sn.indexOf('[' + wantSub + ']') >= 0)                            sc = 80;
-                else if (sn.indexOf(wantSub) >= 0)                                        sc = 50;
-                else continue;
+                var sc = LanguageList.matchScore(wantSub, st.lang, st.name);
+                if (!sc) continue;
 
                 // External subs are reliable on this firmware; embedded ones
                 // often aren't.  Bump externals so they win ties.

--- a/tizen-web-vlc/js/player.js
+++ b/tizen-web-vlc/js/player.js
@@ -76,22 +76,71 @@ var Player = (function () {
         return avplay;
     }
 
+    /* The user's aspect/zoom choice, resolved from Settings each time so a
+     * change from the OSD or the settings view takes effect on the next
+     * apply without the player caching a stale mode. */
+    function aspect() {
+        if (typeof AspectRatio === 'undefined') return { av: 'PLAYER_DISPLAY_MODE_LETTER_BOX', fit: 'contain', zoom: 1 };
+        return AspectRatio.current();
+    }
+
     function avSetDisplayRect() {
+        var w = window.innerWidth  || screen.width  || 1920;
+        var h = window.innerHeight || screen.height || 1080;
+        var z = aspect().zoom || 1;
         try {
-            var w = window.innerWidth  || screen.width  || 1920;
-            var h = window.innerHeight || screen.height || 1080;
+            if (z !== 1) {
+                /* Zoom past the frame edge: hand AVPlay a rect bigger than
+                 * the screen, centred, so the overflow falls outside the
+                 * panel.  This is the only way to crop bars that are baked
+                 * into the video frames — no display method can do it. */
+                var zw = Math.round(w * z), zh = Math.round(h * z);
+                var zx = Math.round((w - zw) / 2), zy = Math.round((h - zh) / 2);
+                av().setDisplayRect(zx, zy, zw, zh);
+                if (typeof Debug !== 'undefined')
+                    Debug.player('AV setDisplayRect zoom ' + z + ' → ' + zx + ',' + zy + ' ' + zw + 'x' + zh);
+                return;
+            }
             av().setDisplayRect(0, 0, w, h);
             if (typeof Debug !== 'undefined') Debug.player('AV setDisplayRect ' + w + 'x' + h);
         } catch (e) {
             if (typeof Debug !== 'undefined') Debug.warn('AV setDisplayRect: ' + e.message);
+            /* Firmware that rejects an off-screen rect: fall back to the
+             * plain full-screen one so we never leave the video unsized. */
+            if (z !== 1) { try { av().setDisplayRect(0, 0, w, h); } catch (e2) {} }
         }
     }
     function avSetDisplayMethod() {
+        var mode = aspect();
         try {
-            av().setDisplayMethod('PLAYER_DISPLAY_MODE_LETTER_BOX');
+            av().setDisplayMethod(mode.av);
+            if (typeof Debug !== 'undefined') Debug.player('AV setDisplayMethod ' + mode.av);
         } catch (e) {
-            if (typeof Debug !== 'undefined') Debug.warn('AV setDisplayMethod: ' + e.message);
+            if (typeof Debug !== 'undefined')
+                Debug.warn('AV setDisplayMethod ' + mode.av + ': ' + e.message);
+            // CROPPED_FULL / FULL_SCREEN aren't on every firmware — letterbox
+            // is, and it's the mode the app shipped with.
+            try { av().setDisplayMethod('PLAYER_DISPLAY_MODE_LETTER_BOX'); } catch (e2) {}
         }
+    }
+
+    /* HTML5 backend equivalent: object-fit covers cases 1 and 3, a CSS
+     * scale() handles the zoom levels.  body is overflow:hidden, so the
+     * scaled overflow is clipped exactly like the AVPlay rect. */
+    function h5ApplyAspect() {
+        var v = h5el();
+        if (!v) return;
+        var mode = aspect();
+        try {
+            v.style.objectFit = mode.fit;
+            v.style.transform = (mode.zoom && mode.zoom !== 1) ? 'scale(' + mode.zoom + ')' : '';
+        } catch (e) {}
+    }
+
+    /* Push the current aspect/zoom mode onto whichever backend is live. */
+    function applyAspect() {
+        if (backend === BACKEND_AVPLAY)     { avSetDisplayRect(); avSetDisplayMethod(); }
+        else if (backend === BACKEND_HTML5) { h5ApplyAspect(); }
     }
 
     /* All external subtitles (SRT / VTT / ASS / SSA / SMI) are painted by the
@@ -132,13 +181,11 @@ var Player = (function () {
         var bestScore = 0;
         for (var i = 0; i < playerSubtitles.length; i++) {
             var s = playerSubtitles[i];
-            var lang = (s.lang || '').toLowerCase();
-            var nm   = (s.name || '').toLowerCase();
-            var sc = 0;
-            if      (lang === want)                                            sc = 100;
-            else if (lang && want.length === 2 && lang.indexOf(want) === 0)    sc = 90;
-            else if (lang && lang.length === 2 && want.indexOf(lang) === 0)    sc = 90;
-            else if (nm.indexOf(want) >= 0)                                    sc = 50;
+            // Same scorer the CC menu and the audio picker use: language tag,
+            // ISO 639-2 spelling, English name or endonym (settings.js).
+            var sc = (typeof LanguageList !== 'undefined')
+                   ? LanguageList.matchScore(want, s.lang, s.name)
+                   : ((s.lang || '').toLowerCase() === want ? 100 : 0);
             if (sc > bestScore) { bestScore = sc; best = s; }
         }
         return best;
@@ -676,6 +723,7 @@ var Player = (function () {
     function h5Open(url, opts) {
         var v = h5el();
         v.style.display = 'block';
+        h5ApplyAspect();
         // playerSubtitles is set in open() for both backends; keep alias
         h5Subtitles = playerSubtitles;
 
@@ -1103,7 +1151,7 @@ var Player = (function () {
         return 'NONE';
     }
     function setDisplayRect() {
-        if (backend === BACKEND_AVPLAY) avSetDisplayRect();
+        applyAspect();
     }
 
     /* Audio codecs Samsung TVs can't decode in-app, no matter the firmware:
@@ -1232,11 +1280,18 @@ var Player = (function () {
             // file too large, etc.).  When we DID extract working SRTs,
             // suppress the native (broken-on-Tizen-5.0) entries so the
             // user doesn't see duplicates where only one actually works.
-            var hasExtracted = false;
+            var extractedCount = 0;
             for (var ei = 0; ei < playerSubtitles.length; ei++) {
-                if (playerSubtitles[ei]._extracted) { hasExtracted = true; break; }
+                if (playerSubtitles[ei]._extracted) extractedCount++;
             }
+            var hasExtracted = extractedCount > 0;
             var showEmbed = !hasExtracted;
+            // How many text tracks AVPlay itself sees.  When that's more than
+            // we managed to extract, tracks are missing from the menu — the
+            // extractors only handle text subs (S_TEXT/*, tx3g), so PGS /
+            // VobSub image subs and anything unreadable drop out silently.
+            // Counting them lets the menu say so instead of just looking short.
+            var nativeTextCount = 0;
 
             /* Pull the currently-selected track indices so we can mark
              * the matching menu entries as active.  AVPlay returns either
@@ -1284,7 +1339,9 @@ var Player = (function () {
                             type:   'AVPLAY',
                             active: (t.index === activeAudioIdx)
                         });
-                    } else if ((t.type === 'TEXT' || t.type === 'SUBTITLE') && showEmbed) {
+                    } else if (t.type === 'TEXT' || t.type === 'SUBTITLE') {
+                        nativeTextCount++;
+                        if (!showEmbed) continue;
                         out.subtitle.push({
                             index:  'embed:' + t.index,
                             name:   '(embedded) ' + (parsed.label || ('Subtitle ' + t.index)),
@@ -1311,6 +1368,20 @@ var Player = (function () {
                     lang:   s.lang || '',
                     type:   s._extracted ? 'AVPLAY_EXTRACTED' : 'AVPLAY_EXTERNAL',
                     active: (currentExternalSub === s)
+                });
+            }
+
+            /* Account for tracks the extractor couldn't take.  A muted row is
+             * not selectable (nothing can render them) but it stops the list
+             * from silently under-reporting what's in the file. */
+            if (hasExtracted && nativeTextCount > extractedCount) {
+                var missing = nativeTextCount - extractedCount;
+                out.subtitle.push({
+                    index:  'missing',
+                    name:   '+' + missing + ' embedded track' + (missing === 1 ? '' : 's') +
+                            ' this TV can’t draw (image-based subs)',
+                    muted:  true,
+                    active: false
                 });
             }
 
@@ -1771,6 +1842,7 @@ var Player = (function () {
         setAudioTrack:      setAudioTrack,
         setSubtitleTrack:   setSubtitleTrack,
         setDisplayRect:     setDisplayRect,
+        applyAspect:        applyAspect,
         isBuffering:        isBuffering,
         lastBufferingMs:    lastBufferingMs,
         setSpeed:           setSpeed,

--- a/tizen-web-vlc/js/settings.js
+++ b/tizen-web-vlc/js/settings.js
@@ -22,6 +22,9 @@ var Settings = (function () {
         subtitleFont:     'sans',      // 'sans' | 'serif' | 'mono'
         subtitlePosition: 'bottom',    // 'bottom' | 'middle' | 'top'
         subtitleBg:       'none',      // 'none' | 'box'  (translucent box behind text)
+        // ── Video geometry ────────────────────────────────────────────────
+        // How the picture is fitted to the screen: see AspectRatio below.
+        aspectMode:       'fit',       // 'fit' | 'fill' | 'stretch' | 'zoom110' | 'zoom125'
         // The TV's pairing code (url-drop.js mints it once and persists it
         // here).  It HAS to be listed: load() rebuilds the cache from this
         // object, so a key that isn't here is silently dropped on the next
@@ -127,37 +130,109 @@ var TvInfo = (function () {
 
 
 /* Curated language list — common languages for media subtitles + audio.
- * '' = auto (no preference), 'off' is added only to the subtitle picker. */
+ * '' = auto (no preference), 'off' is added only to the subtitle picker.
+ *
+ * `alt` carries the spellings a real track label uses for that language:
+ * the ISO 639-2 code(s) a muxer writes into the language tag ('vie', 'ger',
+ * 'chi'), the English name, and the endonym.  matchScore() below works off
+ * those, so "Vietnamese (SDH)" or "[vie]" match a 'vi' preference and a
+ * bare two-letter code can be required to stand as its own word — without
+ * the alias list a 'vi' preference happily matched "Movie". */
 var LanguageList = (function () {
     var langs = [
-        { code: '',   name: 'Auto (file default)' },
-        { code: 'en', name: 'English' },
-        { code: 'nl', name: 'Nederlands' },
-        { code: 'de', name: 'Deutsch' },
-        { code: 'fr', name: 'Français' },
-        { code: 'es', name: 'Español' },
-        { code: 'it', name: 'Italiano' },
-        { code: 'pt', name: 'Português' },
-        { code: 'ru', name: 'Русский' },
-        { code: 'ja', name: '日本語' },
-        { code: 'ko', name: '한국어' },
-        { code: 'zh', name: '中文' },
-        { code: 'ar', name: 'العربية' },
-        { code: 'tr', name: 'Türkçe' },
-        { code: 'pl', name: 'Polski' },
-        { code: 'sv', name: 'Svenska' },
-        { code: 'no', name: 'Norsk' },
-        { code: 'da', name: 'Dansk' },
-        { code: 'fi', name: 'Suomi' }
+        { code: '',   name: 'Auto (file default)', alt: [] },
+        { code: 'en', name: 'English',    alt: ['eng', 'english'] },
+        { code: 'nl', name: 'Nederlands', alt: ['dut', 'nld', 'dutch', 'nederlands'] },
+        { code: 'de', name: 'Deutsch',    alt: ['ger', 'deu', 'german', 'deutsch'] },
+        { code: 'fr', name: 'Français',   alt: ['fre', 'fra', 'french', 'français', 'francais'] },
+        { code: 'es', name: 'Español',    alt: ['spa', 'spanish', 'español', 'espanol', 'castellano'] },
+        { code: 'it', name: 'Italiano',   alt: ['ita', 'italian', 'italiano'] },
+        { code: 'pt', name: 'Português',  alt: ['por', 'portuguese', 'português', 'portugues', 'brazilian'] },
+        { code: 'ru', name: 'Русский',    alt: ['rus', 'russian', 'русский'] },
+        { code: 'ja', name: '日本語',      alt: ['jpn', 'japanese', '日本語'] },
+        { code: 'ko', name: '한국어',      alt: ['kor', 'korean', '한국어'] },
+        { code: 'zh', name: '中文',        alt: ['chi', 'zho', 'chinese', 'mandarin', 'cantonese', '中文'] },
+        { code: 'vi', name: 'Tiếng Việt', alt: ['vie', 'vietnamese', 'tiếng việt', 'tieng viet'] },
+        { code: 'ar', name: 'العربية',   alt: ['ara', 'arabic', 'العربية'] },
+        { code: 'tr', name: 'Türkçe',     alt: ['tur', 'turkish', 'türkçe', 'turkce'] },
+        { code: 'pl', name: 'Polski',     alt: ['pol', 'polish', 'polski'] },
+        { code: 'sv', name: 'Svenska',    alt: ['swe', 'swedish', 'svenska'] },
+        { code: 'no', name: 'Norsk',      alt: ['nor', 'nob', 'norwegian', 'norsk'] },
+        { code: 'da', name: 'Dansk',      alt: ['dan', 'danish', 'dansk'] },
+        { code: 'fi', name: 'Suomi',      alt: ['fin', 'finnish', 'suomi'] }
     ];
+
+    function entryFor(code) {
+        for (var i = 0; i < langs.length; i++) if (langs[i].code === code) return langs[i];
+        return null;
+    }
+
+    /* Every spelling that identifies `code`, lower-cased: the code itself,
+     * its ISO 639-2 forms, the English name and the endonym. */
+    function tagsFor(code) {
+        var c = String(code || '').toLowerCase();
+        var e = entryFor(c);
+        var out = [c];
+        if (e) {
+            for (var i = 0; i < e.alt.length; i++) out.push(e.alt[i]);
+            var n = e.name.toLowerCase();
+            if (out.indexOf(n) < 0) out.push(n);
+        }
+        return out;
+    }
+
+    function esc(s) { return String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
+    /* Whole-"word" test that also works for names with no spaces — track
+     * labels are routinely filename-ish ("Show.S01E02.vi.srt"), so anything
+     * that isn't a latin letter or digit counts as a separator. */
+    function hasWord(hay, word) {
+        return new RegExp('(^|[^a-z0-9])' + esc(word) + '($|[^a-z0-9])', 'i').test(hay);
+    }
+
+    /* How well a track matches a language preference: 0 = no match, 100 =
+     * the track's own language tag says so.  Shared by the audio picker and
+     * the subtitle picker in app.js so both honour the same spellings. */
+    function matchScore(pref, lang, name) {
+        var want = String(pref || '').toLowerCase();
+        if (!want || want === 'off') return 0;
+        var tags = tagsFor(want);
+        var nm   = String(name || '').toLowerCase();
+
+        // 1. The container's own language tag ('vie', 'vi', 'vi-VN').
+        var base = String(lang || '').toLowerCase().split(/[-_]/)[0];
+        if (base) {
+            if (tags.indexOf(base) >= 0) return 100;
+            if (base.length >= 2 &&
+                (base.indexOf(want) === 0 || want.indexOf(base) === 0)) return 90;
+        }
+        if (!nm) return 0;
+
+        // 2. A code in brackets, the muxer convention: "Subtitle [vie]".
+        for (var i = 0; i < tags.length; i++)
+            if (nm.indexOf('[' + tags[i] + ']') >= 0 ||
+                nm.indexOf('(' + tags[i] + ')') >= 0) return 80;
+
+        // 3. A spelled-out name anywhere in the label: "Vietnamese SDH".
+        //    Two-letter latin tags are held back for step 4 (too collision-
+        //    prone), but a short non-ascii endonym like "中文" is unambiguous.
+        for (var j = 0; j < tags.length; j++)
+            if ((tags[j].length >= 3 || /[^\x00-\x7f]/.test(tags[j])) &&
+                hasWord(nm, tags[j])) return 60;
+
+        // 4. The bare two-letter code, but only as its own word — a loose
+        //    substring here is what made 'vi' match "Movie".
+        if (want.length === 2 && hasWord(nm, want)) return 50;
+        return 0;
+    }
+
     return {
         forAudio:    function () { return langs; },
         forSubtitle: function () { return [{ code: 'off', name: 'Off (no subtitles)' }].concat(langs); },
+        matchScore:  matchScore,
         nameFor:     function (code) {
             if (code === 'off') return 'Off';
-            for (var i = 0; i < langs.length; i++)
-                if (langs[i].code === code) return langs[i].name;
-            return code || 'Auto';
+            var e = entryFor(code);
+            return e ? e.name : (code || 'Auto');
         }
     };
 })();
@@ -245,3 +320,75 @@ var SubtitleStyle = (function () {
         apply:       apply
     };
 })();
+
+
+/* Video aspect / zoom modes — how the picture is fitted to the screen.
+ *
+ * Two different "black bars" exist and they need different fixes:
+ *
+ *   1. The file really is wider than the screen (2.39:1 in a 2.39:1 frame).
+ *      The player letterboxes it, and 'fill' — AVPlay's CROPPED_FULL, CSS
+ *      object-fit:cover — scales the picture until it covers the screen and
+ *      crops the sides instead.  Aspect is preserved.
+ *   2. The bars are encoded INTO the frames (a 2.39:1 film muxed as 16:9).
+ *      Nothing the display method does can help there: the frame already
+ *      matches the screen.  The only fix is to zoom past the frame edge,
+ *      which 'zoom110' / 'zoom125' do by handing AVPlay a display rect
+ *      larger than the screen (CSS transform:scale on the HTML5 backend).
+ *
+ * 'stretch' is the blunt instrument — fills the screen by distorting the
+ * picture.  Some users prefer it, so it stays on the list, labelled.
+ *
+ * `av` values are Samsung AVPlay display methods; unsupported ones throw on
+ * older firmware, and player.js falls back to LETTER_BOX when they do. */
+var AspectRatio = (function () {
+    var MODES = [
+        { code: 'fit',     name: 'Fit screen (keep black bars)',  short: 'Fit',
+          av: 'PLAYER_DISPLAY_MODE_LETTER_BOX',   fit: 'contain', zoom: 1 },
+        { code: 'fill',    name: 'Fill screen (crop the sides)',  short: 'Fill',
+          av: 'PLAYER_DISPLAY_MODE_CROPPED_FULL', fit: 'cover',   zoom: 1 },
+        { code: 'zoom110', name: 'Zoom 110% (crop baked-in bars)', short: '110%',
+          av: 'PLAYER_DISPLAY_MODE_LETTER_BOX',   fit: 'contain', zoom: 1.10 },
+        { code: 'zoom125', name: 'Zoom 125% (crop baked-in bars)', short: '125%',
+          av: 'PLAYER_DISPLAY_MODE_LETTER_BOX',   fit: 'contain', zoom: 1.25 },
+        // 'Wide' is the label TVs traditionally put on a stretched 16:9
+        // picture, and unlike 'Stretch' it fits inside the round OSD button.
+        { code: 'stretch', name: 'Stretch (fills, distorts shape)', short: 'Wide',
+          av: 'PLAYER_DISPLAY_MODE_FULL_SCREEN',  fit: 'fill',    zoom: 1 }
+    ];
+
+    function find(code) {
+        for (var i = 0; i < MODES.length; i++) if (MODES[i].code === code) return MODES[i];
+        return MODES[0];
+    }
+    /* The mode currently in force, resolved from Settings. */
+    function current() {
+        if (typeof Settings === 'undefined') return MODES[0];
+        return find(Settings.get('aspectMode'));
+    }
+    /* Next mode in the list — the OSD button cycles rather than opening a
+     * picker when the user just wants to flick through them. */
+    function next(code) {
+        for (var i = 0; i < MODES.length; i++)
+            if (MODES[i].code === code) return MODES[(i + 1) % MODES.length].code;
+        return MODES[0].code;
+    }
+
+    return {
+        forList: function () { return MODES; },
+        find:    find,
+        current: current,
+        next:    next,
+        nameFor:  function (c) { return find(c).name; },
+        shortFor: function (c) { return find(c).short; }
+    };
+})();
+
+// Ignored by the Tizen/browser build; lets Node tests require these helpers.
+if (typeof module !== 'undefined' && module.exports)
+    module.exports = {
+        Settings:      Settings,
+        LanguageList:  LanguageList,
+        SubtitleStyle: SubtitleStyle,
+        AspectRatio:   AspectRatio
+    };


### PR DESCRIPTION
Follow-up requests from the reporter of the ASS-styling issue (#66), who came back with three suggestions after confirming that fix.

## 1. Vietnamese in the preferred-subtitle (and audio) list

Adding `vi` to the list on its own would have misfired: the old matcher accepted any substring of the two-letter code, so a `vi` preference matched a track named `Movie.2019.1080p` before it reached the Vietnamese one.

Each language now carries the spellings that actually appear in track labels — the ISO 639-2 code (`vie`, `ger`, `dut`), the English name and the endonym — and `LanguageList.matchScore()` ranks candidates against them:

| score | match |
|---|---|
| 100 | the container's own language tag (`vie`, `vi`, `vi-VN`) |
| 90 | a prefix match either way |
| 80 | a bracketed code — `Subtitle [vie]` |
| 60 | a spelled-out name — `Vietnamese SDH`, `Tiếng Việt`, `简体中文` |
| 50 | the bare two-letter code, but only as its own word — `Show.S01E02.vi.srt` |

The subtitle picker, the audio picker and the pre-play external-subtitle pick were three near-copies of that logic; they all call the one scorer now.

## 2. Video aspect ratio / zoom

New OSD button (next to the speed button) and a **Settings → Video aspect ratio** row, sharing one picker. The choice is persisted — someone who wants a filled screen wants it for every file:

- **Fit** — letterbox, unchanged default
- **Fill** — AVPlay `CROPPED_FULL` / CSS `object-fit: cover`: crops the sides, keeps the shape
- **Zoom 110% / 125%** — for bars that are *encoded into* the frames, where no display method can help: AVPlay gets a display rect larger than the screen (CSS `transform: scale()` on the HTML5 backend) and the overflow falls outside the panel
- **Stretch** — fills by distorting, labelled as such

Firmware that rejects `CROPPED_FULL` / `FULL_SCREEN` falls back to `LETTER_BOX`; an off-screen rect that's rejected falls back to the plain full-screen one. The OSD button shows the current mode and highlights whenever the picture isn't in plain Fit, so a cropped picture is never a mystery.

## 3. Track menu didn't show every subtitle

Two causes:

- The menu is anchored at `bottom: 240px` with no height cap, so a rip with 20+ subtitle tracks grew straight off the top of the screen. The entries were focusable but invisible. The lists now scroll inside the menu (`max-height` + an `overflow-y` body, Close stays pinned), and the section headings carry a count — `Subtitle (24)` — so a complete list looks complete.
- When embedded-subtitle extraction succeeds, the app hides AVPlay's own (broken-on-this-firmware) entries to avoid duplicates. The extractors only handle text subs, so PGS/VobSub image tracks vanished with them. The menu now compares the two counts and adds a muted, non-selectable row — `+3 embedded tracks this TV can't draw (image-based subs)` — instead of quietly coming up short.

## Testing

- `node --test tests/tizen-web-vlc/*.test.js` — 46 pass, including 12 new ones covering the matcher (Vietnamese tags/names, the `Movie` false positive, non-latin endonyms) and the aspect-mode table.
- Track menu rendered headless at 1920×1080 in both the 24-track and 3-track cases: scrolls with the Close button pinned in the first, stays compact in the second.
- Not yet run on a TV — the AVPlay display-method and off-screen-rect paths are the parts that want a look on real hardware.

Version bump left for its own PR as usual.