### PR TITLE
Put every debug line in the DevTools console

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ tizen-web-vlc/
 ├── css/
 │   └── style.css       Dark slate-blue theme, focus management, OSD
 ├── js/
-│   ├── debug.js        Optional UDP/HTTP-style telemetry to a PC for debugging
+│   ├── debug.js        Log lines to the DevTools console, plus optional POSTs to a PC
 │   ├── remote.js       TV remote key registration + dispatch
 │   ├── ui.js           Focus management + view switching + toast
 │   ├── browser.js      USB / Tizen filesystem enumeration

--- a/tests/tizen-web-vlc/debug-output.test.js
+++ b/tests/tizen-web-vlc/debug-output.test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+var assert = require('assert');
+var test   = require('node:test');
+var fs     = require('fs');
+var vm     = require('vm');
+var path   = require('path');
+
+var SRC = fs.readFileSync(
+    path.join(__dirname, '../../tizen-web-vlc/js/debug.js'), 'utf8');
+
+/* debug.js expects a browser; stub the parts it touches so what it writes to
+ * the console and what it POSTs can be told apart without a TV. */
+function loadDebug(saved) {
+    var logged = [];
+    var errored = [];
+    var posts  = [];
+    var store  = {};
+    if (saved) store['vlctv_debug_v1'] = JSON.stringify(saved);
+
+    var sandbox = {
+        // Same shape Node gives a module: the export guard in debug.js only
+        // fires when module.exports is already an object.
+        module:  { exports: {} },
+        console: {
+            log:   function (line) { logged.push(line); },
+            error: function (line) { errored.push(line); }
+        },
+        localStorage: {
+            getItem: function (k) { return Object.prototype.hasOwnProperty.call(store, k) ? store[k] : null; },
+            setItem: function (k, v) { store[k] = String(v); }
+        },
+        document: {
+            readyState: 'complete',
+            addEventListener: function () {},
+            getElementById: function () { return null; }
+        },
+        window:    { addEventListener: function () {} },
+        navigator: { userAgent: 'test' },
+        location:  { href: 'file:///index.html' },
+        XMLHttpRequest: function () {
+            var req = this;
+            this.open = function (method, dest) { req._dest = dest; };
+            this.setRequestHeader = function () {};
+            this.send = function (body) { posts.push({ dest: req._dest, body: body }); };
+        },
+        Image: function () {}
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(SRC, sandbox);
+
+    return { Debug: sandbox.module.exports, logged: logged, errored: errored, posts: posts };
+}
+
+test('every line reaches the console without anything being configured', function () {
+    // Apps2Samsung → Installed apps → Debug attaches DevTools; the lines have
+    // to be there already, with no listener and nothing switched on.
+    var d = loadDebug();
+    assert.ok(d.logged.some(function (l) { return /\[BOOT\]/.test(l); }),
+        'the boot banner should have been logged');
+
+    d.Debug.player('opened a file');
+    var last = d.logged[d.logged.length - 1];
+    assert.ok(/^\[vlctv\]/.test(last), 'lines carry a filterable prefix: ' + last);
+    assert.ok(/#\d+ \[PLAYER\] opened a file$/.test(last), last);
+    assert.strictEqual(d.posts.length, 0, 'nothing should be posted while unconfigured');
+});
+
+test('warnings and errors go out as console errors', function () {
+    var d = loadDebug();
+    d.Debug.warn('slow read');
+    d.Debug.error('gave up');
+    d.Debug.info('fine');
+
+    assert.strictEqual(d.errored.length, 2, 'WARN and ERROR belong in DevTools error filter');
+    assert.ok(/\[WARN\] slow read$/.test(d.errored[0]));
+    assert.ok(/\[ERROR\] gave up$/.test(d.errored[1]));
+    assert.ok(/\[INFO\] fine$/.test(d.logged[d.logged.length - 1]));
+});
+
+test('the POST half only fires once it is turned on and given an address', function () {
+    var d = loadDebug();
+    d.Debug.configure({ enabled: true, host: '', port: 9999 });
+    d.Debug.info('no address');
+    assert.strictEqual(d.posts.length, 0);
+
+    d.Debug.configure({ enabled: false, host: '192.168.1.50', port: 9999 });
+    d.Debug.info('switched off');
+    assert.strictEqual(d.posts.length, 0);
+
+    d.Debug.configure({ enabled: true, host: '192.168.1.50', port: 9999 });
+    d.Debug.info('both');
+    assert.strictEqual(d.posts.length, 1);
+    assert.strictEqual(d.posts[0].dest, 'http://192.168.1.50:9999/');
+    assert.ok(/\[INFO\] both$/.test(d.posts[0].body));
+    // The POST body carries no console prefix — that is DevTools' filter, not
+    // part of the line.
+    assert.ok(!/^\[vlctv\]/.test(d.posts[0].body), d.posts[0].body);
+    // Every one of those calls still reached the console.
+    assert.ok(d.logged.filter(function (l) { return /\[INFO\]/.test(l); }).length >= 3);
+});

--- a/tizen-web-vlc/js/debug.js
+++ b/tizen-web-vlc/js/debug.js
@@ -1,10 +1,18 @@
-/* Debug telemetry — fire-and-forget HTTP POSTs to a PC listener.
+/* Debug telemetry — every line goes to the browser console, and optionally
+ * to a PC listener as well.
  *
- * The endpoint is configured at runtime under Settings → Debug logging and
- * persisted in localStorage, so anyone can point it at their own machine
- * instead of editing a hard-coded IP. It ships DISABLED: nothing is sent
- * until you turn it on and enter your listener's IP. (A simple HTTP listener
- * on the chosen port — e.g. the PowerShell one on 9999 — receives each line.)
+ * The console is the one that needs no setup: Apps2Samsung → Installed apps →
+ * Debug puts the app in debug mode and opens chrome://inspect, and inspecting
+ * it from there gives a real DevTools console with these lines in it, live,
+ * filterable, on any machine that can reach the TV.  Nothing to configure,
+ * nothing to keep running, and it works even when the network path to a
+ * listener doesn't.  Lines are tagged [vlctv] so they're one filter away from
+ * whatever else the WebView is saying.
+ *
+ * The HTTP POSTs are still there for capturing a session without DevTools
+ * attached.  That half is configured under Settings → Debug logging,
+ * persisted in localStorage, and ships DISABLED — the console output does
+ * not depend on it.
  */
 
 var Debug = (function () {
@@ -22,6 +30,10 @@ var Debug = (function () {
     }
     var cfg = loadCfg();
 
+    /* Whether the POST half has somewhere to go.  The console half is always
+     * on: it costs nothing when no inspector is attached, and having to go
+     * and enable something before the interesting thing happens again is
+     * exactly what makes a bug hard to catch. */
     function active() { return cfg.enabled && !!cfg.host; }
     function url()    { return 'http://' + cfg.host + ':' + cfg.port + '/'; }
 
@@ -31,10 +43,22 @@ var Debug = (function () {
     }
 
     function send(tag, msg) {
-        if (!active()) return;
         seq++;
         var payload = ts() + ' #' + seq + ' [' + tag + '] ' +
                       (typeof msg === 'string' ? msg : JSON.stringify(msg));
+
+        /* DevTools first, so a line still lands there when the POST path is
+         * off or the listener has gone away.  console.error for the tags that
+         * mean something went wrong, so they keep DevTools' red styling and
+         * its error filter. */
+        try {
+            var out = (tag === 'ERROR' || tag === 'WARN' ||
+                       tag === 'JSERR' || tag === 'JSREJECT')
+                ? console.error : console.log;
+            out.call(console, '[vlctv]' + payload);
+        } catch (e) {}
+
+        if (!active()) return;
         var dest = url();
         try {
             var x = new XMLHttpRequest();
@@ -122,3 +146,6 @@ var Debug = (function () {
         get enabled() { return cfg.enabled; }
     };
 })();
+
+// Ignored by the Tizen/browser build; lets Node tests check what goes where.
+if (typeof module !== 'undefined' && module.exports) module.exports = Debug;


### PR DESCRIPTION
Reading the log meant running a PowerShell HTTP listener on the PC and typing its IP into the TV's settings *before* the interesting thing happened again.

Apps2Samsung already has the better route: **Installed apps → Debug** puts the app in debug mode and opens `chrome://inspect`, and inspecting it from there is a real DevTools console — live, filterable, searchable, nothing to keep running, nothing to configure on the TV.

So `Debug.send()` writes each line there first:

- tagged `[vlctv]`, so it filters apart from whatever else the WebView is saying
- always, whether or not the POST half is switched on — having to enable something before a bug can be caught is what made the bug hard to catch
- `WARN`, `ERROR`, `JSERR` and `JSREJECT` go through `console.error`, so they keep DevTools' red styling and show up under its error filter

The POSTs are untouched, for capturing a session with no DevTools attached; Settings → Debug logging still governs that half alone.

`node --test tests/tizen-web-vlc/` — 71 pass; 3 new cases check that lines reach the console with nothing configured, that warnings/errors go out as console errors, and that the POST half only fires once it is both enabled and given an address.