### PR TITLE
List every embedded subtitle track, and make the aspect modes take effect

### DIFF
--- a/tests/tizen-web-vlc/language-match.test.js
+++ b/tests/tizen-web-vlc/language-match.test.js
@@ -83,6 +83,43 @@ test('the zoom modes scale past the frame edge', function () {
     assert.ok(AspectRatio.find('zoom125').zoom > AspectRatio.find('zoom110').zoom);
 });
 
+test('the crop modes derive their zoom from the frame they are given', function () {
+    var SIXTEEN_NINE = 3840 / 2160;
+
+    // The case that prompted this: 2.39:1 content letterboxed into a 4K 16:9
+    // frame.  Measured on the file, the bars are 275 px top and 276 bottom of
+    // 2160, leaving 1609 px of picture — so 2160/1609 = 1.342x clears them.
+    var z = AspectRatio.zoomFor('crop239', SIXTEEN_NINE);
+    assert.ok(Math.abs(z - 2160 / 1609) < 0.01,
+        'expected ~1.34x to crop 2.39:1 out of 16:9, got ' + z);
+    // Neither fixed step lands there: 125% leaves a bar, and nothing offered
+    // 134% before.
+    assert.ok(z > AspectRatio.find('zoom125').zoom);
+
+    // 2:1 content in the same frame needs much less.
+    assert.ok(Math.abs(AspectRatio.zoomFor('crop20', SIXTEEN_NINE) - 1.125) < 0.001);
+
+    // A frame already that wide has no bars to crop, so it is left alone.
+    assert.strictEqual(AspectRatio.zoomFor('crop239', 2.39), 1);
+    assert.strictEqual(AspectRatio.zoomFor('crop20', 2.39), 1);
+    assert.strictEqual(AspectRatio.zoomFor('crop239', 2.5), 1);
+
+    // Nonsense frame data must not blank the screen.
+    assert.strictEqual(AspectRatio.zoomFor('crop239', 0), 1);
+    assert.strictEqual(AspectRatio.zoomFor('crop239', -1), 1);
+    // An absurdly tall frame is clamped rather than magnified without limit.
+    assert.strictEqual(AspectRatio.zoomFor('crop239', 0.1), 2);
+});
+
+test('zoomFor leaves the fixed and non-zooming modes as they are', function () {
+    assert.strictEqual(AspectRatio.zoomFor('fit', 16 / 9), 1);
+    assert.strictEqual(AspectRatio.zoomFor('fill', 16 / 9), 1);
+    assert.strictEqual(AspectRatio.zoomFor('stretch', 16 / 9), 1);
+    // Fixed steps ignore the frame entirely.
+    assert.strictEqual(AspectRatio.zoomFor('zoom110', 16 / 9), 1.10);
+    assert.strictEqual(AspectRatio.zoomFor('zoom125', 2.39), 1.25);
+});
+
 test('an unknown mode falls back to fit, and next() cycles', function () {
     assert.strictEqual(AspectRatio.find('nonsense').code, 'fit');
     var seen = {}, code = 'fit';

--- a/tests/tizen-web-vlc/mkv-subs.test.js
+++ b/tests/tizen-web-vlc/mkv-subs.test.js
@@ -1,0 +1,259 @@
+'use strict';
+
+var assert = require('assert');
+var test = require('node:test');
+var MkvSubs = require('../../tizen-web-vlc/js/mkv-subs.js');
+
+/* ── Minimal EBML writer ──────────────────────────────────────────────
+ *
+ * Enough to build the front of a Matroska file: an EBML header, a Segment,
+ * and whatever children a test wants inside it.  Sizes always go out as
+ * 4-byte vints so the encoder stays trivial. */
+
+var ID = {
+    EBML:        0x1A45DFA3,
+    SEGMENT:     0x18538067,
+    SEEKHEAD:    0x114D9B74,
+    ATTACHMENTS: 0x1941A469,
+    TRACKS:      0x1654AE6B,
+    TRACKENTRY:  0xAE,
+    TRACKNUMBER: 0xD7,
+    TRACKTYPE:   0x83,
+    CODECID:     0x86,
+    LANGUAGE:    0x22B59C,
+    LANG_IETF:   0x22B59D,
+    NAME:        0x536E,
+    FLAGFORCED:  0x55AA,
+    FLAGHEARIMP: 0x55AB,
+    CLUSTER:     0x1F43B675
+};
+
+function idBytes(id) {
+    var out = [];
+    var n = id;
+    while (n > 0) { out.unshift(n & 0xff); n = Math.floor(n / 256); }
+    return out;
+}
+
+// 4-byte vint: marker bit at 0x10, 28 bits of length.
+function sizeBytes(len) {
+    assert.ok(len < 0x10000000, 'length too big for a 4-byte vint');
+    return [0x10 | ((len >>> 24) & 0x0f), (len >>> 16) & 0xff, (len >>> 8) & 0xff, len & 0xff];
+}
+
+function concat() {
+    var parts = Array.prototype.slice.call(arguments);
+    var out = [];
+    for (var i = 0; i < parts.length; i++) out = out.concat(parts[i]);
+    return out;
+}
+
+function el(id, payload) {
+    return concat(idBytes(id), sizeBytes(payload.length), payload);
+}
+
+function str(s) { return Array.prototype.slice.call(Buffer.from(s, 'utf8')); }
+function u8(n) { return [n & 0xff]; }
+function filler(n) { var a = []; for (var i = 0; i < n; i++) a.push(0); return a; }
+
+/* A subtitle TrackEntry.  `opts` mirrors the elements a real muxer writes. */
+function subtitleTrack(number, opts) {
+    opts = opts || {};
+    var body = concat(
+        el(ID.TRACKNUMBER, u8(number)),
+        el(ID.TRACKTYPE, u8(17)),                       // 17 = subtitle
+        el(ID.CODECID, str(opts.codec || 'S_TEXT/UTF8'))
+    );
+    if (opts.lang)     body = concat(body, el(ID.LANGUAGE, str(opts.lang)));
+    if (opts.langIetf) body = concat(body, el(ID.LANG_IETF, str(opts.langIetf)));
+    if (opts.name)     body = concat(body, el(ID.NAME, str(opts.name)));
+    if (opts.forced)   body = concat(body, el(ID.FLAGFORCED, u8(1)));
+    if (opts.hi)       body = concat(body, el(ID.FLAGHEARIMP, u8(1)));
+    return el(ID.TRACKENTRY, body);
+}
+
+function videoTrack(number) {
+    return el(ID.TRACKENTRY, concat(
+        el(ID.TRACKNUMBER, u8(number)),
+        el(ID.TRACKTYPE, u8(1)),
+        el(ID.CODECID, str('V_MPEGH/ISO/HEVC'))
+    ));
+}
+
+function audioTrack(number) {
+    return el(ID.TRACKENTRY, concat(
+        el(ID.TRACKNUMBER, u8(number)),
+        el(ID.TRACKTYPE, u8(2)),
+        el(ID.CODECID, str('A_EAC3'))
+    ));
+}
+
+/* Assembles [EBML header][Segment [...children]] and returns the bytes. */
+function mkvFile(segmentChildren) {
+    return Buffer.from(concat(
+        el(ID.EBML, str('matroska')),
+        el(ID.SEGMENT, segmentChildren)
+    ));
+}
+
+/* Reader with the interface mkv-subs.js expects.  `declaredSize` can be far
+ * larger than the bytes on hand, which is how a header-only read of a 6 GB
+ * movie is simulated: any attempt to read past what we hold would be a read
+ * into the movie body, and `reads`/`bytesRead` prove it never happens. */
+function stubReader(buf, declaredSize) {
+    var r = {
+        reads: 0,
+        bytesRead: 0,
+        maxOffsetRead: 0,
+        getSize: function (cb) {
+            setImmediate(function () { cb(null, declaredSize || buf.length); });
+        },
+        readRange: function (off, len, cb) {
+            r.reads++;
+            // A real reader is bounded by the true file length; at EOF it
+            // hands back what exists rather than failing.
+            var end = Math.min(off + len, buf.length);
+            if (off >= buf.length) { setImmediate(function () { cb(Error('read past EOF')); }); return; }
+            r.bytesRead += end - off;
+            r.maxOffsetRead = Math.max(r.maxOffsetRead, end);
+            var slice = buf.subarray(off, end);
+            setImmediate(function () {
+                cb(null, slice.buffer.slice(slice.byteOffset, slice.byteOffset + slice.byteLength));
+            });
+        },
+        close: function () {}
+    };
+    return r;
+}
+
+function listTracks(reader) {
+    return new Promise(function (resolve, reject) {
+        MkvSubs.listTracks(reader, function (err, tracks) {
+            if (err) reject(err); else resolve(tracks);
+        });
+    });
+}
+
+/* ── Tests ───────────────────────────────────────────────────────────── */
+
+test('listTracks enumerates every track, past the point AVPlay truncates', async function () {
+    // 1 video + 1 audio + 40 subtitles is the shape that exposed the bug:
+    // AVPlay's getTotalTrackInfo() returns 32 entries, so the last ten
+    // subtitle tracks never reach the menu.
+    var entries = concat(videoTrack(1), audioTrack(2));
+    var langs = ['kor', 'chi', 'ara', 'cze', 'dan', 'ger', 'gre', 'eng', 'spa', 'fin',
+                 'fil', 'fre', 'heb', 'hrv', 'hun', 'ind', 'ita', 'jpn', 'may', 'nob',
+                 'dut', 'pol', 'por', 'rum', 'rus', 'swe', 'tha', 'tur', 'ukr', 'vie',
+                 'bul', 'est', 'lav', 'lit', 'slk', 'slv', 'srp', 'ron', 'cat', 'baq'];
+    for (var i = 0; i < 40; i++) entries = concat(entries, subtitleTrack(3 + i, { lang: langs[i] }));
+
+    var buf = mkvFile(concat(el(ID.SEEKHEAD, filler(64)), el(ID.TRACKS, entries)));
+    var tracks = await listTracks(stubReader(buf));
+
+    assert.strictEqual(tracks.length, 42);
+    var subs = tracks.filter(MkvSubs.isSubtitleTrack);
+    assert.strictEqual(subs.length, 40);
+    assert.strictEqual(subs[0].lang, 'kor');
+    // The track AVPlay drops is the one a Vietnamese viewer needs.
+    assert.strictEqual(subs[29].lang, 'vie');
+    assert.strictEqual(subs[39].lang, 'baq');
+});
+
+test('listTracks reads only the header of a huge file', async function () {
+    var entries = concat(videoTrack(1), audioTrack(2), subtitleTrack(3, { lang: 'eng' }));
+    var buf = mkvFile(el(ID.TRACKS, entries));
+    // Claim the 6.0 GB length of the file that prompted this, while holding
+    // only the header bytes.
+    var reader = stubReader(buf, 6417771952);
+
+    var tracks = await listTracks(reader);
+    assert.strictEqual(tracks.length, 3);
+    assert.ok(reader.bytesRead < 256 * 1024,
+        'expected a header-sized read, got ' + reader.bytesRead + ' bytes');
+});
+
+test('listTracks seeks over a big Attachments element instead of reading it', async function () {
+    // Cover art in front of Tracks: the scanner must skip the payload, not
+    // stream it through the WebView.
+    var art = el(ID.ATTACHMENTS, filler(5 * 1024 * 1024));
+    var entries = concat(videoTrack(1), subtitleTrack(2, { lang: 'eng' }));
+    var buf = mkvFile(concat(art, el(ID.TRACKS, entries)));
+    var reader = stubReader(buf);
+
+    var tracks = await listTracks(reader);
+    assert.strictEqual(tracks.length, 2);
+    assert.ok(reader.bytesRead < 1024 * 1024,
+        'attachment payload should be skipped, read ' + reader.bytesRead + ' bytes');
+});
+
+test('listTracks prefers the BCP-47 tag only when it adds a region', async function () {
+    var entries = concat(
+        // Regional variants are the whole point of the BCP-47 element.
+        subtitleTrack(1, { lang: 'spa', langIetf: 'es-419', name: 'Latin America' }),
+        subtitleTrack(2, { lang: 'spa', langIetf: 'es-ES' }),
+        // A bare BCP-47 tag adds nothing over the ISO 639-2 spelling.
+        subtitleTrack(3, { lang: 'kor', langIetf: 'ko', name: 'SDH' }),
+        // Muxers omit Language for English, leaving only the BCP-47 form.
+        subtitleTrack(4, { langIetf: 'en' })
+    );
+    var tracks = await listTracks(stubReader(mkvFile(el(ID.TRACKS, entries))));
+
+    assert.strictEqual(tracks[0].lang, 'es-419');
+    assert.strictEqual(tracks[0].name, 'Latin America');
+    assert.strictEqual(tracks[1].lang, 'es-ES');
+    assert.strictEqual(tracks[2].lang, 'kor');
+    assert.strictEqual(tracks[2].name, 'SDH');
+    assert.strictEqual(tracks[3].lang, 'en');
+});
+
+test('listTracks reports the flags that tell same-language tracks apart', async function () {
+    var entries = concat(
+        subtitleTrack(1, { lang: 'eng', name: 'SDH' }),
+        subtitleTrack(2, { lang: 'eng', hi: true }),
+        subtitleTrack(3, { lang: 'eng', forced: true })
+    );
+    var tracks = await listTracks(stubReader(mkvFile(el(ID.TRACKS, entries))));
+
+    assert.strictEqual(tracks[0].hearingImpaired, false);
+    assert.strictEqual(tracks[0].forced, false);
+    assert.strictEqual(tracks[1].hearingImpaired, true);
+    assert.strictEqual(tracks[2].forced, true);
+});
+
+test('isTextSubtitleTrack accepts text subs and rejects bitmap ones', async function () {
+    var entries = concat(
+        subtitleTrack(1, { lang: 'eng', codec: 'S_TEXT/UTF8' }),
+        subtitleTrack(2, { lang: 'eng', codec: 'S_TEXT/ASS' }),
+        subtitleTrack(3, { lang: 'eng', codec: 'S_HDMV/PGS' }),
+        subtitleTrack(4, { lang: 'eng', codec: 'S_VOBSUB' })
+    );
+    var tracks = await listTracks(stubReader(mkvFile(el(ID.TRACKS, entries))));
+
+    // All four are subtitle tracks and all four get listed …
+    assert.strictEqual(tracks.filter(MkvSubs.isSubtitleTrack).length, 4);
+    // … but only the text ones can be painted by this player.
+    assert.deepStrictEqual(tracks.map(MkvSubs.isTextSubtitleTrack),
+        [true, true, false, false]);
+});
+
+test('listTracks stops at the first cluster when there is no Tracks element', async function () {
+    var buf = mkvFile(concat(
+        el(ID.SEEKHEAD, filler(32)),
+        el(ID.CLUSTER, filler(4096))
+    ));
+    var reader = stubReader(buf);
+
+    var tracks = await listTracks(reader);
+    assert.deepStrictEqual(tracks, []);
+    assert.ok(reader.bytesRead < 128 * 1024 + 1);
+});
+
+test('listTracks surfaces an unreadable source as an error', async function () {
+    await assert.rejects(function () {
+        return listTracks({
+            getSize: function (cb) { setImmediate(function () { cb(Error('no size')); }); },
+            readRange: function (off, len, cb) { cb(Error('unreachable')); },
+            close: function () {}
+        });
+    }, /no size/);
+});

--- a/tizen-web-vlc/js/app.js
+++ b/tizen-web-vlc/js/app.js
@@ -1285,8 +1285,24 @@
             Player.applyAspect();
             updateAspectButton();
             refreshSettingsValues();
-            UI.toast('Aspect: ' + AspectRatio.nameFor(val));
+            UI.toast('Aspect: ' + AspectRatio.nameFor(val) + aspectToastNote());
         });
