### PR TITLE
Read the subtitle track the TV won't select, and drop the modes it can't do

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,16 @@ with VLC-inspired UI and TV remote-friendly navigation.
   embedded MP4/MKV text tracks, painted by the app (AVPlay can't render text
   subs on this firmware), with **customisable size, font, position and
   background** under Settings → Subtitle appearance
-- **Aspect ratio / zoom** — fit, fill (crop the sides), 110% / 125% zoom for
-  bars burned into the picture, or stretch; from the OSD button or
-  Settings → Video aspect ratio
+- **Every embedded track selectable** — a 40-language mux lists all 40, and
+  picking one the TV's own demuxer won't select (it stops at 32 tracks) reads
+  that track's text straight out of the container through its cue index, so
+  it starts showing within a second or two of being picked
+- **Aspect ratio** — fit, fill (crop the sides) or stretch, from the OSD
+  button or Settings → Video aspect ratio.  Bars *burned into* the frames
+  (2.39:1 film muxed as 16:9) can't be cropped by any player on this
+  firmware — AVPlay would need a video plane larger than the screen and it
+  rejects one — so the app says that plainly instead of offering a zoom that
+  does nothing
 - **No native code** — pure HTML/CSS/JS so it runs on any Tizen TV with a
   Public-tier developer cert. No partner-cert or platform-side requirements.
 

