### PR TITLE
Declare the tv.inputdevice privilege so Play/Pause and the media keys work

### DIFF
--- a/tizen-web-vlc/config.xml
+++ b/tizen-web-vlc/config.xml
@@ -51,4 +51,8 @@
     <tizen:privilege name="http://tizen.org/privilege/filesystem.read"/>
     <tizen:privilege name="http://tizen.org/privilege/filesystem.write"/>
     <tizen:privilege name="http://tizen.org/privilege/download"/>
+    <!-- Required for tizen.tvinputdevice.registerKey(); without it the TV keeps
+         Play/Pause/FF/RW and the colour keys for itself and shows a
+         "not supported" toast when they're pressed. -->
+    <tizen:privilege name="http://tizen.org/privilege/tv.inputdevice"/>
 </widget>

--- a/tizen-web-vlc/js/remote.js
+++ b/tizen-web-vlc/js/remote.js
@@ -51,8 +51,16 @@ var Remote = (function () {
             'ChannelUp', 'ChannelDown',
             'Exit',
         ];
+        var failed = [];
         for (var i = 0; i < keys.length; i++) {
-            try { tizen.tvinputdevice.registerKey(keys[i]); } catch (e) {}
+            try { tizen.tvinputdevice.registerKey(keys[i]); }
+            catch (e) { failed.push(keys[i] + ' (' + ((e && e.name) || e) + ')'); }
+        }
+        /* A SecurityError here means config.xml lacks the tv.inputdevice
+         * privilege and NO media key will reach the app — the TV shows its
+         * own "key not supported" toast instead.  Surface it loudly. */
+        if (failed.length && typeof Debug !== 'undefined') {
+            Debug.warn('registerKey failed: ' + failed.join(', '));
         }
     }
 


### PR DESCRIPTION
## What was wrong

`tizen.tvinputdevice.registerKey()` requires the `http://tizen.org/privilege/tv.inputdevice` privilege. `config.xml` never declared it, so every registration call in `remote.js` threw a SecurityError that the empty `catch` swallowed. The TV kept Play/Pause, the transport keys and the colour keys for itself and showed its own "not supported" toast when they were pressed. The keydown handlers mapping those keys have been correct all along.

This very likely also explains the media-key reports from Smart Monitors in #42: the `MediaTrackPrevious` / `MediaTrackNext` registrations added there were failing for the same reason, and the MediaSession fallback was working around this bug.

## What changed

- `tizen-web-vlc/config.xml` declares `http://tizen.org/privilege/tv.inputdevice`, with a comment explaining why. Public-level privilege, no partner approval needed.
- `tizen-web-vlc/js/remote.js` collects failed registrations and reports them once through `Debug.warn` with the error name, so a repeat of this shows up in the DevTools console instead of vanishing.

## Credit

Diagnosis and patch by @alfrededison in #71, applied as-is.

Fixes #71