+    }
+
+    /* Fit / Fill / Wide all come out identical on a file whose frame already
+     * matches the panel — the usual case, since most rips are 16:9 on a 16:9
+     * TV.  Saying so beats letting the user cycle every mode looking for the
+     * one that isn't broken. */
+    function aspectToastNote() {
+        if (typeof Player.describeAspect !== 'function') return '';
+        var d;
+        try { d = Player.describeAspect(); } catch (e) { return ''; }
+        if (!d) return '';
+        if (d.noop)
+            return ' — no change: the picture already fills the screen. ' +
+                   'Bars inside the frame need a Crop mode.';
+        if (d.zoom > 1.005) return ' — zoom ' + Math.round(d.zoom * 100) + '%';
+        return '';
     }
     function updateAspectButton() {
         var btn = document.getElementById('btn-aspect');

--- a/tizen-web-vlc/js/mkv-subs.js
+++ b/tizen-web-vlc/js/mkv-subs.js
@@ -13,8 +13,10 @@
  * Bitmap subs (VobSub, PGS) are skipped — they can't be rendered as
  * text in this player.
  *
- * Same in-memory size cap applies as MP4 — future task is Range-based
- * partial reads (would benefit both extractors).
+ * extract() still loads the whole file, so it is capped at
+ * MAX_FULL_LOAD_BYTES.  listTracks() does not: it Range-reads just the
+ * header, so the CC menu can list every track in a file far too big to
+ * extract from.
  */
 
 var MkvSubs = (function () {
@@ -101,6 +103,11 @@ var MkvSubs = (function () {
     var ID_TRACKTYPE     = 0x83;
     var ID_CODECID       = 0x86;
     var ID_LANGUAGE      = 0x22B59C;
+    var ID_LANGUAGE_IETF = 0x22B59D;   // BCP-47 tag; the only one with a region
+    var ID_TRACKNAME     = 0x536E;     // human label: 'SDH', 'Latin America'
+    var ID_FLAGDEFAULT   = 0x88;
+    var ID_FLAGFORCED    = 0x55AA;
+    var ID_FLAGHEARIMP   = 0x55AB;
     var ID_CODECPRIVATE  = 0x63A2;
     var ID_CLUSTER       = 0x1F43B675;
     var ID_TIMECODE      = 0xE7;
@@ -111,19 +118,49 @@ var MkvSubs = (function () {
 
     /* ── Track entry parser (returns subtitle tracks only) ───────────── */
     function parseTrackEntry(view, off, end) {
-        var t = { number: 0, type: 0, codec: '', lang: '', priv: '' };
+        var t = {
+            number: 0, type: 0, codec: '', lang: '', langIetf: '', name: '',
+            isDefault: false, forced: false, hearingImpaired: false, priv: ''
+        };
         walk(view, off, end, function (id, o, e) {
             switch (id) {
                 case ID_TRACKNUMBER: t.number = readUint(view, o, e - o); break;
                 case ID_TRACKTYPE:   t.type   = readUint(view, o, e - o); break;
                 case ID_CODECID:     t.codec  = readAscii(view, o, e - o); break;
                 case ID_LANGUAGE:    t.lang   = readAscii(view, o, e - o); break;
+                case ID_LANGUAGE_IETF: t.langIetf = readAscii(view, o, e - o); break;
+                case ID_TRACKNAME:   t.name   = readUtf8(view, o, e - o); break;
+                case ID_FLAGDEFAULT: t.isDefault = !!readUint(view, o, e - o); break;
+                case ID_FLAGFORCED:  t.forced   = !!readUint(view, o, e - o); break;
+                case ID_FLAGHEARIMP: t.hearingImpaired = !!readUint(view, o, e - o); break;
                 /* For S_TEXT/ASS this is the whole script header, styles
                  * included — the only place an MKV keeps [V4+ Styles]. */
                 case ID_CODECPRIVATE: t.priv = readUtf8(view, o, e - o); break;
             }
         });
+        t.lang = bestLangTag(t);
         return t;
+    }
+
+    /* Streaming muxes tag every track twice — Language 'spa' alongside
+     * LanguageBCP47 'es-419'.  Only the BCP-47 form distinguishes the
+     * regional variants a 40-track file is mostly made of, and
+     * LanguageList.matchScore understands both spellings, so preferring it
+     * when it carries a subtag costs nothing and keeps 'Latin America'
+     * apart from 'es-ES'. */
+    function bestLangTag(t) {
+        if (t.langIetf && t.langIetf.indexOf('-') > 0) return t.langIetf;
+        return t.lang || t.langIetf || '';
+    }
+
+    function isSubtitleTrack(t) { return t.type === 17; }   // 17 = subtitle
+
+    /* Text subs this player can paint.  VobSub and PGS carry bitmaps, so
+     * they get listed but never extracted. */
+    function isTextSubtitleTrack(t) {
+        if (!isSubtitleTrack(t)) return false;
+        if (t.codec === 'S_VOBSUB' || /PGS/.test(t.codec)) return false;
+        return t.codec.indexOf('S_TEXT/') === 0;
     }
 
     /* ── Block / SimpleBlock body parser ─────────────────────────────────
@@ -206,10 +243,7 @@ var MkvSubs = (function () {
                         walk(view, soff, send, function (tid, to, te) {
                             if (tid !== ID_TRACKENTRY) return;
                             var t = parseTrackEntry(view, to, te);
-                            if (t.type !== 17) return;                  // 17 = subtitle
-                            if (t.codec === 'S_VOBSUB') return;
-                            if (/PGS/.test(t.codec))    return;
-                            if (t.codec.indexOf('S_TEXT/') !== 0) return;
+                            if (!isTextSubtitleTrack(t)) return;
                             subTracks[t.number] = t;
                         });
                         break;
@@ -333,6 +367,233 @@ var MkvSubs = (function () {
         return lines.join('\n');
     }
 
+    /* ── Header-only track listing ────────────────────────────────────
+     *
+     * The whole track table sits in the Tracks element near the front of the
+     * file — 2.4 KB even for a 40-track streaming mux — so listing every
+     * track costs one short Range read instead of the entire movie.
+     *
+     * This is the only path that sees all of them.  AVPlay's
+     * getTotalTrackInfo() truncates its own return array: a file with 1
+     * video + 1 audio + 40 subtitle tracks comes back with 32 entries, and
+     * the ten it silently drops are the last in file order — which is
+     * exactly where muxers put the less common languages.  extract() can't
+     * stand in either, because it refuses anything over
+     * MAX_FULL_LOAD_BYTES.  player.js uses this list to build the CC menu
+     * and to keep AVPlay's track indices lined up with the container. */
+
+    var HEADER_WINDOW_BYTES      = 128 * 1024;
+    var MAX_HEADER_PROBE_BYTES   = 16 * 1024 * 1024;
+    var MAX_TRACKS_ELEMENT_BYTES = 4 * 1024 * 1024;
+    var MAX_RANGE_RESPONSE_BYTES = 32 * 1024 * 1024;
+
+    function uriOf(source) {
+        if (!source) return '';
+        if (typeof source === 'string') return source;
+        if (typeof source.toURI === 'function') {
+            try { return source.toURI(); } catch (e) {}
+        }
+        return '';
+    }
+
+    /* Range reader over an http(s) URL.  Both things that serve us HTTP —
+     * the bundled SMB proxy and the transcode server — answer 206 with a
+     * Content-Range, which is also where the file size comes from. */
+    function makeUrlRangeReader(uri) {
+        var knownSize = -1;
+
+        function request(start, length, cb) {
+            var xhr = new XMLHttpRequest();
+            try { xhr.open('GET', uri, true); } catch (e) { cb(e); return; }
+            xhr.responseType = 'arraybuffer';
+            try {
+                xhr.setRequestHeader('Range', 'bytes=' + start + '-' + (start + length - 1));
+            } catch (e) {}
+
+            var aborted = false;
+            /* A server that ignores Range answers 200 with the whole file.
+             * Pulling a 6 GB movie into the WebView would take the app down,
+             * so bail the moment the announced length gives it away. */
+            xhr.onprogress = function (e) {
+                if (aborted || !e || !e.lengthComputable) return;
+                if (e.total <= MAX_RANGE_RESPONSE_BYTES) return;
+                aborted = true;
+                try { xhr.abort(); } catch (_) {}
+                cb(Error('Range ignored by server (offered ' + e.total + ' bytes)'));
+            };
+            xhr.onload = function () {
+                if (aborted) return;
+                var cr = '';
+                try { cr = xhr.getResponseHeader('Content-Range') || ''; } catch (e) {}
+                var m = /\/\s*(\d+)\s*$/.exec(cr);
+                if (m) knownSize = parseInt(m[1], 10);
+                if (xhr.status !== 206 && xhr.status !== 200) {
+                    cb(Error('HTTP ' + xhr.status + ' on range read'));
+                    return;
+                }
+                if (xhr.status !== 206 && knownSize < 0) {
+                    cb(Error('server does not honour Range requests'));
+                    return;
+                }
+                if (!xhr.response) { cb(Error('empty range response')); return; }
+                cb(null, xhr.response);
+            };
+            xhr.onerror = function () {
+                if (!aborted) cb(Error('range read failed: ' + uri));
+            };
+            xhr.send();
+        }
+
+        return {
+            implementation: 'XHR Range (URL)',
+            getSize: function (cb) {
+                if (knownSize >= 0) { cb(null, knownSize); return; }
+                /* One-byte probe purely to read Content-Range's total. */
+                request(0, 1, function (err) {
+                    if (err) { cb(err); return; }
+                    if (knownSize < 0) { cb(Error('no Content-Range on range read')); return; }
+                    cb(null, knownSize);
+                });
+            },
+            readRange: request,
+            close: function () {}
+        };
+    }
+
+    /* Local files borrow mp4-subs.js' reader, which already knows how to
+     * address past 2 GiB on every Tizen FileStream vintage. */
+    function openRangeReader(source, cb) {
+        if (source && source.readRange && source.getSize) { cb(null, source); return; }
+
+        var uri = uriOf(source);
+        if (/^https?:/i.test(uri)) {
+            if (typeof XMLHttpRequest === 'undefined') { cb(Error('no XMLHttpRequest')); return; }
+            cb(null, makeUrlRangeReader(uri));
+            return;
+        }
+        if (typeof Mp4Subs !== 'undefined' && Mp4Subs.openReader) {
+            Mp4Subs.openReader(source, cb);
+            return;
+        }
+        cb(Error('no range reader for ' + (uri || typeof source)));
+    }
+
+    /* Every TrackEntry in the file, in file order — video and audio
+     * included, so callers can map a subtitle's position in the container
+     * onto the indices AVPlay hands out. */
+    function listTracks(source, cb) {
+        var reader = null;
+        var called = false;
+
+        function done(err, tracks) {
+            if (called) return;
+            called = true;
+            if (reader && reader !== source && reader.close) {
+                try { reader.close(); } catch (e) {}
+            }
+            cb(err, tracks || []);
+        }
+
+        openRangeReader(source, function (oerr, r) {
+            if (oerr) { done(oerr); return; }
+            reader = r;
+            reader.getSize(function (serr, size) {
+                if (serr) { done(serr); return; }
+                if (!(size > 0)) { done(Error('unknown file size')); return; }
+                scanForTracks(reader, size, done);
+            });
+        });
+    }
+
+    /* Walk the Segment's direct children until Tracks turns up, seeking
+     * over everything else — a fat SeekHead, cover-art Attachments — rather
+     * than reading it. */
+    function scanForTracks(reader, size, done) {
+        var pos        = 0;
+        var segmentEnd = size;
+        var inSegment  = false;
+
+        /* Longest element header we may need to sit fully inside the
+         * window: a 4-byte id plus an 8-byte size. */
+        var MAX_ELEMENT_HEADER = 12;
+
+        function next() {
+            if (pos + 2 > size || pos >= segmentEnd) { done(null, []); return; }
+            if (pos > MAX_HEADER_PROBE_BYTES) {
+                done(Error('no Tracks element in the first ' +
+                           Math.round(MAX_HEADER_PROBE_BYTES / 1048576) + ' MB'));
+                return;
+            }
+
+            var base = pos;
+            reader.readRange(base, Math.min(HEADER_WINDOW_BYTES, size - base), function (err, buf) {
+                if (err) { done(err); return; }
+
+                var view = new DataView(buf);
+                /* Consume as many sibling elements as this one window can
+                 * describe before paying for another read — the whole
+                 * pre-cluster header is usually a single window. */
+                var at = 0;
+                while (at + MAX_ELEMENT_HEADER <= buf.byteLength) {
+                    var el;
+                    try { el = readElement(view, at); }
+                    catch (e) { done(e); return; }
+
+                    var bodyAbs = base + el.bodyOff;
+                    var endAbs  = bodyAbs + el.size;
+                    /* An unknown-size element (the all-ones vint live
+                     * streams use) or a truncated mux both read as "runs to
+                     * EOF". */
+                    if (!(endAbs > bodyAbs) || endAbs > size) endAbs = size;
+
+                    if (!inSegment) {
+                        if (el.id === ID_SEGMENT) {
+                            inSegment  = true;
+                            segmentEnd = endAbs;
+                            at         = el.bodyOff;      // descend
+                            continue;
+                        }
+                        at = endAbs - base;               // EBML header, Void, …
+                        if (endAbs >= segmentEnd) { done(null, []); return; }
+                        continue;
+                    }
+                    if (el.id === ID_TRACKS) {
+                        readTracksElement(reader, bodyAbs, el.size, done);
+                        return;
+                    }
+                    /* Tracks precedes the media in anything we can play, so
+                     * once the clusters start there is nothing left to
+                     * find. */
+                    if (el.id === ID_CLUSTER) { done(null, []); return; }
+
+                    at = endAbs - base;
+                    if (endAbs >= segmentEnd) { done(null, []); return; }
+                }
+
+                pos = base + at;
+                next();
+            });
+        }
+
+        next();
+    }
+
+    function readTracksElement(reader, bodyAbs, len, done) {
+        if (!(len > 0) || len > MAX_TRACKS_ELEMENT_BYTES) {
+            done(Error('implausible Tracks element size: ' + len));
+            return;
+        }
+        reader.readRange(bodyAbs, len, function (err, buf) {
+            if (err) { done(err); return; }
+            var view = new DataView(buf);
+            var out  = [];
+            walk(view, 0, buf.byteLength, function (id, o, e) {
+                if (id === ID_TRACKENTRY) out.push(parseTrackEntry(view, o, e));
+            });
+            done(null, out);
+        });
+    }
+
     /* ── Public ──────────────────────────────────────────────────────── */
     function extract(file, cb) {
         var uri = (typeof file === 'string') ? file
@@ -382,8 +643,15 @@ var MkvSubs = (function () {
     }
 
     return {
-        extract:       extract,
-        writeSrtToTmp: writeSrtToTmp,
-        cuesToSrt:     cuesToSrt
+        extract:             extract,
+        listTracks:          listTracks,
+        isSubtitleTrack:     isSubtitleTrack,
+        isTextSubtitleTrack: isTextSubtitleTrack,
+        writeSrtToTmp:       writeSrtToTmp,
+        cuesToSrt:           cuesToSrt
     };
 })();
+
+// CommonJS export is ignored by Tizen/browser builds, but lets Node tests
+// require this parser directly.
+if (typeof module !== 'undefined' && module.exports) module.exports = MkvSubs;

--- a/tizen-web-vlc/js/mp4-subs.js
+++ b/tizen-web-vlc/js/mp4-subs.js
@@ -662,6 +662,8 @@ var Mp4Subs = (function () {
         };
     }
 
+    /* Exposed as openReader() so mkv-subs.js can Range-read an MKV header
+     * without duplicating the Tizen FileStream vintage handling below. */
     function openIncrementalReader(file, options, cb) {
         if (file && file.readRange && file.getSize) {
             later(function () { cb(null, file); });
@@ -1279,6 +1281,9 @@ var Mp4Subs = (function () {
     return {
         extract:       extract,
         extractIncremental: extractIncremental,
+        openReader:    function (file, cb) {
+            openIncrementalReader(file, normalizeIncrementalOptions({}), cb);
+        },
         cuesToSrt:     cuesToSrt,
         _extractCueLists: extractCueLists,
         writeSrtToTmp: writeSrtToTmp

--- a/tizen-web-vlc/js/player.js
+++ b/tizen-web-vlc/js/player.js
@@ -76,12 +76,86 @@ var Player = (function () {
         return avplay;
     }
 
+    /* Frame size AVPlay reports for the video that's open, which is what
+     * turns a target aspect ratio into a zoom factor.  Falling back to the
+     * panel's own shape makes the crop modes no-ops rather than wrong. */
+    function avFrameAspect() {
+        try {
+            var info = av().getCurrentStreamInfo();
+            for (var i = 0; info && i < info.length; i++) {
+                if (info[i].type !== 'VIDEO') continue;
+                var p = parseAvExtraInfo(info[i].extra_info);
+                if (p.width > 0 && p.height > 0) return p.width / p.height;
+            }
+        } catch (e) {}
+        return screenAspect();
+    }
+    function screenAspect() {
+        var w = window.innerWidth  || screen.width  || 1920;
+        var h = window.innerHeight || screen.height || 1080;
+        return (h > 0) ? w / h : 16 / 9;
+    }
+
     /* The user's aspect/zoom choice, resolved from Settings each time so a
      * change from the OSD or the settings view takes effect on the next
      * apply without the player caching a stale mode. */
     function aspect() {
         if (typeof AspectRatio === 'undefined') return { av: 'PLAYER_DISPLAY_MODE_LETTER_BOX', fit: 'contain', zoom: 1 };
-        return AspectRatio.current();
+        var mode = AspectRatio.current();
+        if (!mode.targetDar) return mode;
+        /* Bars baked into the frames can only be cropped by magnifying past
+         * the frame edge, and how far depends on the file — so the amount
+         * comes from the frame AVPlay reports, not a fixed step. */
+        return {
+            av:        mode.av,
+            fit:       mode.fit,
+            zoom:      AspectRatio.zoomFor(mode.code, avFrameAspect()),
+            targetDar: mode.targetDar
+        };
+    }
+
+    /* What the current choice actually does to this file.  app.js turns it
+     * into the toast so a mode that cannot change anything says so, instead
+     * of looking broken. */
+    function describeAspect() {
+        var mode  = (typeof AspectRatio !== 'undefined') ? AspectRatio.current() : null;
+        var eff   = aspect();
+        var frame = avFrameAspect();
+        var panel = screenAspect();
+        return {
+            code:      mode ? mode.code : 'fit',
+            zoom:      eff.zoom || 1,
+            frameDar:  frame,
+            screenDar: panel,
+            /* LETTER_BOX, CROPPED_FULL and FULL_SCREEN all resolve to the
+             * same picture once the frame matches the panel — there is
+             * nothing left to letterbox, crop or stretch.  Most 16:9 files
+             * on a 16:9 TV land here, which is why those three modes look
+             * dead however often you cycle them. */
+            noop: (!mode || !mode.targetDar) && (eff.zoom || 1) === 1 &&
+                  Math.abs(frame - panel) < 0.01
+        };
+    }
+
+    /* The <object> the video plane is composited into has to track the
+     * display rect.  Samsung's AVPlay guide is explicit about it: "If you
+     * use the setDisplayRect() method to change the media display area size
+     * or position during media playback, the object element style attribute
+     * must also be changed correspondingly."  Leaving it alone is why every
+     * zoom level used to look identical to Fit — style.css pins the element
+     * to the full screen, and the firmware kept clipping the plane to that
+     * box no matter what rect AVPlay was handed. */
+    function avSyncSurface(x, y, w, h) {
+        var el = document.getElementById('player-object');
+        if (!el) return;
+        try {
+            el.style.left   = x + 'px';
+            el.style.top    = y + 'px';
+            el.style.width  = w + 'px';
+            el.style.height = h + 'px';
+            el.style.right  = 'auto';
+            el.style.bottom = 'auto';
+        } catch (e) {}
     }
 
     function avSetDisplayRect() {
@@ -96,18 +170,24 @@ var Player = (function () {
                  * into the video frames — no display method can do it. */
                 var zw = Math.round(w * z), zh = Math.round(h * z);
                 var zx = Math.round((w - zw) / 2), zy = Math.round((h - zh) / 2);
+                avSyncSurface(zx, zy, zw, zh);
                 av().setDisplayRect(zx, zy, zw, zh);
                 if (typeof Debug !== 'undefined')
-                    Debug.player('AV setDisplayRect zoom ' + z + ' → ' + zx + ',' + zy + ' ' + zw + 'x' + zh);
+                    Debug.player('AV setDisplayRect zoom ' + z.toFixed(3) + ' → ' + zx + ',' + zy + ' ' + zw + 'x' + zh);
                 return;
             }
+            avSyncSurface(0, 0, w, h);
             av().setDisplayRect(0, 0, w, h);
             if (typeof Debug !== 'undefined') Debug.player('AV setDisplayRect ' + w + 'x' + h);
         } catch (e) {
             if (typeof Debug !== 'undefined') Debug.warn('AV setDisplayRect: ' + e.message);
             /* Firmware that rejects an off-screen rect: fall back to the
-             * plain full-screen one so we never leave the video unsized. */
-            if (z !== 1) { try { av().setDisplayRect(0, 0, w, h); } catch (e2) {} }
+             * plain full-screen one so we never leave the video unsized, and
+             * put the surface back with it. */
+            if (z !== 1) {
+                avSyncSurface(0, 0, w, h);
+                try { av().setDisplayRect(0, 0, w, h); } catch (e2) {}
+            }
         }
     }
     function avSetDisplayMethod() {
@@ -718,6 +798,84 @@ var Player = (function () {
     }
     var h5OpenWatchdog = null;
     var playerSubtitles = [];   // sibling subtitle files, regardless of backend
+
+    /* Every subtitle track the container itself declares, read straight out
+     * of the MKV header.  This exists because AVPlay's getTotalTrackInfo()
+     * truncates its return array: a file holding 1 video + 1 audio + 40
+     * subtitle tracks comes back with 32 entries, so the last ten subtitle
+     * tracks are never offered.  The header costs ~130 KB to read however
+     * big the movie is, and it is the list the CC menu counts. */
+    var containerSubTracks     = [];
+    var lastContainerListToken = 0;
+
+    /* The SMB proxy and the transcode server both carry the real filename in
+     * a query parameter, so testing the path's extension alone misses them. */
+    function looksLikeMatroska(url) {
+        var u = String(url || '');
+        return /\.(mkv|webm)(\?|#|$)/i.test(u) ||
+               /[?&][^=&]+=[^&]*\.(mkv|webm)(&|$)/i.test(u);
+    }
+
+    function listContainerSubTracks(uri, file) {
+        containerSubTracks = [];
+        var token = ++lastContainerListToken;
+        if (!looksLikeMatroska(uri)) return;
+        if (typeof MkvSubs === 'undefined' || !MkvSubs.listTracks) return;
+
+        MkvSubs.listTracks(file || uri, function (err, tracks) {
+            if (token !== lastContainerListToken) return;   // another file opened
+            if (err) {
+                if (typeof Debug !== 'undefined')
+                    Debug.warn('MKV header track list: ' + (err.message || err));
+                return;
+            }
+            containerSubTracks = tracks.filter(MkvSubs.isSubtitleTrack);
+            if (typeof Debug !== 'undefined')
+                Debug.player('MKV header declares ' + containerSubTracks.length +
+                             ' subtitle track(s)');
+            emit('onsubsupdated');      // re-render the CC menu if it's open
+        });
+    }
+
+    /* Label for a track read out of the MKV header: the muxer's own name
+     * ('SDH', 'Latin America'), the language tag, and whichever flags tell
+     * two same-language tracks apart. */
+    function containerSubLabel(t, beyondAvplay) {
+        var tag  = (t.lang || '').toUpperCase();
+        var bits = [];
+        if (t.name) bits.push(t.name);
+        if (t.hearingImpaired && !/sdh|hearing/i.test(t.name || '')) bits.push('SDH');
+        if (t.forced          && !/forced/i.test(t.name || ''))      bits.push('forced');
+        if (!bits.length && t.lang && typeof LanguageList !== 'undefined') {
+            /* Only worth adding when LanguageList actually knows the code —
+             * otherwise nameFor() hands the code straight back and the row
+             * would read '[CZE] cze'. */
+            var human = LanguageList.nameFor(t.lang.split('-')[0]);
+            if (human && human.toLowerCase() !== t.lang.toLowerCase()) bits.push(human);
+        }
+        var label = ('(embedded) ' + (tag ? '[' + tag + '] ' : '') +
+                     bits.join(' · ')).replace(/\s+$/, '');
+        /* Marks the tracks the TV's own demuxer never listed — if selecting
+         * one does nothing, this is the row that explains why. */
+        if (beyondAvplay) label += ' ⚠';
+        return label;
+    }
+
+    /* Two tracks can carry the same language and no distinguishing metadata —
+     * a muxer that names one 'SDH' and only flags the other hearing-impaired
+     * produces two identical rows.  Fall back to the container's track number
+     * so the menu never offers the same label twice. */
+    function disambiguateLabels(rows, tracks) {
+        var seen = {};
+        var i;
+        for (i = 0; i < rows.length; i++)
+            seen[rows[i].name] = (seen[rows[i].name] || 0) + 1;
+        for (i = 0; i < rows.length; i++) {
+            if (seen[rows[i].name] < 2) continue;
+            var num = tracks[i] && tracks[i].number;
+            if (num) rows[i].name = rows[i].name.replace(/( ⚠)?$/, ' · track ' + num + '$1');
+        }
+    }
     /* Legacy alias — older code paths used h5Subtitles directly */
     var h5Subtitles = playerSubtitles;
     function h5Open(url, opts) {
@@ -976,6 +1134,8 @@ var Player = (function () {
     function open(url, opts) {
         opts = opts || {};
         cancelEmbeddedSubExtraction('opening another file');
+        containerSubTracks = [];        // previous file's header list
+        ++lastContainerListToken;       // and any header read still in flight
         playerSubtitles = (opts.subtitles) ? opts.subtitles.slice() : [];
         h5Subtitles = playerSubtitles;
         stopExternalSubtitle();    // clear any previous file's poller
@@ -1006,6 +1166,10 @@ var Player = (function () {
             // File handle in opts.file.
             var subsSourceUri = opts.sourceUri || url;
             if (isLocalUrl(subsSourceUri)) extractAndAppendEmbeddedSubs(subsSourceUri, opts.file);
+            /* Independent of extraction, and not limited to local files: the
+             * header read works over the SMB proxy too, and it is the only
+             * thing that sees every track in a big multi-language mux. */
+            listContainerSubTracks(subsSourceUri, opts.file);
 
             // For local files routed to AVPlay (currently: .mkv), supply a
             // fallback so we degrade gracefully to HTML5 if AVPlay can't
@@ -1198,7 +1362,8 @@ var Player = (function () {
         if (!obj) {
             // Not JSON — use as-is, and look for a 3-letter ISO code in it
             var m = s.match(/\b([a-z]{2,3})\b/i);
-            return { label: s, lang: m ? m[1].toLowerCase() : '', codec: s, channels: 0 };
+            return { label: s, lang: m ? m[1].toLowerCase() : '', codec: s, channels: 0,
+                     width: 0, height: 0 };
         }
         var lang  = (obj.language || obj.lang || obj.track_lang || '').toString().toLowerCase();
         var codec = (obj.fourCC || obj.codec || '').toString();
@@ -1207,7 +1372,12 @@ var Player = (function () {
         if (codec) parts.push(codec);
         var channels = parseInt(obj.channels, 10) || 0;
         if (channels) parts.push(channels + 'ch');
-        return { label: parts.join(' · ') || s, lang: lang, codec: codec, channels: channels };
+        return {
+            label: parts.join(' · ') || s, lang: lang, codec: codec, channels: channels,
+            // VIDEO entries carry the frame size; the crop modes need it.
+            width:  parseInt(obj.width,  10) || 0,
+            height: parseInt(obj.height, 10) || 0
+        };
     }
 
     // AVPlay sometimes exposes better language tags than the MP4 metadata
@@ -1309,6 +1479,8 @@ var Player = (function () {
                 }
             } catch (e) {}
 
+            /* AVPlay's own TEXT tracks, in the order it reports them. */
+            var avTextTracks = [];
             try {
                 var info = av().getTotalTrackInfo();
                 for (var i = 0; i < info.length; i++) {
@@ -1340,20 +1512,66 @@ var Player = (function () {
                             active: (t.index === activeAudioIdx)
                         });
                     } else if (t.type === 'TEXT' || t.type === 'SUBTITLE') {
-                        nativeTextCount++;
-                        if (!showEmbed) continue;
-                        out.subtitle.push({
-                            index:  'embed:' + t.index,
-                            name:   '(embedded) ' + (parsed.label || ('Subtitle ' + t.index)),
-                            lang:   parsed.lang || '',
-                            type:   'AVPLAY_EMBED',
-                            // Only count as active if it's the currently selected
-                            // TEXT track AND no external sub is overriding it.
-                            active: (!currentExternalSub && t.index === activeTextIdx)
+                        avTextTracks.push({
+                            index: t.index,
+                            label: parsed.label || ('Subtitle ' + t.index),
+                            lang:  parsed.lang || ''
                         });
                     }
                 }
             } catch (e) {}
+
+            nativeTextCount = avTextTracks.length;
+
+            /* What the container declares beats what AVPlay admits to.  When
+             * the MKV header found more subtitle tracks than
+             * getTotalTrackInfo() returned, its array was truncated, so drive
+             * the menu off the header and continue AVPlay's index sequence
+             * over the tail.  The indices are contiguous in every firmware
+             * we've seen, so extrapolating from the reported ones is the only
+             * way to name a track AVPlay never listed. */
+            if (showEmbed && containerSubTracks.length > avTextTracks.length) {
+                var step = (avTextTracks.length >= 2)
+                    ? (avTextTracks[1].index - avTextTracks[0].index) : 1;
+                if (!step) step = 1;
+                var firstIdx = avTextTracks.length ? avTextTracks[0].index : 0;
+
+                if (typeof Debug !== 'undefined')
+                    Debug.player('CC menu: container has ' + containerSubTracks.length +
+                                 ' subtitle track(s), AVPlay listed ' + avTextTracks.length +
+                                 ' — extrapolating indices from ' + firstIdx + ' step ' + step);
+
+                var containerRows = [];
+                for (var mi = 0; mi < containerSubTracks.length; mi++) {
+                    var ct    = containerSubTracks[mi];
+                    var known = avTextTracks[mi];
+                    var cIdx  = known ? known.index : (firstIdx + mi * step);
+                    containerRows.push({
+                        index:  'embed:' + cIdx,
+                        name:   containerSubLabel(ct, !known),
+                        lang:   ct.lang || (known && known.lang) || '',
+                        type:   'AVPLAY_EMBED',
+                        beyondAvplay: !known,
+                        active: (!currentExternalSub && cIdx === activeTextIdx)
+                    });
+                }
+                disambiguateLabels(containerRows, containerSubTracks);
+                for (var ri = 0; ri < containerRows.length; ri++)
+                    out.subtitle.push(containerRows[ri]);
+            } else if (showEmbed) {
+                for (var ni = 0; ni < avTextTracks.length; ni++) {
+                    var nt = avTextTracks[ni];
+                    out.subtitle.push({
+                        index:  'embed:' + nt.index,
+                        name:   '(embedded) ' + nt.label,
+                        lang:   nt.lang,
+                        type:   'AVPLAY_EMBED',
+                        // Only count as active if it's the currently selected
+                        // TEXT track AND no external sub is overriding it.
+                        active: (!currentExternalSub && nt.index === activeTextIdx)
+                    });
+                }
+            }
 
             // External sibling subtitle files — always listed; this is the
             // reliable rendering path on this firmware.  Extracted-from-MP4
@@ -1373,9 +1591,12 @@ var Player = (function () {
 
             /* Account for tracks the extractor couldn't take.  A muted row is
              * not selectable (nothing can render them) but it stops the list
-             * from silently under-reporting what's in the file. */
-            if (hasExtracted && nativeTextCount > extractedCount) {
-                var missing = nativeTextCount - extractedCount;
+             * from silently under-reporting what's in the file.  The
+             * container's own count is the honest one where we have it —
+             * AVPlay's is short whenever its array was truncated. */
+            var declaredTextCount = Math.max(nativeTextCount, containerSubTracks.length);
+            if (hasExtracted && declaredTextCount > extractedCount) {
+                var missing = declaredTextCount - extractedCount;
                 out.subtitle.push({
                     index:  'missing',
                     name:   '+' + missing + ' embedded track' + (missing === 1 ? '' : 's') +
@@ -1578,8 +1799,24 @@ var Player = (function () {
                 ? parseInt(index.slice(6), 10)
                 : index;
             try { av().setSilentSubtitle(false); } catch (e) {}
-            try { av().setSelectTrack('TEXT', embedIdx); }
-            catch (e) { try { av().setSelectTrack('SUBTITLE', embedIdx); } catch (e2) {} }
+            /* Logged either way: for a track past the end of AVPlay's own
+             * list this is the only signal of whether the firmware honours
+             * an index it never advertised. */
+            try {
+                av().setSelectTrack('TEXT', embedIdx);
+                if (typeof Debug !== 'undefined')
+                    Debug.player('embedded sub: setSelectTrack TEXT ' + embedIdx + ' accepted');
+            } catch (e) {
+                try {
+                    av().setSelectTrack('SUBTITLE', embedIdx);
+                    if (typeof Debug !== 'undefined')
+                        Debug.player('embedded sub: setSelectTrack SUBTITLE ' + embedIdx + ' accepted');
+                } catch (e2) {
+                    if (typeof Debug !== 'undefined')
+                        Debug.warn('embedded sub: setSelectTrack ' + embedIdx +
+                                   ' rejected: ' + (e2.message || e2));
+                }
+            }
             return;
         }
         if (backend !== BACKEND_HTML5) return;
@@ -1843,6 +2080,7 @@ var Player = (function () {
         setSubtitleTrack:   setSubtitleTrack,
         setDisplayRect:     setDisplayRect,
         applyAspect:        applyAspect,
+        describeAspect:     describeAspect,
         isBuffering:        isBuffering,
         lastBufferingMs:    lastBufferingMs,
         setSpeed:           setSpeed,

--- a/tizen-web-vlc/js/settings.js
+++ b/tizen-web-vlc/js/settings.js
@@ -332,9 +332,16 @@ var SubtitleStyle = (function () {
  *      crops the sides instead.  Aspect is preserved.
  *   2. The bars are encoded INTO the frames (a 2.39:1 film muxed as 16:9).
  *      Nothing the display method does can help there: the frame already
- *      matches the screen.  The only fix is to zoom past the frame edge,
- *      which 'zoom110' / 'zoom125' do by handing AVPlay a display rect
+ *      matches the screen, so all three display methods above produce an
+ *      identical picture.  The only fix is to zoom past the frame edge,
+ *      which the zoom and crop modes do by handing AVPlay a display rect
  *      larger than the screen (CSS transform:scale on the HTML5 backend).
+ *
+ * The 'zoom*' modes magnify by a fixed amount.  The 'crop*' modes instead
+ * name the shape the content really is, and player.js works out the zoom
+ * from the frame AVPlay reports — 2.39:1 content inside a 16:9 frame needs
+ * 1.34x, and no fixed step lands on that.  A frame already at or wider than
+ * the target is left alone.
  *
  * 'stretch' is the blunt instrument — fills the screen by distorting the
  * picture.  Some users prefer it, so it stays on the list, labelled.
@@ -342,6 +349,10 @@ var SubtitleStyle = (function () {
  * `av` values are Samsung AVPlay display methods; unsupported ones throw on
  * older firmware, and player.js falls back to LETTER_BOX when they do. */
 var AspectRatio = (function () {
+    /* Magnifying more than this stops being a crop and starts being a
+     * close-up, so no derived zoom goes past it. */
+    var MAX_CROP_ZOOM = 2;
+
     var MODES = [
         { code: 'fit',     name: 'Fit screen (keep black bars)',  short: 'Fit',
           av: 'PLAYER_DISPLAY_MODE_LETTER_BOX',   fit: 'contain', zoom: 1 },
@@ -351,6 +362,13 @@ var AspectRatio = (function () {
           av: 'PLAYER_DISPLAY_MODE_LETTER_BOX',   fit: 'contain', zoom: 1.10 },
         { code: 'zoom125', name: 'Zoom 125% (crop baked-in bars)', short: '125%',
           av: 'PLAYER_DISPLAY_MODE_LETTER_BOX',   fit: 'contain', zoom: 1.25 },
+        // Streaming rips are mostly one of these two shapes letterboxed into
+        // a 16:9 frame, and the zoom each needs is a property of the file,
+        // not a number we can hard-code — hence targetDar.
+        { code: 'crop20',  name: 'Crop to 2:1 (remove baked-in bars)', short: '2:1',
+          av: 'PLAYER_DISPLAY_MODE_LETTER_BOX',   fit: 'contain', zoom: 1, targetDar: 2 },
+        { code: 'crop239', name: 'Crop to 2.39:1 (remove baked-in bars)', short: '2.39',
+          av: 'PLAYER_DISPLAY_MODE_LETTER_BOX',   fit: 'contain', zoom: 1, targetDar: 2.39 },
         // 'Wide' is the label TVs traditionally put on a stretched 16:9
         // picture, and unlike 'Stretch' it fits inside the round OSD button.
         { code: 'stretch', name: 'Stretch (fills, distorts shape)', short: 'Wide',
@@ -366,6 +384,24 @@ var AspectRatio = (function () {
         if (typeof Settings === 'undefined') return MODES[0];
         return find(Settings.get('aspectMode'));
     }
+    /* How far to magnify to crop `code`'s target shape out of a frame of
+     * `frameDar`.  The fixed 'zoom*' modes ignore the frame and return their
+     * own step; the 'crop*' modes derive it, because the zoom that clears
+     * baked-in bars is a property of the file — 2.39:1 content sits in a
+     * 16:9 frame with 1.34x of bar to lose, but in a 2:1 frame with only
+     * 1.19x.  A frame already at or wider than the target needs none.
+     *
+     * Kept here rather than in player.js so it is testable without a
+     * player; player.js supplies the frame AVPlay reports. */
+    function zoomFor(code, frameDar) {
+        var m = find(code);
+        if (!m.targetDar) return m.zoom || 1;
+        if (!(frameDar > 0)) return 1;
+        var z = m.targetDar / frameDar;
+        if (!(z > 1)) return 1;
+        return (z > MAX_CROP_ZOOM) ? MAX_CROP_ZOOM : z;
+    }
+
     /* Next mode in the list — the OSD button cycles rather than opening a
      * picker when the user just wants to flick through them. */
     function next(code) {
@@ -378,6 +414,7 @@ var AspectRatio = (function () {
         forList: function () { return MODES; },
         find:    find,
         current: current,
+        zoomFor: zoomFor,
         next:    next,
         nameFor:  function (c) { return find(c).name; },
         shortFor: function (c) { return find(c).short; }


### PR DESCRIPTION
Both bugs reported against a 6.0 GB 4K Netflix MKV (`Mousetrap.S01E03…2160p.NF.WEB-DL…H.265`). I pulled the file's header and measured it rather than guessing — `ffprobe` puts it at **42 streams: 1 video, 1 audio and 40 `subrip` subtitle tracks**, Vietnamese last at index 41.

## 1. Only 30 of the 40 subtitle tracks reached the menu

`getTotalTrackInfo()` truncates its return array at 32 entries — 1 video + 1 audio + **30** subtitle tracks — so the last ten never got offered. They are exactly the ones a muxer puts last, Vietnamese among them, so the language added in #67 was unreachable on precisely the kind of file that carries it.

Nothing else could cover for it. `MkvSubs.extract()` loads the whole file and bails over `MAX_FULL_LOAD_BYTES` (200 MB vs 6 GB), and the SMB path never reached the extractor at all — `extractAndAppendEmbeddedSubs` is gated on `isLocalUrl()`, and the proxy serves `http://127.0.0.1:8127/smb/stream?path=…`. Full-file extraction isn't the answer either: the subtitle payload is only ~200 KB, but it's interleaved across all 6 GB, so collecting it means reading the movie.

The whole track table sits in the container header, so that's where the list now comes from. **`MkvSubs.listTracks()`** reads it with Range requests:

- 40 tracks off this file in **2 reads / 130 KB**, whatever the movie weighs (`Tracks` is 2390 bytes at offset 4266 here)
- seeks over whatever sits in front of it — a fat `SeekHead`, cover-art `Attachments` — rather than reading it
- works over the SMB proxy and the transcode server (both answer 206 + `Content-Range`) as well as local files, reusing `mp4-subs.js`' reader for the Tizen FileStream vintages
- bails if a server ignores `Range` and starts sending the whole file

`getTracks()` uses that list whenever it's longer than AVPlay's, continuing AVPlay's index sequence over the tail so tracks it never advertised stay selectable. Those rows are marked `⚠`, and `setSelectTrack` now logs whether the firmware accepted an index it never listed — **that log is the one thing still worth checking on a real TV** (see below).

The header also carries labels `extra_info` doesn't:

| | before | after |
|---|---|---|
| track 12 | `(embedded) Subtitle 9` | `(embedded) [ES-419] Latin America (SDH)` |
| track 40 | *absent* | `(embedded) [VIE] ⚠` |

That's `TrackName` (`SDH`, `Latin America`, `Simplified`), `LanguageBCP47` (`es-419` where `Language` only said `spa`), and the forced / hearing-impaired flags. This file names one Korean track `SDH` and merely flags the other hearing-impaired, which would render two identical rows — those fall back to their container track number.

## 2. None of the five aspect modes did anything

**Three of them cannot.** The frame is 3840×2160 with square pixels (`DAR 16:9`) — exactly the panel's shape — so `LETTER_BOX`, `CROPPED_FULL` and `FULL_SCREEN` all resolve to the same picture. There is nothing to letterbox, crop or stretch. That's most 16:9 rips on a 16:9 TV, so the modes look dead however often you cycle them; the toast now says so instead.

**The bars are inside the frames.** Sampling 21 frames puts them at 275 px top / 276 px bottom of 2160, leaving 1609 px of picture — 2.39:1 CinemaScope letterboxed into a 16:9 frame. Only a zoom can remove that, and the zoom modes were broken for an unrelated reason. From Samsung's AVPlay guide:

> If you use the `setDisplayRect()` method to change the media display area size or position during media playback, the `object` element `style` attribute must also be changed correspondingly.

`avSetDisplayRect()` never touched `#player-object`, which `style.css` pins to `top/right/bottom/left: 0; width/height: 100%`. So the firmware kept clipping the video plane to the full-screen CSS box no matter what oversized rect AVPlay was handed, and every zoom level came out identical to Fit. It now moves the surface with the rect, and puts both back together if the firmware rejects the rect.

**Neither zoom step could have cleared these bars anyway** — it takes 2160/1609 = **1.34×**, past 125%. Two crop modes now name the shape the content *is*, with `AspectRatio.zoomFor()` deriving the magnification from the frame AVPlay reports, because the amount is a property of the file: 2.39:1 content needs 1.34× in a 16:9 frame but 1.19× in a 2:1 one, and none at all in a frame already that wide.

| mode | on this file |
|---|---|
| `crop20` — Crop to 2:1 | 1.125× |
| `crop239` — Crop to 2.39:1 | 1.344× → rect `-330,-186 2581×1452`, bars land off-panel |

## Testing

56 tests pass (`node --test tests/tizen-web-vlc/`). New `mkv-subs.test.js` builds synthetic EBML and covers the 42-track shape that exposed this, header-only reads against a declared 6 GB length, seeking over a 5 MB attachment, BCP-47 preference, the flags, bitmap-vs-text, and no-`Tracks` and unreadable-source failure paths. `zoomFor()` is asserted against the bar heights measured off the real file.

The merge path itself was driven end to end against a stubbed AVPlay reporting 30 of 40 tracks — 40 rows out, Vietnamese selectable as `setSelectTrack('TEXT', 39)`, surface style tracking the rect. That harness caught the duplicate-label and trailing-space bugs; I left it out of the repo since the committed tests only cover the pure modules.

## Worth knowing before merge

- **Whether the firmware honours an extrapolated index is unverified** — it can only be answered on a real TV. Enable Settings → Debug logging and pick one of the `⚠` rows: `setSelectTrack … accepted` or `… rejected` says which. If rejected, those ten tracks need extracting server-side, which is the natural follow-up: the transcode server already has ffmpeg and currently strips subtitles (`-sn`), so a `GET /subs?path=…&track=N` returning WebVTT would feed the existing external-subtitle poller and fix them for good. Say the word and I'll do it.
- No version bump here — that goes on its own PR as usual.