--- a/tests/tizen-web-vlc/language-match.test.js
+++ b/tests/tizen-web-vlc/language-match.test.js
@@ -68,7 +68,6 @@ test('fit is the default aspect mode and keeps the letterbox', function () {
     assert.strictEqual(AspectRatio.forList()[0].code, 'fit');
     assert.strictEqual(fit.av, 'PLAYER_DISPLAY_MODE_LETTER_BOX');
     assert.strictEqual(fit.fit, 'contain');
-    assert.strictEqual(fit.zoom, 1);
 });
 
 test('fill crops instead of distorting, stretch distorts', function () {
@@ -78,46 +77,30 @@ test('fill crops instead of distorting, stretch distorts', function () {
     assert.strictEqual(AspectRatio.find('stretch').fit, 'fill');
 });
 
-test('the zoom modes scale past the frame edge', function () {
-    assert.ok(AspectRatio.find('zoom110').zoom > 1);
-    assert.ok(AspectRatio.find('zoom125').zoom > AspectRatio.find('zoom110').zoom);
+test('the list holds only modes AVPlay can actually carry out', function () {
+    /* Zoom and crop modes were offered for two releases and never moved a
+     * pixel: cropping bars baked into the frames needs a display rect bigger
+     * than the screen and centred on it, whose origin is negative, and
+     * setDisplayRect rejects a negative parameter.  They are gone rather
+     * than left on the list looking broken — every mode here is one of the
+     * three display methods the firmware really has. */
+    assert.deepStrictEqual(AspectRatio.forList().map(function (m) { return m.code; }),
+        ['fit', 'fill', 'stretch']);
+    AspectRatio.forList().forEach(function (m) {
+        assert.ok(/^PLAYER_DISPLAY_MODE_/.test(m.av), m.code + ' has no display method');
+        assert.strictEqual(m.zoom, undefined, m.code + ' still carries a zoom factor');
+        assert.strictEqual(m.targetDar, undefined, m.code + ' still carries a crop target');
+    });
 });
 
-test('the crop modes derive their zoom from the frame they are given', function () {
-    var SIXTEEN_NINE = 3840 / 2160;
-
-    // The case that prompted this: 2.39:1 content letterboxed into a 4K 16:9
-    // frame.  Measured on the file, the bars are 275 px top and 276 bottom of
-    // 2160, leaving 1609 px of picture — so 2160/1609 = 1.342x clears them.
-    var z = AspectRatio.zoomFor('crop239', SIXTEEN_NINE);
-    assert.ok(Math.abs(z - 2160 / 1609) < 0.01,
-        'expected ~1.34x to crop 2.39:1 out of 16:9, got ' + z);
-    // Neither fixed step lands there: 125% leaves a bar, and nothing offered
-    // 134% before.
-    assert.ok(z > AspectRatio.find('zoom125').zoom);
-
-    // 2:1 content in the same frame needs much less.
-    assert.ok(Math.abs(AspectRatio.zoomFor('crop20', SIXTEEN_NINE) - 1.125) < 0.001);
-
-    // A frame already that wide has no bars to crop, so it is left alone.
-    assert.strictEqual(AspectRatio.zoomFor('crop239', 2.39), 1);
-    assert.strictEqual(AspectRatio.zoomFor('crop20', 2.39), 1);
-    assert.strictEqual(AspectRatio.zoomFor('crop239', 2.5), 1);
-
-    // Nonsense frame data must not blank the screen.
-    assert.strictEqual(AspectRatio.zoomFor('crop239', 0), 1);
-    assert.strictEqual(AspectRatio.zoomFor('crop239', -1), 1);
-    // An absurdly tall frame is clamped rather than magnified without limit.
-    assert.strictEqual(AspectRatio.zoomFor('crop239', 0.1), 2);
-});
-
-test('zoomFor leaves the fixed and non-zooming modes as they are', function () {
-    assert.strictEqual(AspectRatio.zoomFor('fit', 16 / 9), 1);
-    assert.strictEqual(AspectRatio.zoomFor('fill', 16 / 9), 1);
-    assert.strictEqual(AspectRatio.zoomFor('stretch', 16 / 9), 1);
-    // Fixed steps ignore the frame entirely.
-    assert.strictEqual(AspectRatio.zoomFor('zoom110', 16 / 9), 1.10);
-    assert.strictEqual(AspectRatio.zoomFor('zoom125', 2.39), 1.25);
+test('a mode saved by an older build is not treated as current', function () {
+    // 1.4.0 could persist any of these; find() has to land on Fit and
+    // isKnown() has to let app.js write the setting back.
+    ['zoom110', 'zoom125', 'crop20', 'crop239', 'nonsense', '', undefined].forEach(function (code) {
+        assert.strictEqual(AspectRatio.isKnown(code), false, code + ' should be unknown');
+        assert.strictEqual(AspectRatio.find(code).code, 'fit');
+    });
+    assert.strictEqual(AspectRatio.isKnown('fill'), true);
 });
 
 test('an unknown mode falls back to fit, and next() cycles', function () {

--- a/tests/tizen-web-vlc/mkv-subs.test.js
+++ b/tests/tizen-web-vlc/mkv-subs.test.js
@@ -257,3 +257,326 @@ test('listTracks surfaces an unreadable source as an error', async function () {
         });
     }, /no size/);
 });
+
+/* ── Cue-indexed extraction fixtures ─────────────────────────────────
+ *
+ * A file shaped like the one this exists for: a fat video track, subtitle
+ * blocks scattered through the clusters, and a cue index at the end that
+ * points at every one of them.  Extracting a track has to reach the blocks
+ * through that index without streaming the video. */
+
+var CUE_ID = {
+    INFO:          0x1549A966,
+    TIMECODESCALE: 0x2AD7B1,
+    TIMECODE:      0xE7,
+    SIMPLEBLOCK:   0xA3,
+    BLOCKGROUP:    0xA0,
+    BLOCK:         0xA1,
+    BLOCKDURATION: 0x9B,
+    CODECPRIVATE:  0x63A2,
+    SEEK:          0x4DBB,
+    SEEKID:        0x53AB,
+    SEEKPOSITION:  0x53AC,
+    CUES:          0x1C53BB6B,
+    CUEPOINT:      0xBB,
+    CUETIME:       0xB3,
+    CUETRACKPOS:   0xB7,
+    CUETRACK:      0xF7,
+    CUECLUSTERPOS: 0xF1,
+    CUERELPOS:     0xF0,
+    CUEDURATION:   0xB2
+};
+
+/* Fixed-width big-endian uint — EBML allows the leading zeroes, and a stable
+ * width keeps a SeekPosition patchable after the fact. */
+function uintBytes(n, width) {
+    var out = [];
+    for (var i = (width || 4) - 1; i >= 0; i--) out.unshift(Math.floor(n / Math.pow(256, i)) % 256);
+    return out.reverse();
+}
+
+/* Block body: track vint, i16 cluster-relative timestamp, flags, payload. */
+function blockBody(track, relTs, payload) {
+    return concat([0x80 | track], [(relTs >> 8) & 0xff, relTs & 0xff], [0x80], payload);
+}
+
+function subtitleBlockGroup(track, relTs, text, durationMs) {
+    var body = el(CUE_ID.BLOCK, blockBody(track, relTs, str(text)));
+    if (durationMs) body = concat(body, el(CUE_ID.BLOCKDURATION, uintBytes(durationMs)));
+    return el(CUE_ID.BLOCKGROUP, body);
+}
+
+/* One cluster, and where each subtitle block landed inside its payload —
+ * which is exactly what CueRelativePosition records. */
+function cluster(timecodeMs, videoBytes, subs) {
+    var body = el(CUE_ID.TIMECODE, uintBytes(timecodeMs));
+    body = concat(body, el(CUE_ID.SIMPLEBLOCK, blockBody(1, 0, filler(videoBytes))));
+
+    var positions = [];
+    subs.forEach(function (s) {
+        positions.push({
+            track:  s.track,
+            time:   timecodeMs + (s.relTs || 0),
+            relPos: body.length,
+            dur:    s.dur || 0
+        });
+        body = concat(body, subtitleBlockGroup(s.track, s.relTs || 0, s.text,
+                                               s.noBlockDuration ? 0 : (s.dur || 0)));
+    });
+    return { bytes: el(ID.CLUSTER, body), positions: positions };
+}
+
+function cuesElement(positions, opts) {
+    var byTime = {};
+    positions.forEach(function (p) { (byTime[p.time] = byTime[p.time] || []).push(p); });
+    var times = Object.keys(byTime).map(Number).sort(function (a, b) { return a - b; });
+
+    var body = [];
+    times.forEach(function (t) {
+        var point = el(CUE_ID.CUETIME, uintBytes(t));
+        byTime[t].forEach(function (p) {
+            var tp = concat(el(CUE_ID.CUETRACK, u8(p.track)),
+                            el(CUE_ID.CUECLUSTERPOS, uintBytes(p.clusterPos, 8)));
+            if (!opts.noRelPos)  tp = concat(tp, el(CUE_ID.CUERELPOS, uintBytes(p.relPos)));
+            if (opts.cueDuration) tp = concat(tp, el(CUE_ID.CUEDURATION, uintBytes(p.dur)));
+            point = concat(point, el(CUE_ID.CUETRACKPOS, tp));
+        });
+        body = concat(body, el(CUE_ID.CUEPOINT, point));
+    });
+    return el(CUE_ID.CUES, body);
+}
+
+/* [EBML][Segment [SeekHead][Info][Tracks][Cluster…][Cues]] with every cue
+ * position filled in for real, so the extractor's arithmetic is under test
+ * and not just its parser. */
+function cueIndexedFile(trackEntries, clusters, opts) {
+    opts = opts || {};
+
+    var info   = el(CUE_ID.INFO, el(CUE_ID.TIMECODESCALE, uintBytes(opts.timecodeScale || 1000000)));
+    var tracks = el(ID.TRACKS, trackEntries);
+    function seekHead(cuesPos) {
+        return el(ID.SEEKHEAD, el(CUE_ID.SEEK, concat(
+            el(CUE_ID.SEEKID, idBytes(CUE_ID.CUES)),
+            el(CUE_ID.SEEKPOSITION, uintBytes(cuesPos, 8)))));
+    }
+
+    /* Cue positions count from the Segment's first data byte, so the
+     * elements in front of the clusters set the origin. */
+    function assemble(cuesLen) {
+        var base = seekHead(0).length + info.length + tracks.length + (opts.cuesUpFront ? cuesLen : 0);
+        var positions = [];
+        var body = [];
+        var at   = base;
+        clusters.forEach(function (c) {
+            c.positions.forEach(function (p) {
+                positions.push({
+                    track: p.track, time: p.time, dur: p.dur,
+                    clusterPos: at, relPos: p.relPos
+                });
+            });
+            body = concat(body, c.bytes);
+            at += c.bytes.length;
+        });
+        return { positions: positions, clusterBytes: body, cuesPos: opts.cuesUpFront ? base - cuesLen : at };
+    }
+
+    // Two passes: the cue index's own length shifts everything after it.
+    var first = assemble(0);
+    var cues  = cuesElement(first.positions, opts);
+    var laid  = assemble(cues.length);
+    cues      = cuesElement(laid.positions, opts);
+
+    var children = opts.cuesUpFront
+        ? concat(seekHead(laid.cuesPos), info, tracks, cues, laid.clusterBytes)
+        : concat(seekHead(laid.cuesPos), info, tracks, laid.clusterBytes, cues);
+    return mkvFile(children);
+}
+
+/* A 4K rip's shape in miniature: Korean and Vietnamese lines interleaved,
+ * half a megabyte of video between them. */
+function bilingualFile(opts) {
+    opts = opts || {};
+    var VIDEO = opts.videoBytes === undefined ? 512 * 1024 : opts.videoBytes;
+    var entries = concat(
+        videoTrack(1),
+        audioTrack(2),
+        subtitleTrack(3, { lang: 'kor' }),
+        subtitleTrack(4, { lang: 'vie' })
+    );
+    var clusters = [];
+    for (var i = 0; i < 6; i++) {
+        clusters.push(cluster(i * 10000, VIDEO, [
+            { track: 3, relTs: 100, text: '한국어 ' + i, dur: opts.noBlockDuration ? 0 : 2000,
+              noBlockDuration: opts.noBlockDuration },
+            { track: 4, relTs: 200, text: 'Tiếng Việt ' + i, dur: opts.noBlockDuration ? 0 : 2500,
+              noBlockDuration: opts.noBlockDuration }
+        ]));
+    }
+    return cueIndexedFile(entries, clusters, opts);
+}
+
+function extractTrack(reader, trackNumber, opts) {
+    return new Promise(function (resolve, reject) {
+        MkvSubs.extractTrack(reader, trackNumber, opts || {}, function (err, res) {
+            if (err) reject(err); else resolve(res);
+        });
+    });
+}
+
+test('extractTrack pulls one subtitle track through the cue index', async function () {
+    var reader = stubReader(bilingualFile());
+
+    var res = await extractTrack(reader, 4);
+
+    assert.strictEqual(res.cues.length, 6);
+    assert.strictEqual(res.cues[0].text, 'Tiếng Việt 0');
+    assert.strictEqual(res.cues[5].text, 'Tiếng Việt 5');
+    // 0.2 s into the cluster that starts at 50 s, 2.5 s of BlockDuration.
+    assert.strictEqual(res.cues[5].start, 50.2);
+    assert.strictEqual(res.cues[5].end, 52.7);
+    // Nothing from the other language leaked in.
+    res.cues.forEach(function (c) { assert.ok(!/한국어/.test(c.text)); });
+});
+
+test('extractTrack never reads the video it is skipping past', async function () {
+    // 6 clusters × 512 KB of video: the index has to carry the extractor
+    // straight to the subtitle blocks, or this streams 3 MB.
+    var reader = stubReader(bilingualFile());
+
+    await extractTrack(reader, 4);
+
+    assert.ok(reader.bytesRead < 512 * 1024,
+        'expected less than one video block of reads, got ' + reader.bytesRead + ' bytes');
+});
+
+test('extractTrack keeps cues sorted when it starts at the playhead', async function () {
+    var live   = [];
+    var reader = stubReader(bilingualFile());
+
+    // 30 s in: the reads begin at the cue covering that point and wrap.
+    var res = await extractTrack(reader, 4, { cues: live, startAtMs: 30000 });
+
+    assert.strictEqual(res.cues, live, 'must fill the array the poller is reading');
+    assert.strictEqual(live.length, 6);
+    for (var i = 1; i < live.length; i++)
+        assert.ok(live[i].start > live[i - 1].start, 'cue ' + i + ' out of order');
+    assert.strictEqual(live[0].text, 'Tiếng Việt 0');
+});
+
+test('extractTrack reads the cue index when it sits in front of the media', async function () {
+    var reader = stubReader(bilingualFile({ cuesUpFront: true }));
+
+    var res = await extractTrack(reader, 3);
+
+    assert.strictEqual(res.cues.length, 6);
+    assert.strictEqual(res.cues[0].text, '한국어 0');
+});
+
+test('extractTrack prefers CueDuration over BlockDuration', async function () {
+    var reader = stubReader(bilingualFile({ cueDuration: true }));
+
+    var res = await extractTrack(reader, 4);
+
+    // CueDuration is written from the same figure, so the check is that the
+    // index's own value is what lands on the cue.
+    assert.strictEqual(res.cues[0].end - res.cues[0].start, 2.5);
+});
+
+test('extractTrack ends a cue at the next one when no duration is written', async function () {
+    var reader = stubReader(bilingualFile({ noBlockDuration: true }));
+
+    var res = await extractTrack(reader, 4);
+
+    // Cues are 10 s apart, capped at the 8 s a subtitle line is allowed.
+    assert.strictEqual(res.cues[0].start, 0.2);
+    assert.strictEqual(res.cues[0].end, 8.2);
+    // The last cue has nothing after it to borrow from.
+    assert.strictEqual(res.cues[5].end - res.cues[5].start, 5);
+});
+
+test('extractTrack reports cue counts while it works', async function () {
+    var seen   = [];
+    var reader = stubReader(bilingualFile());
+
+    var res = await extractTrack(reader, 4, {
+        batchSize: 2,
+        onCues: function (have, total) { seen.push([have, total]); }
+    });
+
+    assert.ok(seen.length >= 2, 'expected progress callbacks, got ' + seen.length);
+    assert.deepStrictEqual(seen[seen.length - 1], [6, 6]);
+    assert.strictEqual(res.expected, 6);
+});
+
+test('extractTrack applies the ASS style table from CodecPrivate', async function () {
+    var priv = '[V4+ Styles]\n' +
+        'Format: Name, Fontname, Fontsize, PrimaryColour\n' +
+        'Style: Default,Arial,48,&H00FFFFFF\n[Events]\n';
+    var entries = concat(
+        videoTrack(1),
+        el(ID.TRACKENTRY, concat(
+            el(ID.TRACKNUMBER, u8(2)),
+            el(ID.TRACKTYPE, u8(17)),
+            el(ID.CODECID, str('S_TEXT/ASS')),
+            el(ID.LANGUAGE, str('vie')),
+            el(CUE_ID.CODECPRIVATE, str(priv))))
+    );
+    // ReadOrder,Layer,Style,Name,MarginL,MarginR,MarginV,Effect,Text
+    var line = '0,0,Default,,0,0,0,,Xin chào {\\i1}bạn{\\i0}';
+    var clusters = [cluster(0, 1024, [{ track: 2, relTs: 500, text: line, dur: 3000 }])];
+    var reader = stubReader(cueIndexedFile(entries, clusters, {}));
+
+    var res = await extractTrack(reader, 2);
+
+    assert.strictEqual(res.cues.length, 1);
+    assert.strictEqual(res.cues[0].text, 'Xin chào bạn');
+    assert.strictEqual(res.cues[0].start, 0.5);
+});
+
+test('extractTrack says so when the index holds nothing for the track', async function () {
+    // Cues cover track 4 only; track 3 is in the header but not the index.
+    var entries = concat(videoTrack(1), subtitleTrack(3, { lang: 'kor' }), subtitleTrack(4, { lang: 'vie' }));
+    var clusters = [cluster(0, 4096, [{ track: 4, relTs: 0, text: 'Tiếng Việt', dur: 2000 }])];
+    var reader = stubReader(cueIndexedFile(entries, clusters, {}));
+
+    await assert.rejects(function () { return extractTrack(reader, 3); },
+        /no entries for track 3/);
+});
+
+test('extractTrack says so when the index has no block positions', async function () {
+    // Matroska v1 cues: the cluster is named, the block inside it is not.
+    var reader = stubReader(bilingualFile({ noRelPos: true }));
+
+    await assert.rejects(function () { return extractTrack(reader, 4); },
+        /no block positions/);
+});
+
+test('extractTrack refuses a bitmap subtitle track', async function () {
+    var entries = concat(videoTrack(1), subtitleTrack(2, { lang: 'eng', codec: 'S_HDMV/PGS' }));
+    var clusters = [cluster(0, 4096, [{ track: 2, relTs: 0, text: 'x', dur: 1000 }])];
+    var reader = stubReader(cueIndexedFile(entries, clusters, {}));
+
+    await assert.rejects(function () { return extractTrack(reader, 2); },
+        /only text subtitles/);
+});
+
+test('extractTrack refuses a track the container never declared', async function () {
+    var reader = stubReader(bilingualFile());
+
+    await assert.rejects(function () { return extractTrack(reader, 9); },
+        /no track 9/);
+});
+
+test('extractTrack stops reading when cancelled', async function () {
+    var reader = stubReader(bilingualFile());
+    var calls  = 0;
+
+    var handle = MkvSubs.extractTrack(reader, 4, {}, function () { calls++; });
+    handle.cancel('file closed');
+
+    await new Promise(function (r) { setTimeout(r, 50); });
+    assert.strictEqual(calls, 0, 'a cancelled extraction must not call back');
+    var afterCancel = reader.reads;
+    await new Promise(function (r) { setTimeout(r, 50); });
+    assert.strictEqual(reader.reads, afterCancel, 'reads continued after cancel');
+});

--- a/tizen-web-vlc/js/app.js
+++ b/tizen-web-vlc/js/app.js
@@ -280,7 +280,15 @@
             UI.toast('Playback finished');
             exitPlayer();
         });
+        // A track being read out of the container, or one that turned out
+        // unreadable — the only place the user hears about either.
+        Player.setListener('onsubnotice', function (msg) {
+            if (msg) UI.toast(msg);
+        });
         Player.setListener('onsubsupdated', function () {
+            // Tracks the container declared but AVPlay never listed land
+            // here — give an unmatched language preference another go.
+            retrySubtitlePreference();
             // MP4 embedded-sub extraction completed.  If the CC menu is
             // currently open, re-render it so the new entries appear.
             var menu = document.getElementById('track-menu');
@@ -309,7 +317,11 @@
         UI.showView('view-home');
         updateRepeatButton();        // reflect saved repeat preference on OSD
         updateShuffleButton();       // reflect saved shuffle preference on OSD
-        updateAspectButton();        // reflect saved aspect/zoom mode on OSD
+        /* A mode saved by an older build that no longer exists — the zoom
+           and crop modes AVPlay turned out to be incapable of — would show
+           as Fit on the OSD while the stored value said otherwise. */
+        if (!AspectRatio.isKnown(Settings.get('aspectMode'))) Settings.set('aspectMode', 'fit');
+        updateAspectButton();        // reflect the saved aspect mode on the OSD
         SubtitleStyle.apply();       // push saved subtitle appearance onto the overlay
     }
 
@@ -1273,11 +1285,11 @@
         if (Player.isSpeedMuted && Player.isSpeedMuted()) label += ' 🔇';
         btn.textContent = label;
     }
-    /* Video aspect / zoom (user request: "remove the black bars").  Unlike
-     * playback speed this IS persisted — someone who wants a filled screen
-     * wants it for every file, not just the one that's open.  Applying it
-     * mid-playback is safe on both backends, so the OSD button and the
-     * settings row share this one picker. */
+    /* Video aspect (user request: "remove the black bars").  Unlike playback
+     * speed this IS persisted — someone who wants a filled screen wants it
+     * for every file, not just the one that's open.  Applying it mid-playback
+     * is safe on both backends, so the OSD button and the settings row share
+     * this one picker. */
     function openAspectPicker() {
         var cur = Settings.get('aspectMode');
         openPicker('Video aspect ratio', AspectRatio.forList(), cur, function (val) {
@@ -1291,18 +1303,17 @@
 
     /* Fit / Fill / Wide all come out identical on a file whose frame already
      * matches the panel — the usual case, since most rips are 16:9 on a 16:9
-     * TV.  Saying so beats letting the user cycle every mode looking for the
-     * one that isn't broken. */
+     * TV — and any black bars on such a file are inside the picture, where
+     * nothing AVPlay can do will reach them (settings.js says why).  Telling
+     * the user that beats letting them cycle every mode looking for the one
+     * that isn't broken. */
     function aspectToastNote() {
         if (typeof Player.describeAspect !== 'function') return '';
         var d;
         try { d = Player.describeAspect(); } catch (e) { return ''; }
-        if (!d) return '';
-        if (d.noop)
-            return ' — no change: the picture already fills the screen. ' +
-                   'Bars inside the frame need a Crop mode.';
-        if (d.zoom > 1.005) return ' — zoom ' + Math.round(d.zoom * 100) + '%';
-        return '';
+        if (!d || !d.noop) return '';
+        return ' — no change: this picture already fills the screen. Black bars ' +
+               'inside the frames are part of the picture and can’t be cropped.';
     }
     function updateAspectButton() {
         var btn = document.getElementById('btn-aspect');
@@ -1311,7 +1322,7 @@
         btn.textContent = AspectRatio.shortFor(mode);
         // Highlight whenever the picture is NOT in the default fit mode, so
         // a cropped/stretched picture is never a mystery.
-        btn.classList.toggle('aspect-on', mode !== 'fit');
+        btn.classList.toggle('aspect-on', AspectRatio.isKnown(mode) && mode !== 'fit');
     }
     function openAutoPlayPicker() {
         pickerSetting = 'autoPlay';
@@ -1388,7 +1399,26 @@
         var h = document.getElementById(id);
         if (h) h.textContent = count > 1 ? (label + ' (' + count + ')') : label;
     }
+    /* Re-rendering while a track is being read out of the container must not
+     * throw the cursor back to the active row — the user may be part way
+     * down a 40-item list, and the progress label updates every few
+     * seconds. */
+    function focusedTrackRow() {
+        var el = document.querySelector('#track-menu li.focused');
+        var ul = el && el.parentNode;
+        if (!ul || (ul.id !== 'audio-tracks' && ul.id !== 'subtitle-tracks')) return null;
+        return { list: ul.id, index: [].indexOf.call(ul.children, el) };
+    }
+    function restoreTrackRowFocus(mark) {
+        if (!mark) return false;
+        var ul = document.getElementById(mark.list);
+        var li = ul && ul.children[mark.index];
+        if (!li) return false;
+        UI.focusOn(li);
+        return true;
+    }
     function openTrackMenu() {
+        var keepFocus = focusedTrackRow();
         var t = Player.getTracks();
         var aUL = document.getElementById('audio-tracks');
         var sUL = document.getElementById('subtitle-tracks');
@@ -1426,8 +1456,17 @@
             // the focus order too.
             if (tr.muted) { li.classList.add('muted'); sUL.appendChild(li); return; }
             li.addEventListener('click', function () {
-                Player.setSubtitleTrack(tr.off ? -1 : tr.index);
-                UI.toast('Subtitle: ' + tr.name);
+                // The row, not just its index: a track AVPlay can't select
+                // is read out of the container instead, and that path needs
+                // the container's own track number.
+                var how = Player.setSubtitleTrack(tr.off ? -1 : tr);
+                // 'extracting' announces itself through onsubnotice — a
+                // second toast here would only overwrite it.
+                if (how !== 'extracting') {
+                    UI.toast(how === null
+                        ? 'This TV can’t show ' + tr.name
+                        : 'Subtitle: ' + tr.name);
+                }
                 closeTrackMenu();
             });
             sUL.appendChild(li);
@@ -1435,8 +1474,10 @@
 
         document.getElementById('track-menu').classList.remove('hidden');
         UI.refreshFocusables();
-        // Land on the currently-active track if any, else the first real (non-
-        // muted) track item, else the Close button.
+        // Where the user already was, if this is a re-render.  Otherwise the
+        // currently-active track, else the first real (non-muted) track item,
+        // else the Close button.
+        if (restoreTrackRowFocus(keepFocus)) return;
         var first = document.querySelector('#track-menu .active') ||
                     document.querySelector('#track-menu .track-section li:not(.muted)') ||
                     document.querySelector('#track-menu button');
@@ -1668,10 +1709,12 @@
     }
 
     var prefsAppliedFor = null;
+    var subPrefSettled  = false;
     function applyLanguagePreferences() {
         // Only apply once per file to avoid clobbering manual selections
         if (prefsAppliedFor === state.playingUri) return;
         prefsAppliedFor = state.playingUri;
+        subPrefSettled  = false;
 
         var prefSub   = Settings.get('subtitleLang');
         var tracks    = Player.getTracks();
@@ -1683,37 +1726,59 @@
         // Subtitle: 'off' explicit, '' auto (no action), code → match
         if (prefSub === 'off') {
             Player.setSubtitleTrack(-1);
+            subPrefSettled = true;
             if (typeof Debug !== 'undefined') Debug.player('subtitle pref: off (silent)');
         } else if (prefSub) {
-            var wantSub = prefSub.toLowerCase();
-            // Score each candidate so we can prefer external SRT/VTT files
-            // over AVPlay's embedded (often broken) subtitle tracks.
-            var bestMatch = null;
-            var bestScore = 0;
-            for (var j = 0; j < tracks.subtitle.length; j++) {
-                var st = tracks.subtitle[j];
-                if (st.off) continue;
-
-                var sc = LanguageList.matchScore(wantSub, st.lang, st.name);
-                if (!sc) continue;
-
-                // External subs are reliable on this firmware; embedded ones
-                // often aren't.  Bump externals so they win ties.
-                if (st.type === 'AVPLAY_EXTERNAL' || st.type === 'HTML5_EXTERNAL') sc += 15;
-
-                if (sc > bestScore) { bestScore = sc; bestMatch = st; }
-            }
-            if (bestMatch) {
-                Player.setSubtitleTrack(bestMatch.index);
-                if (typeof Debug !== 'undefined')
-                    Debug.player('applied subtitle pref ' + prefSub + ' → ' + bestMatch.name + ' (score ' + bestScore + ')');
-            } else if (typeof Debug !== 'undefined') {
-                Debug.player('subtitle pref ' + prefSub + ': no matching track in ' +
-                             tracks.subtitle.map(function (x) { return x.name; }).join(' / '));
-            }
-        } else if (typeof Debug !== 'undefined') {
-            Debug.player('subtitle pref: auto (no preference set)');
+            applySubtitlePreference(prefSub, tracks);
+        } else {
+            subPrefSettled = true;
+            if (typeof Debug !== 'undefined') Debug.player('subtitle pref: auto (no preference set)');
         }
+    }
+
+    /* Score every candidate and take the best.  External subs are reliable
+     * on this firmware and embedded ones often aren't, so they win ties. */
+    function applySubtitlePreference(prefSub, tracks) {
+        var wantSub   = prefSub.toLowerCase();
+        var bestMatch = null;
+        var bestScore = 0;
+        for (var j = 0; j < tracks.subtitle.length; j++) {
+            var st = tracks.subtitle[j];
+            if (st.off || st.muted) continue;
+
+            var sc = LanguageList.matchScore(wantSub, st.lang, st.name);
+            if (!sc) continue;
+            if (st.type === 'AVPLAY_EXTERNAL' || st.type === 'HTML5_EXTERNAL') sc += 15;
+
+            if (sc > bestScore) { bestScore = sc; bestMatch = st; }
+        }
+        if (bestMatch) {
+            subPrefSettled = true;
+            Player.setSubtitleTrack(bestMatch);
+            if (typeof Debug !== 'undefined')
+                Debug.player('applied subtitle pref ' + prefSub + ' → ' + bestMatch.name +
+                             ' (score ' + bestScore + ')');
+            return true;
+        }
+        if (typeof Debug !== 'undefined')
+            Debug.player('subtitle pref ' + prefSub + ': no matching track in ' +
+                         tracks.subtitle.map(function (x) { return x.name; }).join(' / '));
+        return false;
+    }
+
+    /* The container's own track list is read after playback starts, so a
+     * preferred language that only exists in the tail of a 40-track mux
+     * becomes matchable a second or two late.  Retry then — but never over
+     * the top of a subtitle that is already showing, which would undo a
+     * choice the user just made by hand. */
+    function retrySubtitlePreference() {
+        if (subPrefSettled) return;
+        if (prefsAppliedFor !== state.playingUri) return;
+        var prefSub = Settings.get('subtitleLang');
+        if (!prefSub || prefSub === 'off') { subPrefSettled = true; return; }
+        var tracks = Player.getTracks();
+        if (!tracks.subtitle.length || !tracks.subtitle[0].active) return;   // one is showing
+        applySubtitlePreference(prefSub, tracks);
     }
 
     /* On the settings view, after the last focusable row there's a TV-info

--- a/tizen-web-vlc/js/mkv-subs.js
+++ b/tizen-web-vlc/js/mkv-subs.js
@@ -115,6 +115,21 @@ var MkvSubs = (function () {
     var ID_BLOCKGROUP    = 0xA0;
     var ID_BLOCK         = 0xA1;
     var ID_BLOCKDURATION = 0x9B;
+    /* Header-level index elements.  The SeekHead is the only thing in front
+     * of the media that knows where the cue index went, and the cue index is
+     * what makes extracting one subtitle track out of a 6 GB file cheap. */
+    var ID_SEEKHEAD      = 0x114D9B74;
+    var ID_SEEK          = 0x4DBB;
+    var ID_SEEKID        = 0x53AB;
+    var ID_SEEKPOSITION  = 0x53AC;
+    var ID_CUES          = 0x1C53BB6B;
+    var ID_CUEPOINT      = 0xBB;
+    var ID_CUETIME       = 0xB3;
+    var ID_CUETRACKPOS   = 0xB7;
+    var ID_CUETRACK      = 0xF7;
+    var ID_CUECLUSTERPOS = 0xF1;
+    var ID_CUERELPOS     = 0xF0;
+    var ID_CUEDURATION   = 0xB2;
 
     /* ── Track entry parser (returns subtitle tracks only) ───────────── */
     function parseTrackEntry(view, off, end) {
@@ -259,20 +274,55 @@ var MkvSubs = (function () {
         return buildCueLists(view, tcScaleNs, subTracks, clusters);
     }
 
+    /* One track's block payload -> a paintable cue.  S_TEXT/ASS and /SSA
+     * carry a dialogue line whose colours live in the CodecPrivate style
+     * table, so that table is parsed once per track and applied per cue;
+     * S_TEXT/UTF8 is the text as it stands.  Shared by the whole-file parse
+     * and by the per-track cue-index extraction below, which is the only
+     * reason it is a separate function. */
+    function makeCueFormatter(track) {
+        var codec   = (track && track.codec) || '';
+        var isAss   = codec.indexOf('ASS') >= 0 || codec.indexOf('SSA') >= 0;
+        var assFile = (isAss && typeof AssStyle !== 'undefined')
+            ? AssStyle.forFile((track && track.priv) || '')
+            : null;
+
+        return function (rawText, startMs, durMs) {
+            var text = (rawText == null ? '' : String(rawText)).trim();
+            if (!text) return null;
+            var runs = null;
+            if (isAss) {
+                if (assFile) {
+                    /* Inline {\c&H..&} overrides plus the CodecPrivate
+                     * [V4+ Styles] defaults become paintable runs. */
+                    var split = splitAssLine(text);
+                    runs = assFile.runs(split.text, split.fields[2] || '');
+                    text = AssStyle.plainText(runs);
+                    if (AssStyle.isPlain(runs)) runs = null;
+                } else {
+                    text = cleanAssLine(text);
+                }
+            }
+            if (!text) return null;
+            return {
+                start: startMs / 1000,
+                end:   (startMs + durMs) / 1000,
+                text:  text,
+                runs:  runs
+            };
+        };
+    }
+
     function buildCueLists(view, tcScaleNs, subTracks, clusters) {
         var toMs = tcScaleNs / 1000000;
         var byTrack = {};
         for (var tn in subTracks) {
-            var codec = subTracks[tn].codec;
-            var isAss = codec.indexOf('ASS') >= 0 || codec.indexOf('SSA') >= 0;
             byTrack[tn] = {
                 id:    subTracks[tn].number,
                 lang:  subTracks[tn].lang || '',
-                codec: codec,
+                codec: subTracks[tn].codec,
                 /* Style table parsed once per track, not per cue. */
-                assFile: (isAss && typeof AssStyle !== 'undefined')
-                    ? AssStyle.forFile(subTracks[tn].priv || '')
-                    : null,
+                fmt:   makeCueFormatter(subTracks[tn]),
                 cues:  []
             };
         }
@@ -284,30 +334,10 @@ var MkvSubs = (function () {
                 if (!t) continue;
                 var startMs = (c.clusterTc + b.relTs) * toMs;
                 var durMs   = (b.duration || 0) * toMs;
-                if (durMs <= 0) durMs = 5000;           // fallback if no BlockDuration
+                if (durMs <= 0) durMs = CUE_FALLBACK_MS;   // no BlockDuration
 
-                var text = readUtf8(view, b.dataOff, b.dataLen).trim();
-                if (!text) continue;
-                var runs = null;
-                if (t.codec.indexOf('ASS') >= 0 || t.codec.indexOf('SSA') >= 0) {
-                    if (t.assFile) {
-                        /* Inline {\c&H..&} overrides plus the CodecPrivate
-                         * [V4+ Styles] defaults become paintable runs. */
-                        var split = splitAssLine(text);
-                        runs = t.assFile.runs(split.text, split.fields[2] || '');
-                        text = AssStyle.plainText(runs);
-                        if (AssStyle.isPlain(runs)) runs = null;
-                    } else {
-                        text = cleanAssLine(text);
-                    }
-                }
-                if (!text) continue;
-                t.cues.push({
-                    start: startMs / 1000,
-                    end:   (startMs + durMs) / 1000,
-                    text:  text,
-                    runs:  runs
-                });
+                var cue = t.fmt(readUtf8(view, b.dataOff, b.dataLen), startMs, durMs);
+                if (cue) t.cues.push(cue);
             }
         }
         var out = [];
@@ -500,15 +530,35 @@ var MkvSubs = (function () {
             reader.getSize(function (serr, size) {
                 if (serr) { done(serr); return; }
                 if (!(size > 0)) { done(Error('unknown file size')); return; }
-                scanForTracks(reader, size, done);
+                readLayout(reader, size, function (lerr, layout) {
+                    done(lerr, layout && layout.tracks);
+                });
             });
         });
     }
 
-    /* Walk the Segment's direct children until Tracks turns up, seeking
-     * over everything else — a fat SeekHead, cover-art Attachments — rather
-     * than reading it. */
-    function scanForTracks(reader, size, done) {
+    /* Walk the Segment's direct children, noting where the header elements
+     * live and seeking over everything else — a fat SeekHead, cover-art
+     * Attachments — rather than reading it.  Stops at the first Cluster:
+     * everything worth having sits in front of the media.
+     *
+     * Yields { segmentDataStart, timecodeScale, tracks, cuesPos, cuesSize,
+     * cuesElementPos }.  The cue index is normally written *after* the
+     * clusters, far out of this scan's reach, so the SeekHead's pointer to
+     * it is picked up on the way past — extractTrack() needs it. */
+    function readLayout(reader, size, done) {
+        var layout = {
+            size:             size,
+            segmentDataStart: -1,
+            timecodeScale:    1000000,   // 1 ms per tick unless Info says otherwise
+            tracks:           [],
+            tracksPos:        -1,
+            tracksSize:       0,
+            cuesPos:          -1,        // Cues body, absolute; -1 when unknown
+            cuesSize:         0,
+            cuesElementPos:   -1         // Cues element start, from the SeekHead
+        };
+
         var pos        = 0;
         var segmentEnd = size;
         var inSegment  = false;
@@ -517,17 +567,52 @@ var MkvSubs = (function () {
          * window: a 4-byte id plus an 8-byte size. */
         var MAX_ELEMENT_HEADER = 12;
 
+        /* A header we could only read part of still yields the track list —
+         * the error only matters when it cost us the Tracks element. */
+        function finish(err) {
+            if (layout.tracksPos < 0) {
+                done(err || null, err ? null : layout);
+                return;
+            }
+            readTracksElement(reader, layout.tracksPos, layout.tracksSize, function (terr, tracks) {
+                if (terr) { done(terr); return; }
+                layout.tracks = tracks;
+                done(null, layout);
+            });
+        }
+
+        function readInfo(view, bodyOff, bodyEnd) {
+            walk(view, bodyOff, bodyEnd, function (id, o, e) {
+                if (id !== ID_TIMECODESCALE) return;
+                var v = readUint(view, o, e - o);
+                if (v > 0) layout.timecodeScale = v;
+            });
+        }
+        function readSeekHead(view, bodyOff, bodyEnd) {
+            walk(view, bodyOff, bodyEnd, function (id, o, e) {
+                if (id !== ID_SEEK) return;
+                var seekId = 0, seekPos = -1;
+                walk(view, o, e, function (sid, so, se) {
+                    if (sid === ID_SEEKID)            seekId  = readUint(view, so, se - so);
+                    else if (sid === ID_SEEKPOSITION) seekPos = readUint(view, so, se - so);
+                });
+                /* SeekPosition counts from the Segment's first data byte. */
+                if (seekId === ID_CUES && seekPos >= 0 && layout.segmentDataStart >= 0)
+                    layout.cuesElementPos = layout.segmentDataStart + seekPos;
+            });
+        }
+
         function next() {
-            if (pos + 2 > size || pos >= segmentEnd) { done(null, []); return; }
+            if (pos + 2 > size || pos >= segmentEnd) { finish(); return; }
             if (pos > MAX_HEADER_PROBE_BYTES) {
-                done(Error('no Tracks element in the first ' +
-                           Math.round(MAX_HEADER_PROBE_BYTES / 1048576) + ' MB'));
+                finish(Error('no Tracks element in the first ' +
+                             Math.round(MAX_HEADER_PROBE_BYTES / 1048576) + ' MB'));
                 return;
             }
 
             var base = pos;
             reader.readRange(base, Math.min(HEADER_WINDOW_BYTES, size - base), function (err, buf) {
-                if (err) { done(err); return; }
+                if (err) { finish(err); return; }
 
                 var view = new DataView(buf);
                 /* Consume as many sibling elements as this one window can
@@ -537,7 +622,7 @@ var MkvSubs = (function () {
                 while (at + MAX_ELEMENT_HEADER <= buf.byteLength) {
                     var el;
                     try { el = readElement(view, at); }
-                    catch (e) { done(e); return; }
+                    catch (e) { finish(e); return; }
 
                     var bodyAbs = base + el.bodyOff;
                     var endAbs  = bodyAbs + el.size;
@@ -550,24 +635,40 @@ var MkvSubs = (function () {
                         if (el.id === ID_SEGMENT) {
                             inSegment  = true;
                             segmentEnd = endAbs;
+                            layout.segmentDataStart = bodyAbs;
                             at         = el.bodyOff;      // descend
                             continue;
                         }
                         at = endAbs - base;               // EBML header, Void, …
-                        if (endAbs >= segmentEnd) { done(null, []); return; }
+                        if (endAbs >= segmentEnd) { finish(); return; }
                         continue;
                     }
+                    /* Info and SeekHead are a few hundred bytes at the very
+                     * front, so they are read out of this window rather than
+                     * fetched again. */
+                    var haveBody = (el.bodyOff + el.size <= buf.byteLength);
+                    if (el.id === ID_INFO && haveBody)
+                        readInfo(view, el.bodyOff, el.bodyOff + el.size);
+                    if (el.id === ID_SEEKHEAD && haveBody)
+                        readSeekHead(view, el.bodyOff, el.bodyOff + el.size);
                     if (el.id === ID_TRACKS) {
-                        readTracksElement(reader, bodyAbs, el.size, done);
-                        return;
+                        layout.tracksPos  = bodyAbs;
+                        layout.tracksSize = el.size;
+                    }
+                    /* A cue index written in front of the media (mkclean and
+                     * some hardware muxers do) beats the SeekHead's pointer:
+                     * its size comes free with the header. */
+                    if (el.id === ID_CUES) {
+                        layout.cuesPos  = bodyAbs;
+                        layout.cuesSize = el.size;
                     }
                     /* Tracks precedes the media in anything we can play, so
                      * once the clusters start there is nothing left to
                      * find. */
-                    if (el.id === ID_CLUSTER) { done(null, []); return; }
+                    if (el.id === ID_CLUSTER) { finish(); return; }
 
                     at = endAbs - base;
-                    if (endAbs >= segmentEnd) { done(null, []); return; }
+                    if (endAbs >= segmentEnd) { finish(); return; }
                 }
 
                 pos = base + at;
@@ -592,6 +693,357 @@ var MkvSubs = (function () {
             });
             done(null, out);
         });
+    }
+
+    /* ── Single-track extraction over the cue index ───────────────────
+     *
+     * listTracks() can name all 40 subtitle tracks, but naming them is not
+     * selecting them: AVPlay's setSelectTrack('TEXT', n) only works for the
+     * tracks its own getTotalTrackInfo() returned, and that array stops at
+     * 32 entries.  Handed an index it never advertised it leaves the track
+     * that was already playing on screen — which is exactly what a user
+     * picking Vietnamese out of the tail of the list sees.  So for those
+     * tracks the text has to come from the container and be painted by the
+     * external-subtitle poller, and extract() can't supply it: it loads the
+     * whole movie and gives up over MAX_FULL_LOAD_BYTES.
+     *
+     * The cue index makes one track affordable.  mkvmerge's default is
+     * `--cues iframes` for subtitle tracks and every subtitle block is a
+     * keyframe, so Cues carries a CueTrackPositions for every single
+     * subtitle cue in the file: the cluster it lives in, its offset inside
+     * that cluster, its timestamp, usually its duration.  Extracting one
+     * track out of a 6 GB file is then one read of the index plus one short
+     * read per cue — a couple of MB, not 6 GB.  Reads start at the playhead,
+     * so the track the user just picked appears within a second and the rest
+     * of the file fills in behind it.
+     */
+
+    var BLOCK_WINDOW_BYTES      = 16 * 1024;         // per-cue read
+    var MAX_BLOCK_BYTES         = 512 * 1024;        // sanity bound on a block header
+    var MAX_CUES_ELEMENT_BYTES  = 32 * 1024 * 1024;
+    var CLUSTER_HEADER_MAX      = 12;                // 4-byte id + 8-byte size vint
+    var CUE_FALLBACK_MS         = 5000;              // no duration anywhere
+    var CUE_MAX_GAP_MS          = 8000;              // cap when the end comes from the next cue
+    var CUE_BATCH               = 24;                // cues per onCues callback
+    var MAX_BLOCK_READ_FAILURES = 12;
+    var READS_PER_TICK          = 4;                 // reads between pauses
+    /* The drive or share being read is the same one feeding the video, so the
+     * scan gives it room to breathe rather than issuing hundreds of seeks
+     * back to back.  A subtitle track is a few hundred cues; even paced, the
+     * ones around the playhead land in the first second. */
+    var TICK_PAUSE_MS           = 10;
+
+    function later(fn) { setTimeout(fn, TICK_PAUSE_MS); }
+
+    /* Every cue in the index that belongs to `trackNumber`, in time order.
+     * A CuePoint holds one timestamp and one CueTrackPositions per track
+     * that has a block at it, which is why a 40-track file's index is worth
+     * reading once and filtering. */
+    function parseCuePositions(buf, trackNumber) {
+        var view = new DataView(buf);
+        var out  = [];
+        walk(view, 0, buf.byteLength, function (id, off, end) {
+            if (id !== ID_CUEPOINT) return;
+            var time  = -1;
+            var mine  = [];
+            walk(view, off, end, function (cid, co, ce) {
+                if (cid === ID_CUETIME) { time = readUint(view, co, ce - co); return; }
+                if (cid !== ID_CUETRACKPOS) return;
+                var p = { track: 0, clusterPos: -1, relPos: -1, duration: 0 };
+                walk(view, co, ce, function (pid, po, pe) {
+                    switch (pid) {
+                        case ID_CUETRACK:      p.track      = readUint(view, po, pe - po); break;
+                        case ID_CUECLUSTERPOS: p.clusterPos = readUint(view, po, pe - po); break;
+                        case ID_CUERELPOS:     p.relPos     = readUint(view, po, pe - po); break;
+                        case ID_CUEDURATION:   p.duration   = readUint(view, po, pe - po); break;
+                    }
+                });
+                if (p.track === trackNumber) mine.push(p);
+            });
+            if (time < 0) return;
+            for (var i = 0; i < mine.length; i++) {
+                mine[i].time = time;
+                out.push(mine[i]);
+            }
+        });
+        out.sort(function (a, b) { return a.time - b.time; });
+        return out;
+    }
+
+    /* Extract one subtitle track, cue by cue.  `opts.cues` lets the caller
+     * pass the very array the subtitle poller is reading, so cues render as
+     * they arrive; it stays sorted, and the reference is never replaced.
+     * Returns a handle whose cancel() stops the reads (a new file, or the
+     * user picking a different track). */
+    function extractTrack(source, trackNumber, opts, cb) {
+        if (typeof opts === 'function') { cb = opts; opts = {}; }
+        opts = opts || {};
+
+        var cues      = opts.cues || [];
+        var startAtMs = opts.startAtMs || 0;
+        var batch     = opts.batchSize || CUE_BATCH;
+        var reader    = null;
+        var owns      = false;
+        var cancelled = false;
+        var settled   = false;
+
+        function log(m)  { if (typeof Debug !== 'undefined') Debug.player('MKV track ' + trackNumber + ': ' + m); }
+        function warn(m) { if (typeof Debug !== 'undefined') Debug.warn('MKV track ' + trackNumber + ': ' + m); }
+
+        function settle(err, expected) {
+            if (settled) return;
+            settled = true;
+            if (owns && reader && reader.close) { try { reader.close(); } catch (e) {} }
+            reader = null;
+            if (cancelled || typeof cb !== 'function') return;
+            cb(err || null, { cues: cues, cueCount: cues.length, expected: expected || cues.length });
+        }
+        function fail(err) {
+            warn(err.message || err);
+            settle(err);
+        }
+
+        /* The poller walks the array in order and stops at the first cue
+         * that starts after the playhead, so out-of-order arrivals (the
+         * reads wrap round to the start of the file) have to be inserted,
+         * not appended. */
+        function insertCue(cue) {
+            var i = cues.length - 1;
+            while (i >= 0 && cues[i].start > cue.start) i--;
+            cues.splice(i + 1, 0, cue);
+        }
+
+        function isOurTrack(n) { return n === trackNumber; }
+
+        function loadCues(layout, track) {
+            if (layout.cuesPos >= 0 && layout.cuesSize > 0) {
+                readCuesBody(layout, track, layout.cuesPos, layout.cuesSize);
+                return;
+            }
+            if (layout.cuesElementPos < 0) {
+                fail(Error('no cue index in this file — nothing points at a Cues element'));
+                return;
+            }
+            /* Only the SeekHead knew about it, so its size has to be read
+             * off the element itself. */
+            reader.readRange(layout.cuesElementPos, CLUSTER_HEADER_MAX + 4, function (err, buf) {
+                if (cancelled) { settle(); return; }
+                if (err) { fail(err); return; }
+                var el;
+                try { el = readElement(new DataView(buf), 0); }
+                catch (e) { fail(e); return; }
+                if (el.id !== ID_CUES) {
+                    fail(Error('SeekHead pointed at element 0x' + el.id.toString(16) + ', not Cues'));
+                    return;
+                }
+                readCuesBody(layout, track, layout.cuesElementPos + el.bodyOff, el.size);
+            });
+        }
+
+        function readCuesBody(layout, track, bodyAbs, len) {
+            if (!(len > 0)) { fail(Error('empty cue index')); return; }
+            if (len > MAX_CUES_ELEMENT_BYTES) {
+                fail(Error('cue index too big to read: ' + Math.round(len / 1048576) + ' MB'));
+                return;
+            }
+            if (bodyAbs + len > layout.size) len = layout.size - bodyAbs;
+            reader.readRange(bodyAbs, len, function (err, buf) {
+                if (cancelled) { settle(); return; }
+                if (err) { fail(err); return; }
+                var entries;
+                try { entries = parseCuePositions(buf, trackNumber); }
+                catch (e) { fail(e); return; }
+                if (!entries.length) {
+                    fail(Error('cue index has no entries for track ' + trackNumber));
+                    return;
+                }
+                fetchBlocks(layout, track, entries);
+            });
+        }
+
+        function fetchBlocks(layout, track, entries) {
+            var fmt  = makeCueFormatter(track);
+            var toMs = layout.timecodeScale / 1000000;
+            var i;
+            for (i = 0; i < entries.length; i++) {
+                entries[i].startMs = entries[i].time * toMs;
+                /* CueRelativePosition counts from the cluster's first *data*
+                 * byte, and the length of the cluster's own header (5–12
+                 * bytes) isn't in the index — so this is the earliest byte
+                 * the block can start at, and take() finds it from there. */
+                entries[i].at    = layout.segmentDataStart + entries[i].clusterPos + entries[i].relPos;
+                entries[i].endMs = (i + 1 < entries.length) ? entries[i + 1].time * toMs : 0;
+            }
+
+            /* Whatever covers the playhead first: the user sees the track
+             * they picked almost at once, and the rest arrives behind it. */
+            var first = 0;
+            while (first < entries.length && entries[first].startMs < startAtMs) first++;
+            if (first >= entries.length) first = 0;
+            var order = entries.slice(first).concat(entries.slice(0, first));
+
+            var pos = 0, failures = 0, missed = 0, sinceCallback = 0, reads = 0;
+            /* The cluster-header length the first block turned up at.  It is
+             * the same for every cluster a muxer writes, so trying it first
+             * both skips the scan and keeps a stray 0xA3 in the video bytes
+             * ahead of the block from being mistaken for one. */
+            var hdrLen = -1;
+
+            function announce() {
+                sinceCallback = 0;
+                if (typeof opts.onCues !== 'function') return;
+                try { opts.onCues(cues.length, entries.length); } catch (e) {}
+            }
+
+            /* The block sits somewhere in the first CLUSTER_HEADER_MAX bytes
+             * of the window; the one that parses as a block of this track is
+             * it.  Checking the track rules out a false hit on a byte of the
+             * cluster's size vint. */
+            function take(view, windowStart, entry) {
+                for (var n = 0; n <= CLUSTER_HEADER_MAX + 1; n++) {
+                    /* Known header length first, then every candidate. */
+                    var skip = (hdrLen >= 0)
+                        ? (n === 0 ? hdrLen : n - 1)
+                        : n;
+                    if (skip > CLUSTER_HEADER_MAX) continue;
+                    if (hdrLen >= 0 && n > 0 && skip === hdrLen) continue;
+                    var at = entry.at - windowStart + skip;
+                    if (at < 0) continue;
+                    if (at + 4 > view.byteLength) break;
+                    var head = view.getUint8(at);
+                    if (head !== ID_SIMPLEBLOCK && head !== ID_BLOCKGROUP) continue;
+                    var el;
+                    try { el = readElement(view, at); } catch (e) { continue; }
+                    if (el.id !== ID_SIMPLEBLOCK && el.id !== ID_BLOCKGROUP) continue;
+                    if (!(el.size > 0) || el.size > MAX_BLOCK_BYTES) continue;
+                    if (el.bodyEnd > view.byteLength) continue;   // block ran past the window
+                    var b = (el.id === ID_SIMPLEBLOCK)
+                        ? parseBlock(view, el.bodyOff, el.bodyEnd, isOurTrack)
+                        : parseBlockGroup(view, el.bodyOff, el.bodyEnd, isOurTrack);
+                    if (!b) continue;
+
+                    /* Three places carry the end time, in order of trust:
+                     * the cue's own CueDuration, the block group's
+                     * BlockDuration, and failing both, the next cue. */
+                    var durMs = entry.duration ? entry.duration * toMs
+                              : b.duration     ? b.duration * toMs
+                              : (entry.endMs > entry.startMs)
+                                  ? Math.min(entry.endMs - entry.startMs, CUE_MAX_GAP_MS)
+                                  : CUE_FALLBACK_MS;
+                    var cue = fmt(readUtf8(view, b.dataOff, b.dataLen), entry.startMs, durMs);
+                    if (cue) insertCue(cue);
+                    hdrLen = skip;
+                    return true;
+                }
+                return false;
+            }
+
+            function step() {
+                if (cancelled) { settle(); return; }
+                while (pos < order.length && order[pos].done) pos++;
+                if (pos >= order.length) {
+                    announce();
+                    /* Every entry accounted for and nothing to show: a
+                     * Matroska v1 index that names clusters but not the
+                     * blocks inside them, or a source that stopped
+                     * answering.  Either way there is no track to paint,
+                     * and the caller has to hear about it. */
+                    if (!cues.length) {
+                        fail(Error('cue index has no block positions for track ' + trackNumber +
+                                   ' (' + entries.length + ' entries, none readable)'));
+                        return;
+                    }
+                    log('extracted ' + cues.length + ' cues of ' + entries.length +
+                        (missed ? ' (' + missed + ' unreadable)' : ''));
+                    settle(null, entries.length);
+                    return;
+                }
+
+                var entry = order[pos];
+                if (!(entry.relPos >= 0) || !(entry.at >= 0) || entry.at >= layout.size) {
+                    /* A cue index without CueRelativePosition (Matroska v1)
+                     * points at the cluster but not at the block inside it,
+                     * and hunting for it would mean reading the cluster —
+                     * megabytes of video per subtitle line. */
+                    entry.done = true;
+                    missed++;
+                    step();
+                    return;
+                }
+
+                var start = entry.at;
+                var len   = Math.min(BLOCK_WINDOW_BYTES, layout.size - start);
+                reader.readRange(start, len, function (err, buf) {
+                    if (cancelled) { settle(); return; }
+                    if (err) {
+                        entry.done = true;
+                        if (++failures > MAX_BLOCK_READ_FAILURES) {
+                            fail(Error('gave up after ' + failures + ' failed reads: ' +
+                                       (err.message || err)));
+                            return;
+                        }
+                        later(step);
+                        return;
+                    }
+
+                    var view = new DataView(buf);
+                    var end  = start + buf.byteLength;
+                    /* Consecutive cues of one track often share a cluster,
+                     * so this window can settle several of them. */
+                    for (var k = pos; k < order.length; k++) {
+                        var e2 = order[k];
+                        if (e2.done || e2.at < start || e2.at >= end) continue;
+                        if (take(view, start, e2)) { e2.done = true; sinceCallback++; }
+                        else if (k === pos)        { e2.done = true; missed++; }
+                    }
+                    if (sinceCallback >= batch) announce();
+                    if ((++reads % READS_PER_TICK) === 0) later(step);
+                    else step();
+                });
+            }
+
+            log(entries.length + ' cue entries in the index, reading from ' +
+                Math.round(startAtMs / 1000) + 's');
+            step();
+        }
+
+        openRangeReader(source, function (oerr, r) {
+            if (cancelled) { settle(); return; }
+            if (oerr) { fail(oerr); return; }
+            reader = r;
+            owns   = (r !== source);
+            reader.getSize(function (serr, size) {
+                if (cancelled) { settle(); return; }
+                if (serr) { fail(serr); return; }
+                if (!(size > 0)) { fail(Error('unknown file size')); return; }
+                readLayout(reader, size, function (lerr, layout) {
+                    if (cancelled) { settle(); return; }
+                    if (lerr) { fail(lerr); return; }
+                    var track = null;
+                    for (var i = 0; i < layout.tracks.length; i++)
+                        if (layout.tracks[i].number === trackNumber) track = layout.tracks[i];
+                    if (!track) {
+                        fail(Error('container has no track ' + trackNumber));
+                        return;
+                    }
+                    if (!isTextSubtitleTrack(track)) {
+                        fail(Error('track ' + trackNumber + ' is ' + (track.codec || 'not text') +
+                                   ' — only text subtitles can be painted'));
+                        return;
+                    }
+                    loadCues(layout, track);
+                });
+            });
+        });
+
+        return {
+            cancel: function (reason) {
+                if (settled) return;
+                cancelled = true;
+                if (reason) log('cancelled: ' + reason);
+                settle();
+            }
+        };
     }
 
     /* ── Public ──────────────────────────────────────────────────────── */
@@ -644,6 +1096,7 @@ var MkvSubs = (function () {
 
     return {
         extract:             extract,
+        extractTrack:        extractTrack,
         listTracks:          listTracks,
         isSubtitleTrack:     isSubtitleTrack,
         isTextSubtitleTrack: isTextSubtitleTrack,

--- a/tizen-web-vlc/js/player.js
+++ b/tizen-web-vlc/js/player.js
@@ -59,9 +59,12 @@ var Player = (function () {
         onbuffering:    null,
         onprogress:     null,
         oncomplete:     null,
-        onsubsupdated:  null    // fired when extracted-from-MP4 subs land in
+        onsubsupdated:  null,   // fired when extracted-from-MP4 subs land in
                                 // playerSubtitles after open() — lets the CC
                                 // menu re-render if it's currently visible
+        onsubnotice:    null    // user-facing subtitle message (a track being
+                                // read out of the container, or one that
+                                // couldn't be) — app.js toasts it
     };
     function setListener(name, fn) { if (name in listeners) listeners[name] = fn; }
     function emit(name) {
@@ -72,13 +75,35 @@ var Player = (function () {
     var avplay = null;
     function av() {
         if (avplay) return avplay;
-        if (typeof webapis !== 'undefined' && webapis.avplay) avplay = webapis.avplay;
+        if (typeof webapis !== 'undefined' && webapis.avplay) {
+            avplay = webapis.avplay;
+            logAvplayApi();
+        }
         return avplay;
     }
 
-    /* Frame size AVPlay reports for the video that's open, which is what
-     * turns a target aspect ratio into a zoom factor.  Falling back to the
-     * panel's own shape makes the crop modes no-ops rather than wrong. */
+    /* One-time inventory of the geometry calls the firmware actually has.
+     * settings.js explains why there are only three aspect modes: AVPlay's
+     * documented surface can position the picture but never crop or magnify
+     * it.  If some set turns out to expose a call that can, this line in the
+     * log is the only place it would show up. */
+    var avplayApiLogged = false;
+    function logAvplayApi() {
+        if (avplayApiLogged || typeof Debug === 'undefined') return;
+        avplayApiLogged = true;
+        var probes = ['setVideoRoi', 'setCropArea', 'setZoom', 'setScaling', 'setPictureSize'];
+        var found  = [];
+        for (var i = 0; i < probes.length; i++) {
+            try { if (typeof avplay[probes[i]] === 'function') found.push(probes[i]); }
+            catch (e) {}
+        }
+        Debug.player('avplay crop/zoom API: ' + (found.join(' ') || 'none (display rect only)'));
+    }
+
+    /* Frame shape AVPlay reports for the video that's open, against the
+     * panel's own — the pair that says whether a display method has anything
+     * left to do.  Falling back to the panel's shape makes the answer "no"
+     * rather than a wrong guess. */
     function avFrameAspect() {
         try {
             var info = av().getCurrentStreamInfo();
@@ -96,98 +121,52 @@ var Player = (function () {
         return (h > 0) ? w / h : 16 / 9;
     }
 
-    /* The user's aspect/zoom choice, resolved from Settings each time so a
-     * change from the OSD or the settings view takes effect on the next
-     * apply without the player caching a stale mode. */
+    /* The user's aspect choice, resolved from Settings each time so a change
+     * from the OSD or the settings view takes effect on the next apply
+     * without the player caching a stale mode. */
     function aspect() {
-        if (typeof AspectRatio === 'undefined') return { av: 'PLAYER_DISPLAY_MODE_LETTER_BOX', fit: 'contain', zoom: 1 };
-        var mode = AspectRatio.current();
-        if (!mode.targetDar) return mode;
-        /* Bars baked into the frames can only be cropped by magnifying past
-         * the frame edge, and how far depends on the file — so the amount
-         * comes from the frame AVPlay reports, not a fixed step. */
-        return {
-            av:        mode.av,
-            fit:       mode.fit,
-            zoom:      AspectRatio.zoomFor(mode.code, avFrameAspect()),
-            targetDar: mode.targetDar
-        };
+        if (typeof AspectRatio === 'undefined')
+            return { av: 'PLAYER_DISPLAY_MODE_LETTER_BOX', fit: 'contain' };
+        return AspectRatio.current();
     }
 
     /* What the current choice actually does to this file.  app.js turns it
-     * into the toast so a mode that cannot change anything says so, instead
+     * into the toast, so a mode that cannot change anything says so instead
      * of looking broken. */
     function describeAspect() {
         var mode  = (typeof AspectRatio !== 'undefined') ? AspectRatio.current() : null;
-        var eff   = aspect();
         var frame = avFrameAspect();
         var panel = screenAspect();
         return {
             code:      mode ? mode.code : 'fit',
-            zoom:      eff.zoom || 1,
             frameDar:  frame,
             screenDar: panel,
             /* LETTER_BOX, CROPPED_FULL and FULL_SCREEN all resolve to the
              * same picture once the frame matches the panel — there is
-             * nothing left to letterbox, crop or stretch.  Most 16:9 files
-             * on a 16:9 TV land here, which is why those three modes look
-             * dead however often you cycle them. */
-            noop: (!mode || !mode.targetDar) && (eff.zoom || 1) === 1 &&
-                  Math.abs(frame - panel) < 0.01
+             * nothing left to letterbox, crop or stretch.  Most rips are
+             * 16:9 on a 16:9 TV and land here, which is why cycling the
+             * modes on one looks like nothing is working: any black bars on
+             * such a file are inside the frames, and settings.js explains
+             * why nothing in AVPlay can crop those. */
+            noop: Math.abs(frame - panel) < 0.01
         };
     }
 
-    /* The <object> the video plane is composited into has to track the
-     * display rect.  Samsung's AVPlay guide is explicit about it: "If you
-     * use the setDisplayRect() method to change the media display area size
-     * or position during media playback, the object element style attribute
-     * must also be changed correspondingly."  Leaving it alone is why every
-     * zoom level used to look identical to Fit — style.css pins the element
-     * to the full screen, and the firmware kept clipping the plane to that
-     * box no matter what rect AVPlay was handed. */
-    function avSyncSurface(x, y, w, h) {
-        var el = document.getElementById('player-object');
-        if (!el) return;
-        try {
-            el.style.left   = x + 'px';
-            el.style.top    = y + 'px';
-            el.style.width  = w + 'px';
-            el.style.height = h + 'px';
-            el.style.right  = 'auto';
-            el.style.bottom = 'auto';
-        } catch (e) {}
-    }
-
+    /* The video plane fills the screen; #player-object's CSS box already
+     * matches it, which is what Samsung's guide asks for ("if you use
+     * setDisplayRect() to change the media display area size or position
+     * during media playback, the object element style attribute must also be
+     * changed correspondingly").  Nothing here ever moves it off that box —
+     * a rect that starts off-screen is what a zoom would need, and AVPlay
+     * rejects those. */
     function avSetDisplayRect() {
         var w = window.innerWidth  || screen.width  || 1920;
         var h = window.innerHeight || screen.height || 1080;
-        var z = aspect().zoom || 1;
         try {
-            if (z !== 1) {
-                /* Zoom past the frame edge: hand AVPlay a rect bigger than
-                 * the screen, centred, so the overflow falls outside the
-                 * panel.  This is the only way to crop bars that are baked
-                 * into the video frames — no display method can do it. */
-                var zw = Math.round(w * z), zh = Math.round(h * z);
-                var zx = Math.round((w - zw) / 2), zy = Math.round((h - zh) / 2);
-                avSyncSurface(zx, zy, zw, zh);
-                av().setDisplayRect(zx, zy, zw, zh);
-                if (typeof Debug !== 'undefined')
-                    Debug.player('AV setDisplayRect zoom ' + z.toFixed(3) + ' → ' + zx + ',' + zy + ' ' + zw + 'x' + zh);
-                return;
-            }
-            avSyncSurface(0, 0, w, h);
             av().setDisplayRect(0, 0, w, h);
             if (typeof Debug !== 'undefined') Debug.player('AV setDisplayRect ' + w + 'x' + h);
         } catch (e) {
             if (typeof Debug !== 'undefined') Debug.warn('AV setDisplayRect: ' + e.message);
-            /* Firmware that rejects an off-screen rect: fall back to the
-             * plain full-screen one so we never leave the video unsized, and
-             * put the surface back with it. */
-            if (z !== 1) {
-                avSyncSurface(0, 0, w, h);
-                try { av().setDisplayRect(0, 0, w, h); } catch (e2) {}
-            }
         }
     }
     function avSetDisplayMethod() {
@@ -204,20 +183,15 @@ var Player = (function () {
         }
     }
 
-    /* HTML5 backend equivalent: object-fit covers cases 1 and 3, a CSS
-     * scale() handles the zoom levels.  body is overflow:hidden, so the
-     * scaled overflow is clipped exactly like the AVPlay rect. */
+    /* HTML5 backend equivalent: object-fit does the same three jobs the
+     * AVPlay display methods do. */
     function h5ApplyAspect() {
         var v = h5el();
         if (!v) return;
-        var mode = aspect();
-        try {
-            v.style.objectFit = mode.fit;
-            v.style.transform = (mode.zoom && mode.zoom !== 1) ? 'scale(' + mode.zoom + ')' : '';
-        } catch (e) {}
+        try { v.style.objectFit = aspect().fit; } catch (e) {}
     }
 
-    /* Push the current aspect/zoom mode onto whichever backend is live. */
+    /* Push the current aspect mode onto whichever backend is live. */
     function applyAspect() {
         if (backend === BACKEND_AVPLAY)     { avSetDisplayRect(); avSetDisplayMethod(); }
         else if (backend === BACKEND_HTML5) { h5ApplyAspect(); }
@@ -837,6 +811,14 @@ var Player = (function () {
         });
     }
 
+    /* Bitmap subs (PGS, VobSub) hold pictures, not text: nothing in this
+     * player can paint them, so a track carrying them is only selectable if
+     * AVPlay itself will render it. */
+    function containerSubExtractable(t) {
+        return (typeof MkvSubs !== 'undefined' && MkvSubs.isTextSubtitleTrack)
+            ? MkvSubs.isTextSubtitleTrack(t) : false;
+    }
+
     /* Label for a track read out of the MKV header: the muxer's own name
      * ('SDH', 'Latin America'), the language tag, and whichever flags tell
      * two same-language tracks apart. */
@@ -855,9 +837,11 @@ var Player = (function () {
         }
         var label = ('(embedded) ' + (tag ? '[' + tag + '] ' : '') +
                      bits.join(' · ')).replace(/\s+$/, '');
-        /* Marks the tracks the TV's own demuxer never listed — if selecting
-         * one does nothing, this is the row that explains why. */
-        if (beyondAvplay) label += ' ⚠';
+        /* Marks a track nothing can reach: AVPlay never listed it, so it
+         * can't select it, and its subs are bitmaps, so we can't extract
+         * them either.  Text tracks past AVPlay's list are fine — they get
+         * read out of the container on demand. */
+        if (beyondAvplay && !containerSubExtractable(t)) label += ' ⚠';
         return label;
     }
 
@@ -876,6 +860,221 @@ var Player = (function () {
             if (num) rows[i].name = rows[i].name.replace(/( ⚠)?$/, ' · track ' + num + '$1');
         }
     }
+    /* ── Tracks AVPlay lists but cannot select ────────────────────────
+     *
+     * getTotalTrackInfo() stops at 32 entries, and setSelectTrack('TEXT', n)
+     * only works for the tracks it returned: hand the firmware an index it
+     * never advertised and the previous track simply keeps rendering, which
+     * is what picking Vietnamese out of the tail of a 40-track file looks
+     * like.  MkvSubs.extractTrack() reads that one track's text out of the
+     * container through the cue index and the existing poller paints it —
+     * the same path a sibling .srt takes, so it is the one path on this
+     * firmware that is known to work.
+     *
+     * Entries made this way are marked _onDemand: they belong to an embedded
+     * row in the CC menu rather than getting a row of their own, and they
+     * must not count as "we extracted this file's subs" — that would hide
+     * the embedded list the rest of the tracks live on. */
+    var subsSource            = null;   // { uri, file } for the file that's open
+    var activeTrackExtraction = null;
+    var activeTrackEntry      = null;
+    var trackExtractToken     = 0;
+
+    function cancelTrackExtraction(reason) {
+        clearTimeout(nativeSubVerifyTimer);
+        ++trackExtractToken;
+        if (activeTrackExtraction && activeTrackExtraction.cancel) {
+            activeTrackExtraction.cancel(reason);
+        }
+        /* Whatever it had got to stays usable, but it must stop claiming to
+         * be still reading — and an entry with nothing in it is just a dead
+         * row in the menu. */
+        if (activeTrackEntry) {
+            if (activeTrackEntry.cues && activeTrackEntry.cues.length) {
+                activeTrackEntry._partial = true;
+                activeTrackEntry.name = trackRowBaseName(activeTrackEntry) +
+                    ' — partial (' + activeTrackEntry.cues.length + ' cues)';
+            } else {
+                dropOnDemandEntry(activeTrackEntry);
+            }
+        }
+        activeTrackExtraction = null;
+        activeTrackEntry      = null;
+    }
+
+    function onDemandEntryFor(trackNumber) {
+        if (!(trackNumber > 0)) return null;
+        for (var i = 0; i < playerSubtitles.length; i++) {
+            if (playerSubtitles[i] && playerSubtitles[i]._mkvTrack === trackNumber)
+                return playerSubtitles[i];
+        }
+        return null;
+    }
+
+    function dropOnDemandEntry(entry) {
+        for (var i = 0; i < playerSubtitles.length; i++) {
+            if (playerSubtitles[i] === entry) { playerSubtitles.splice(i, 1); break; }
+        }
+        h5Subtitles = playerSubtitles;
+    }
+
+    /* Menu-row label without the state suffix this function appends. */
+    function trackRowBaseName(row) {
+        return String((row && row.name) || 'Embedded subtitle')
+            .replace(/ ⚠$/, '')
+            .replace(/ — (extracting.*|partial.*)$/, '');
+    }
+
+    /* Which TEXT track AVPlay says it is rendering right now.  -1 when it
+     * won't say, which is not the same as "none" and must not be read as a
+     * failed selection. */
+    function avActiveTextIndex() {
+        try {
+            var cur = av().getCurrentStreamInfo();
+            for (var i = 0; cur && i < cur.length; i++) {
+                if (cur[i].type === 'TEXT' || cur[i].type === 'SUBTITLE') return cur[i].index;
+            }
+        } catch (e) {}
+        return -1;
+    }
+
+    /* setSelectTrack can return without complaint and still leave the old
+     * track on screen — accepting a call and acting on it are different
+     * things here, and this is the shape the bug takes for a user who picks
+     * a language and watches the previous one carry on.  Give the firmware a
+     * moment, then check what it actually selected and read the track out of
+     * the container ourselves if it didn't move. */
+    var nativeSubVerifyTimer = null;
+    function verifyNativeSubSelection(row, wantIdx) {
+        clearTimeout(nativeSubVerifyTimer);
+        if (!row || !(row.mkvTrack > 0)) return;
+        nativeSubVerifyTimer = setTimeout(function () {
+            // Moved on since: an external sub, or subs off.
+            if (currentExternalSub || !avNativeSubsAllowed) return;
+            var got = avActiveTextIndex();
+            if (got < 0 || got === wantIdx) return;
+            if (typeof Debug !== 'undefined')
+                Debug.warn('embedded sub: asked for TEXT ' + wantIdx + ', firmware still on ' +
+                           got + ' — reading track ' + row.mkvTrack + ' out of the container');
+            var how = extractContainerTrack(row);
+            if (how) emit('onsubsupdated');
+        }, 600);
+    }
+
+    /* Extraction failures the user can do something about (pick another
+     * track, plug the drive in directly) read better than the parser's own
+     * wording, which goes to the log. */
+    function subExtractReason(err) {
+        var m = (err && err.message) || String(err || 'unknown error');
+        if (/no cue index|no block positions|no entries for track/.test(m))
+            return 'the file carries no index for it';
+        if (/only text subtitles/.test(m))
+            return 'its subtitles are images, not text';
+        return m.length > 80 ? m.slice(0, 77) + '…' : m;
+    }
+
+    /* Returns 'cached' when the track was already extracted, 'extracting'
+     * when a read has just started, or null when this file can't supply it. */
+    function extractContainerTrack(row) {
+        var num = row && row.mkvTrack;
+        if (!(num > 0)) return null;
+        if (row.extractable === false) return null;   // bitmap subs: no text to read
+
+        var existing = onDemandEntryFor(num);
+        /* Already read once: nothing to do but point the poller at it. */
+        if (existing && !existing._partial) {
+            avNativeSubsAllowed = false;
+            applyExternalSubtitleLive(existing);
+            return 'cached';
+        }
+        if (typeof MkvSubs === 'undefined' || !MkvSubs.extractTrack || !subsSource) return null;
+
+        var base  = trackRowBaseName(row);
+        var entry;
+        if (existing) {
+            /* Abandoned half-read when another track was picked.  Start it
+             * over — into the same array, which the poller already holds —
+             * rather than leaving the gaps in place. */
+            entry = existing;
+            entry.cues.length = 0;
+            entry.name = base + ' — extracting 0%';
+        } else {
+            entry = {
+                name:            base + ' — extracting 0%',
+                lang:            row.lang || '',
+                ext:             'srt',
+                cues:            [],
+                _extracted:      true,
+                _onDemand:       true,
+                _incremental:    true,
+                _containerLabel: 'MKV',
+                _mkvTrack:       num,
+                _cueCount:       0
+            };
+            playerSubtitles.push(entry);
+            h5Subtitles = playerSubtitles;
+        }
+        entry._partial = false;
+
+        /* Selected before a single cue has arrived: the poller holds this
+         * array and paints whatever lands in it, so the track starts showing
+         * while the rest of the file is still being read. */
+        avNativeSubsAllowed = false;
+        applyExternalSubtitleLive(entry);
+        emit('onsubsupdated');
+        emit('onsubnotice', 'Reading ' + base.replace(/^\(embedded\) /, '') +
+                            ' from the file — subtitles appear as they load');
+
+        cancelTrackExtraction('another track picked');
+        var token    = ++trackExtractToken;
+        var lastEmit = 0;
+        activeTrackEntry = entry;
+
+        activeTrackExtraction = MkvSubs.extractTrack(subsSource.file || subsSource.uri, num, {
+            cues:      entry.cues,
+            startAtMs: currentTime(),      // ms, same as the poller reads
+            onCues: function (have, total) {
+                if (token !== trackExtractToken) return;
+                entry._cueCount = have;
+                entry.name = base + ' — extracting ' +
+                             (total ? Math.round(have * 100 / total) : 0) + '%';
+                /* The CC menu re-renders on this event and takes focus with
+                 * it, so it fires at a pace a user can live with. */
+                var now = Date.now();
+                if (now - lastEmit < 3000) return;
+                lastEmit = now;
+                emit('onsubsupdated');
+            }
+        }, function (err) {
+            if (token !== trackExtractToken) return;
+            activeTrackExtraction = null;
+            activeTrackEntry      = null;
+            entry._cueCount       = entry.cues.length;
+
+            if (err && !entry.cues.length) {
+                /* Nothing to paint: take the entry back out rather than
+                 * leaving a selected track that shows nothing, and put the
+                 * reason on screen. */
+                dropOnDemandEntry(entry);
+                if (currentExternalSub === entry) {
+                    stopExternalSubtitle();
+                    currentExternalSub = null;
+                }
+                emit('onsubsupdated');
+                emit('onsubnotice', 'Can’t read ' + base.replace(/^\(embedded\) /, '') +
+                                    ' from this file — ' + subExtractReason(err));
+                return;
+            }
+            entry._partial = !!err;
+            entry.name = base + (err ? ' — partial (' + entry.cues.length + ' cues)' : '');
+            emit('onsubsupdated');
+            if (typeof Debug !== 'undefined')
+                Debug.player('on-demand sub track ' + num + ': ' + entry.cues.length + ' cues' +
+                             (err ? ' (incomplete: ' + (err.message || err) + ')' : ''));
+        });
+        return 'extracting';
+    }
+
     /* Legacy alias — older code paths used h5Subtitles directly */
     var h5Subtitles = playerSubtitles;
     function h5Open(url, opts) {
@@ -1139,6 +1338,8 @@ var Player = (function () {
         playerSubtitles = (opts.subtitles) ? opts.subtitles.slice() : [];
         h5Subtitles = playerSubtitles;
         stopExternalSubtitle();    // clear any previous file's poller
+        cancelTrackExtraction('new file');
+        subsSource = null;
         avNativeSubsAllowed = false;   // don't paint AVPlay's stray first-cue at file open
         currentSpeed = 1;          // playback speed is per-file; reset every open
         backend = pickBackend(url);
@@ -1165,6 +1366,9 @@ var Player = (function () {
             // container to sniff, while the bytes still come from the Tizen
             // File handle in opts.file.
             var subsSourceUri = opts.sourceUri || url;
+            /* Kept for the whole file: picking a track the TV can't select
+               means going back to these bytes for that one track's text. */
+            subsSource = { uri: subsSourceUri, file: opts.file || null };
             if (isLocalUrl(subsSourceUri)) extractAndAppendEmbeddedSubs(subsSourceUri, opts.file);
             /* Independent of extraction, and not limited to local files: the
              * header read works over the SMB proxy too, and it is the only
@@ -1226,6 +1430,7 @@ var Player = (function () {
     function stop() {
         clearTimeout(h5OpenWatchdog);
         cancelEmbeddedSubExtraction('playback stopped');
+        cancelTrackExtraction('playback stopped');
         stopExternalSubtitle();
         hideSubtitleText();
         currentExternalSub = null;
@@ -1452,7 +1657,11 @@ var Player = (function () {
             // user doesn't see duplicates where only one actually works.
             var extractedCount = 0;
             for (var ei = 0; ei < playerSubtitles.length; ei++) {
-                if (playerSubtitles[ei]._extracted) extractedCount++;
+                /* On-demand tracks belong to an embedded row, not to a row
+                 * of their own — counting them here would suppress the very
+                 * list they were picked from. */
+                if (playerSubtitles[ei]._extracted && !playerSubtitles[ei]._onDemand)
+                    extractedCount++;
             }
             var hasExtracted = extractedCount > 0;
             var showEmbed = !hasExtracted;
@@ -1546,13 +1755,24 @@ var Player = (function () {
                     var ct    = containerSubTracks[mi];
                     var known = avTextTracks[mi];
                     var cIdx  = known ? known.index : (firstIdx + mi * step);
+                    /* A track already read out of the container keeps the
+                     * entry's name — it carries the extraction's progress. */
+                    var got   = onDemandEntryFor(ct.number);
                     containerRows.push({
                         index:  'embed:' + cIdx,
-                        name:   containerSubLabel(ct, !known),
+                        name:   got ? got.name : containerSubLabel(ct, !known),
                         lang:   ct.lang || (known && known.lang) || '',
                         type:   'AVPLAY_EMBED',
+                        /* The container's own track number, which is what
+                         * our extractor addresses tracks by — AVPlay's index
+                         * is no use to it — and whether it holds text at
+                         * all, so a bitmap track fails on the spot instead
+                         * of after a read that could never work. */
+                        mkvTrack:     ct.number,
+                        extractable:  containerSubExtractable(ct),
                         beyondAvplay: !known,
-                        active: (!currentExternalSub && cIdx === activeTextIdx)
+                        active: got ? (currentExternalSub === got)
+                                    : (!currentExternalSub && cIdx === activeTextIdx)
                     });
                 }
                 disambiguateLabels(containerRows, containerSubTracks);
@@ -1560,15 +1780,23 @@ var Player = (function () {
                     out.subtitle.push(containerRows[ri]);
             } else if (showEmbed) {
                 for (var ni = 0; ni < avTextTracks.length; ni++) {
-                    var nt = avTextTracks[ni];
+                    var nt  = avTextTracks[ni];
+                    /* Same ordinal in the container's own list, where we have
+                     * one: it carries the track number our extractor needs
+                     * if the firmware turns the selection down. */
+                    var cnt = containerSubTracks[ni];
+                    var ext = cnt ? onDemandEntryFor(cnt.number) : null;
                     out.subtitle.push({
                         index:  'embed:' + nt.index,
-                        name:   '(embedded) ' + nt.label,
-                        lang:   nt.lang,
+                        name:   ext ? ext.name : ('(embedded) ' + nt.label),
+                        lang:   nt.lang || (cnt && cnt.lang) || '',
                         type:   'AVPLAY_EMBED',
+                        mkvTrack:    cnt ? cnt.number : 0,
+                        extractable: cnt ? containerSubExtractable(cnt) : false,
                         // Only count as active if it's the currently selected
                         // TEXT track AND no external sub is overriding it.
-                        active: (!currentExternalSub && nt.index === activeTextIdx)
+                        active: ext ? (currentExternalSub === ext)
+                                    : (!currentExternalSub && nt.index === activeTextIdx)
                     });
                 }
             }
@@ -1579,6 +1807,7 @@ var Player = (function () {
             // so the user can tell where they came from.
             for (var k = 0; k < playerSubtitles.length; k++) {
                 var s = playerSubtitles[k];
+                if (s._onDemand) continue;      // shown as its embedded row
                 var label = (s.lang ? '[' + s.lang.toUpperCase() + '] ' : '') + s.name;
                 out.subtitle.push({
                     index:  'ext:' + k,
@@ -1765,17 +1994,29 @@ var Player = (function () {
         }
     }
 
-    function setSubtitleTrack(index) {
+    /* `sel` is a whole row from getTracks() where the caller has one — an
+     * embedded row needs its container track number as well as AVPlay's
+     * index, because the two paths that can render it are addressed
+     * differently.  A bare index still works for older callers.
+     *
+     * Returns how the track is being rendered: 'native', 'external',
+     * 'cached', 'extracting', 'off', or null when nothing could take it. */
+    function setSubtitleTrack(sel) {
+        var row   = (sel && typeof sel === 'object') ? sel : null;
+        var index = row ? row.index : sel;
+
         if (backend === BACKEND_AVPLAY) {
             hideSubtitleText();
             stopExternalSubtitle();
 
+            clearTimeout(nativeSubVerifyTimer);
+
             // "Off"
-            if (index === -1 || index === undefined || index === 'off') {
+            if (index === -1 || index === undefined || index === 'off' || (row && row.off)) {
                 try { av().setSilentSubtitle(true); } catch (e) {}
                 avNativeSubsAllowed = false;
                 currentExternalSub = null;   // allow re-selecting the same sub later
-                return;
+                return 'off';
             }
 
             // External subtitle file: render via the JS time-poller so the
@@ -1785,30 +2026,44 @@ var Player = (function () {
             if (typeof index === 'string' && index.indexOf('ext:') === 0) {
                 var k = parseInt(index.slice(4), 10);
                 var sub = playerSubtitles[k];
-                if (!sub) return;
+                if (!sub) return null;
                 avNativeSubsAllowed = false;
                 applyExternalSubtitleLive(sub);
                 if (typeof Debug !== 'undefined')
                     Debug.player('external sub via JS poller (no-seek): ' + sub.name);
-                return;
+                return 'external';
             }
 
-            // Embedded subtitle: "embed:<i>" — delegate to AVPlay's own track API
-            avNativeSubsAllowed = true;
+            // Embedded subtitle: "embed:<i>"
             var embedIdx = (typeof index === 'string' && index.indexOf('embed:') === 0)
                 ? parseInt(index.slice(6), 10)
                 : index;
+
+            /* Past the end of AVPlay's own track list its setSelectTrack is
+             * a no-op — it doesn't fail, it just leaves the track that was
+             * already showing on screen.  Read those out of the container
+             * instead; it's the only thing that renders them. */
+            if (row && row.beyondAvplay) {
+                var how = extractContainerTrack(row);
+                if (how) return how;
+                if (typeof Debug !== 'undefined')
+                    Debug.warn('embedded sub ' + embedIdx + ': past AVPlay\'s list and not ' +
+                               'extractable — nothing can render it');
+                return null;
+            }
+
+            avNativeSubsAllowed = true;
             try { av().setSilentSubtitle(false); } catch (e) {}
-            /* Logged either way: for a track past the end of AVPlay's own
-             * list this is the only signal of whether the firmware honours
-             * an index it never advertised. */
+            var selected = false;
             try {
                 av().setSelectTrack('TEXT', embedIdx);
+                selected = true;
                 if (typeof Debug !== 'undefined')
                     Debug.player('embedded sub: setSelectTrack TEXT ' + embedIdx + ' accepted');
             } catch (e) {
                 try {
                     av().setSelectTrack('SUBTITLE', embedIdx);
+                    selected = true;
                     if (typeof Debug !== 'undefined')
                         Debug.player('embedded sub: setSelectTrack SUBTITLE ' + embedIdx + ' accepted');
                 } catch (e2) {
@@ -1817,9 +2072,17 @@ var Player = (function () {
                                    ' rejected: ' + (e2.message || e2));
                 }
             }
-            return;
+            /* The firmware refused a track it had listed: fall back to
+             * reading it out of the container, same as the tail tracks. */
+            if (!selected) {
+                var alt = extractContainerTrack(row);
+                if (alt) return alt;
+                return null;
+            }
+            verifyNativeSubSelection(row, embedIdx);
+            return 'native';
         }
-        if (backend !== BACKEND_HTML5) return;
+        if (backend !== BACKEND_HTML5) return null;
 
         var v = h5el();
         // "Off" — disable every existing textTrack

--- a/tizen-web-vlc/js/settings.js
+++ b/tizen-web-vlc/js/settings.js
@@ -24,7 +24,7 @@ var Settings = (function () {
         subtitleBg:       'none',      // 'none' | 'box'  (translucent box behind text)
         // ── Video geometry ────────────────────────────────────────────────
         // How the picture is fitted to the screen: see AspectRatio below.
-        aspectMode:       'fit',       // 'fit' | 'fill' | 'stretch' | 'zoom110' | 'zoom125'
+        aspectMode:       'fit',       // 'fit' | 'fill' | 'stretch'
         // The TV's pairing code (url-drop.js mints it once and persists it
         // here).  It HAS to be listed: load() rebuilds the cache from this
         // object, so a key that isn't here is silently dropped on the next
@@ -322,26 +322,32 @@ var SubtitleStyle = (function () {
 })();
 
 
-/* Video aspect / zoom modes — how the picture is fitted to the screen.
+/* Video aspect modes — how the picture is fitted to the screen.
  *
- * Two different "black bars" exist and they need different fixes:
+ * There are three, and the reason there aren't more is worth writing down:
+ * two different kinds of "black bars" exist, and only one of them is the
+ * player's to fix.
  *
- *   1. The file really is wider than the screen (2.39:1 in a 2.39:1 frame).
- *      The player letterboxes it, and 'fill' — AVPlay's CROPPED_FULL, CSS
- *      object-fit:cover — scales the picture until it covers the screen and
- *      crops the sides instead.  Aspect is preserved.
- *   2. The bars are encoded INTO the frames (a 2.39:1 film muxed as 16:9).
- *      Nothing the display method does can help there: the frame already
- *      matches the screen, so all three display methods above produce an
- *      identical picture.  The only fix is to zoom past the frame edge,
- *      which the zoom and crop modes do by handing AVPlay a display rect
- *      larger than the screen (CSS transform:scale on the HTML5 backend).
+ *   1. The frame really is wider than the screen (a 2.39:1 frame on a 16:9
+ *      panel).  The firmware letterboxes it, and 'fill' — AVPlay's
+ *      CROPPED_FULL, CSS object-fit:cover — scales the picture until it
+ *      covers the screen and crops the sides instead, aspect preserved.
  *
- * The 'zoom*' modes magnify by a fixed amount.  The 'crop*' modes instead
- * name the shape the content really is, and player.js works out the zoom
- * from the frame AVPlay reports — 2.39:1 content inside a 16:9 frame needs
- * 1.34x, and no fixed step lands on that.  A frame already at or wider than
- * the target is left alone.
+ *   2. The bars are encoded INTO the frames — a 2.39:1 film muxed as 16:9,
+ *      which is what most streaming rips are.  As far as the firmware is
+ *      concerned the frame already matches the panel, so LETTER_BOX,
+ *      CROPPED_FULL and FULL_SCREEN all paint the same picture and none of
+ *      them can change anything.  Cropping bars like that means magnifying
+ *      past the frame edge: a display rect bigger than the screen and
+ *      centred on it.  A centred oversized rect has a negative origin, and
+ *      setDisplayRect "throws InvalidValuesError if any input parameter
+ *      contains a negative value" — Samsung's own AVPlay reference.  The
+ *      picture is always centred in the rect it is handed, so no legal rect
+ *      can push the top bar off the top of the screen, and AVPlay exposes no
+ *      source-crop or ROI call to do it another way.  Zoom and crop modes
+ *      were built and tried on two sets; neither moved a pixel.  They are
+ *      gone, and the player now says why rather than offering a mode that
+ *      cannot work.
  *
  * 'stretch' is the blunt instrument — fills the screen by distorting the
  * picture.  Some users prefer it, so it stays on the list, labelled.
@@ -349,32 +355,21 @@ var SubtitleStyle = (function () {
  * `av` values are Samsung AVPlay display methods; unsupported ones throw on
  * older firmware, and player.js falls back to LETTER_BOX when they do. */
 var AspectRatio = (function () {
-    /* Magnifying more than this stops being a crop and starts being a
-     * close-up, so no derived zoom goes past it. */
-    var MAX_CROP_ZOOM = 2;
-
     var MODES = [
-        { code: 'fit',     name: 'Fit screen (keep black bars)',  short: 'Fit',
-          av: 'PLAYER_DISPLAY_MODE_LETTER_BOX',   fit: 'contain', zoom: 1 },
-        { code: 'fill',    name: 'Fill screen (crop the sides)',  short: 'Fill',
-          av: 'PLAYER_DISPLAY_MODE_CROPPED_FULL', fit: 'cover',   zoom: 1 },
-        { code: 'zoom110', name: 'Zoom 110% (crop baked-in bars)', short: '110%',
-          av: 'PLAYER_DISPLAY_MODE_LETTER_BOX',   fit: 'contain', zoom: 1.10 },
-        { code: 'zoom125', name: 'Zoom 125% (crop baked-in bars)', short: '125%',
-          av: 'PLAYER_DISPLAY_MODE_LETTER_BOX',   fit: 'contain', zoom: 1.25 },
-        // Streaming rips are mostly one of these two shapes letterboxed into
-        // a 16:9 frame, and the zoom each needs is a property of the file,
-        // not a number we can hard-code — hence targetDar.
-        { code: 'crop20',  name: 'Crop to 2:1 (remove baked-in bars)', short: '2:1',
-          av: 'PLAYER_DISPLAY_MODE_LETTER_BOX',   fit: 'contain', zoom: 1, targetDar: 2 },
-        { code: 'crop239', name: 'Crop to 2.39:1 (remove baked-in bars)', short: '2.39',
-          av: 'PLAYER_DISPLAY_MODE_LETTER_BOX',   fit: 'contain', zoom: 1, targetDar: 2.39 },
+        { code: 'fit',     name: 'Fit screen (keep black bars)',    short: 'Fit',
+          av: 'PLAYER_DISPLAY_MODE_LETTER_BOX',   fit: 'contain' },
+        { code: 'fill',    name: 'Fill screen (crop the sides)',    short: 'Fill',
+          av: 'PLAYER_DISPLAY_MODE_CROPPED_FULL', fit: 'cover' },
         // 'Wide' is the label TVs traditionally put on a stretched 16:9
         // picture, and unlike 'Stretch' it fits inside the round OSD button.
         { code: 'stretch', name: 'Stretch (fills, distorts shape)', short: 'Wide',
-          av: 'PLAYER_DISPLAY_MODE_FULL_SCREEN',  fit: 'fill',    zoom: 1 }
+          av: 'PLAYER_DISPLAY_MODE_FULL_SCREEN',  fit: 'fill' }
     ];
 
+    function isKnown(code) {
+        for (var i = 0; i < MODES.length; i++) if (MODES[i].code === code) return true;
+        return false;
+    }
     function find(code) {
         for (var i = 0; i < MODES.length; i++) if (MODES[i].code === code) return MODES[i];
         return MODES[0];
@@ -383,23 +378,6 @@ var AspectRatio = (function () {
     function current() {
         if (typeof Settings === 'undefined') return MODES[0];
         return find(Settings.get('aspectMode'));
-    }
-    /* How far to magnify to crop `code`'s target shape out of a frame of
-     * `frameDar`.  The fixed 'zoom*' modes ignore the frame and return their
-     * own step; the 'crop*' modes derive it, because the zoom that clears
-     * baked-in bars is a property of the file — 2.39:1 content sits in a
-     * 16:9 frame with 1.34x of bar to lose, but in a 2:1 frame with only
-     * 1.19x.  A frame already at or wider than the target needs none.
-     *
-     * Kept here rather than in player.js so it is testable without a
-     * player; player.js supplies the frame AVPlay reports. */
-    function zoomFor(code, frameDar) {
-        var m = find(code);
-        if (!m.targetDar) return m.zoom || 1;
-        if (!(frameDar > 0)) return 1;
-        var z = m.targetDar / frameDar;
-        if (!(z > 1)) return 1;
-        return (z > MAX_CROP_ZOOM) ? MAX_CROP_ZOOM : z;
     }
 
     /* Next mode in the list — the OSD button cycles rather than opening a
@@ -413,8 +391,8 @@ var AspectRatio = (function () {
     return {
         forList: function () { return MODES; },
         find:    find,
+        isKnown: isKnown,
         current: current,
-        zoomFor: zoomFor,
         next:    next,
         nameFor:  function (c) { return find(c).name; },
         shortFor: function (c) { return find(c).short; }


### PR DESCRIPTION
Follow-up to #68 on the same 4K Netflix MKV (1 video, 1 audio, 40 subtitle tracks): picking Vietnamese still did nothing, and 2.39:1 still left the black bars alone.

## Vietnamese — fixed

Listing all 40 tracks was only half the job. `getTotalTrackInfo()` stops at 32 entries and `setSelectTrack('TEXT', n)` only *acts* on the tracks it returned — hand it an index it never advertised and it doesn't fail, it leaves what was already on screen there. That's "click Vietnamese, it goes back to the current sub". `MkvSubs.extract()` couldn't stand in: it loads the whole movie and gives up over `MAX_FULL_LOAD_BYTES`.

`MkvSubs.extractTrack()` reads one track out of the container through its **cue index**. mkvmerge writes `--cues iframes` for subtitle tracks and every subtitle block is a keyframe, so `Cues` holds a position for *every* subtitle cue in the file — one read of the index plus one 16 KB read per cue, a couple of MB instead of 6 GB.

- reads start **at the playhead**, so the track shows up within a second or two and the rest fills in behind it
- cues go into the array the poller already holds, kept sorted — no temp file, no re-parse
- `CueRelativePosition` counts from the cluster's first data byte and the cluster header's length isn't in the index, so the block is found by scanning the twelve bytes it can start in; the offset it turns up at is remembered for the rest of the file
- reads are paced: the drive being scanned is the one feeding the video
- ASS/SSA styling from `CodecPrivate` applies exactly as on the whole-file path

`getTracks()` now hands the whole menu row to `setSubtitleTrack()` (the container's track number is what the extractor addresses tracks by). Rows past AVPlay's list go to the extractor; rows it did list still go to the firmware first, but the selection is **verified** against `getCurrentStreamInfo()` 600 ms later and falls back to the extractor if the track didn't actually change — the same failure on a file with under 32 tracks is covered too. Bitmap-sub rows are refused on the spot rather than after a read that could never work, so ⚠ now means only "nothing can reach this". A language preference matching only a tail track gets a second chance when the container list lands, and the CC menu keeps your place when it re-renders mid-extraction.

## 2.39:1 — removed, because AVPlay cannot do it

Cropping bars baked into the frames means magnifying past the frame edge: a display rect bigger than the screen and centred on it. A centred oversized rect has a negative origin, and [`setDisplayRect`](https://developer.samsung.com/smarttv/develop/api-references/samsung-product-api-references/avplay-api.html) *"throws InvalidValuesError if any input parameter contains a negative value"*. The picture is always centred in the rect it's handed, so no legal rect can push the top bar off the top of the screen, and AVPlay exposes no source-crop or ROI call to do it another way. The zoom and crop modes were tried on two sets across two releases and never moved a pixel.

So they're gone. **Fit / Fill / Stretch** are what the three display methods can really do; a mode saved by 1.4.0 (`zoom125`, `crop239`, …) resolves back to Fit and gets rewritten on startup. On a file whose frame already matches the panel — where none of the three can change anything, so any bars are inside the picture — the toast says that plainly instead of leaving you to cycle the list looking for the one that isn't broken. The display-rect zoom machinery goes with it; the only thing that could ever bring the feature back is logged once per session (whether the firmware has a crop/ROI call of its own).

## Tests

`node --test tests/tizen-web-vlc/` — 68 pass. 13 new cases build a byte-accurate cue-indexed Matroska fixture and cover: one track pulled through the index, never reading the video it skips, cue order when reads start mid-file and wrap, an index in front of the media, CueDuration vs BlockDuration vs next-cue end times, progress callbacks, ASS styling, a v1 index with no block positions, a bitmap track, a track the container never declared, and cancellation. The aspect tests now assert the list holds only modes the firmware can carry out, and that an old saved mode is not treated as current.
