### PR TITLE
Render embedded MP4 subtitles for network URLs, not just local files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ with VLC-inspired UI and TV remote-friendly navigation.
 - **Full TV remote support** — D-pad navigation, OK/BACK, media keys
   (Play/Pause/Stop/FF/RW), audio + subtitle track picker
 - **External subtitles** — SRT / VTT / ASS·SSA / SAMI sidecar files and
-  embedded MP4/MKV text tracks, painted by the app (AVPlay can't render text
-  subs on this firmware), with **customisable size, font, position and
-  background** under Settings → Subtitle appearance
+  embedded MP4/MKV text tracks — from a USB drive, an SMB share or a network
+  URL alike — painted by the app (AVPlay can't render text subs on this
+  firmware), with **customisable size, font, position and background** under
+  Settings → Subtitle appearance
 - **Every embedded track selectable** — a 40-language mux lists all 40, and
   picking one the TV's own demuxer won't select (it stops at 32 tracks) reads
   that track's text straight out of the container through its cue index, so

--- a/tests/tizen-web-vlc/mp4-subs.test.js
+++ b/tests/tizen-web-vlc/mp4-subs.test.js
@@ -292,3 +292,129 @@ test('cancels in-flight extraction without publishing callbacks', async function
     assert.strictEqual(callbackCount, 0, 'cancelled scans cannot publish callbacks');
     assert.ok(delayedReader.closed, 'reader closed on cancellation');
 });
+
+/* ── Reading an MP4 at an http(s) URL ─────────────────────────────────
+ *
+ * A network stream has no Tizen File behind it, so the extractor has to
+ * learn the file size from Content-Range and read everything through
+ * Range requests.  The fake server below answers the way the SMB proxy and
+ * the transcode server do — 206 + Content-Range — unless told to ignore
+ * Range, in which case it answers 200 with the whole file, as a naive
+ * origin would. */
+function fakeHttpServer(data, behaviour) {
+    behaviour = behaviour || {};
+    var log = { requests: [], instances: [] };
+
+    function FakeXhr() {
+        this.readyState = 0;
+        this.status = 0;
+        this.response = null;
+        this.responseType = '';
+        this.timeout = 0;
+        this.aborted = false;
+        this._req = {};
+        this._res = {};
+        log.instances.push(this);
+    }
+    FakeXhr.prototype.open = function (method, url) { this.method = method; this.url = url; };
+    FakeXhr.prototype.setRequestHeader = function (k, v) { this._req[k.toLowerCase()] = v; };
+    FakeXhr.prototype.getResponseHeader = function (k) { return this._res[k.toLowerCase()] || null; };
+    FakeXhr.prototype.abort = function () { this.aborted = true; };
+    FakeXhr.prototype.send = function () {
+        var self = this;
+        log.requests.push(this._req.range || '(no Range)');
+        setTimeout(function () {
+            var m = /^bytes=(\d+)-(\d+)$/.exec(self._req.range || '');
+            var body;
+            if (!m || behaviour.ignoreRange) {
+                self.status = 200;
+                body = data;
+                self._res['content-length'] = String(data.length);
+            } else {
+                var start = +m[1];
+                var end   = Math.min(+m[2], data.length - 1);
+                self.status = 206;
+                body = data.subarray(start, end + 1);
+                self._res['content-range'] = 'bytes ' + start + '-' + end + '/' + data.length;
+            }
+            self.readyState = 2;
+            if (self.onreadystatechange) self.onreadystatechange();
+            if (self.aborted) { if (self.onabort) self.onabort(); return; }
+            self.readyState = 4;
+            self.response = body.slice().buffer;
+            if (self.onprogress) self.onprogress({ lengthComputable: true, loaded: body.length, total: body.length });
+            if (self.onreadystatechange) self.onreadystatechange();
+            if (self.onload) self.onload();
+        }, 0);
+    };
+
+    log.XMLHttpRequest = FakeXhr;
+    return log;
+}
+
+function withFakeXhr(server, fn) {
+    var had = Object.prototype.hasOwnProperty.call(global, 'XMLHttpRequest');
+    var prev = global.XMLHttpRequest;
+    global.XMLHttpRequest = server.XMLHttpRequest;
+    return Promise.resolve().then(fn).finally(function () {
+        if (had) global.XMLHttpRequest = prev;
+        else delete global.XMLHttpRequest;
+    });
+}
+
+function openReader(source) {
+    return new Promise(function (resolve, reject) {
+        Mp4Subs.openReader(source, function (err, reader) {
+            if (err) reject(err); else resolve(reader);
+        });
+    });
+}
+
+test('opens an http URL as a range reader sized from Content-Range', async function () {
+    var data = fixture();
+    var server = fakeHttpServer(data);
+    await withFakeXhr(server, async function () {
+        var reader = await openReader('http://nas.local/movies/film.mp4');
+        var size = await new Promise(function (resolve, reject) {
+            reader.getSize(function (err, n) { if (err) reject(err); else resolve(n); });
+        });
+        assert.strictEqual(size, data.length, 'file size comes from the Content-Range total');
+        assert.deepStrictEqual(server.requests, ['bytes=0-0'], 'one single-byte probe, nothing more');
+        assert.strictEqual(server.instances[0].url, 'http://nas.local/movies/film.mp4');
+    });
+});
+
+test('extracts the embedded track of an MP4 at a URL through Range requests only', async function () {
+    var data = fixture();
+    var server = fakeHttpServer(data);
+    await withFakeXhr(server, async function () {
+        var result = await incremental('https://cdn.example/film.mp4?token=abc');
+        assert.strictEqual(result.tracks.length, 1);
+        assert.strictEqual(result.tracks[0].cues.length, 2);
+        assert.strictEqual(result.tracks[0].cues[0].text, 'Hello from a huge MP4');
+        assert.strictEqual(result.tracks[0].cues[1].text, 'Second cue');
+        assert.ok(server.requests.length > 1, 'read the moov and the samples after the probe');
+        assert.ok(server.requests.every(function (r) { return /^bytes=\d+-\d+$/.test(r); }),
+                  'every request carried a Range header: ' + server.requests.join(', '));
+    });
+});
+
+test('refuses a URL whose server ignores Range before the body is read', async function () {
+    var data = fixture();
+    var server = fakeHttpServer(data, { ignoreRange: true });
+    await withFakeXhr(server, async function () {
+        await assert.rejects(openReader('http://naive.example/film.mp4'), /does not honour Range/);
+        assert.strictEqual(server.instances.length, 1);
+        assert.ok(server.instances[0].aborted, 'the 200 was dropped at the headers, not downloaded');
+    });
+});
+
+test('non-http sources still go to the filesystem readers', async function () {
+    var server = fakeHttpServer(fixture());
+    await withFakeXhr(server, async function () {
+        // No `tizen` global in Node: the local path reports that, and must
+        // not have touched the network.
+        await assert.rejects(openReader('file:///opt/media/film.mp4'), /Tizen filesystem unavailable/);
+        assert.deepStrictEqual(server.requests, []);
+    });
+});

--- a/tizen-web-vlc/js/mp4-subs.js
+++ b/tizen-web-vlc/js/mp4-subs.js
@@ -13,7 +13,9 @@
  * after the text (style, colour, etc.) are skipped.
  *
  * Large-file flow:
- *   1. Open a generic range reader for the local file.
+ *   1. Open a generic range reader — over the Tizen filesystem for a file
+ *      on a drive, over HTTP Range requests for a URL (a network stream,
+ *      the SMB proxy, the transcode server).
  *   2. Walk top-level MP4 boxes by declared size until moov is found.
  *   3. Parse moov track/sample tables to locate supported text tracks.
  *   4. Range-read only subtitle samples and append cues to live tracks.
@@ -350,7 +352,7 @@ var Mp4Subs = (function () {
         xhr.send();
     }
 
-    /* ── Incremental local-file extractor ────────────────────────────── */
+    /* ── Incremental extractor (local file or URL) ───────────────────── */
 
     var DEFAULT_CHUNK_BYTES = 4 * 1024 * 1024;
     var DEFAULT_INTERNAL_READ_BYTES = 256 * 1024;
@@ -509,8 +511,9 @@ var Mp4Subs = (function () {
         };
     }
 
-    // Prefer browser byte-range requests for file:// URIs when available;
-    // they can read large-file offsets without loading the whole movie.
+    // Byte-range requests through XMLHttpRequest — for file:// URIs where
+    // the WebView allows them, and for every http(s) URL.  They read
+    // large-file offsets without loading the whole movie.
     function makeXhrRangeReader(uri, size, timeoutMs) {
         return {
             implementation: 'XHR Range',
@@ -662,11 +665,83 @@ var Mp4Subs = (function () {
         };
     }
 
+    /* Range reader over an http(s) URL: a network stream, the bundled SMB
+     * proxy, or the transcode server.  A URL has no fileSize to read off,
+     * so one request for the first byte settles two things at once — that
+     * the server honours Range (206, not a 200 with the whole movie behind
+     * it) and, from Content-Range's total, how big the file is.  The
+     * verdict is in the headers, so a 200 is dropped the moment they
+     * arrive rather than after the body has been pulled in. */
+    function openUrlRangeReader(uri, options, cb) {
+        if (typeof XMLHttpRequest === 'undefined') {
+            later(function () { cb(Error('no XMLHttpRequest to read ' + uri)); });
+            return;
+        }
+
+        var xhr = new XMLHttpRequest();
+        var done = false;
+
+        function finish(err, size) {
+            if (done) return;
+            done = true;
+            if (err) {
+                try { xhr.abort(); } catch (e) {}
+                cb(err instanceof Error ? err : Error(String(err)));
+                return;
+            }
+            cb(null, makeXhrRangeReader(uri, size, options.xhrRangeTimeoutMs));
+        }
+
+        function judge() {
+            if (done) return;
+            var status = xhr.status;
+            if (status !== 206) {
+                finish(Error(status === 200 ? 'server does not honour Range requests'
+                                            : 'HTTP ' + status + ' probing ' + uri));
+                return;
+            }
+            var cr = '';
+            try { cr = xhr.getResponseHeader('Content-Range') || ''; } catch (e) {}
+            var m = /\/\s*(\d+)\s*$/.exec(cr);
+            var size = m ? parseInt(m[1], 10) : NaN;
+            if (!Number.isSafeInteger(size)) {
+                finish(Error('no total in Content-Range "' + cr + '"'));
+                return;
+            }
+            finish(null, size);
+        }
+
+        try {
+            xhr.open('GET', uri, true);
+            xhr.timeout = options.xhrRangeTimeoutMs;
+            xhr.responseType = 'arraybuffer';
+            xhr.setRequestHeader('Range', 'bytes=0-0');
+        } catch (e) {
+            later(function () { finish(e); });
+            return;
+        }
+
+        xhr.onreadystatechange = function () {
+            if (xhr.readyState === 2 /* HEADERS_RECEIVED */) judge();
+        };
+        xhr.onload    = judge;   // a runtime that never reports readyState 2
+        xhr.onerror   = function () { finish(Error('probe failed: ' + uri)); };
+        xhr.ontimeout = function () { finish(Error('probe timed out: ' + uri)); };
+        xhr.send();
+    }
+
     /* Exposed as openReader() so mkv-subs.js can Range-read an MKV header
      * without duplicating the Tizen FileStream vintage handling below. */
     function openIncrementalReader(file, options, cb) {
         if (file && file.readRange && file.getSize) {
             later(function () { cb(null, file); });
+            return;
+        }
+
+        /* A URL rather than a file: nothing on the filesystem side applies. */
+        var remote = (typeof file === 'string') ? file : '';
+        if (/^https?:/i.test(remote)) {
+            openUrlRangeReader(remote, options, cb);
             return;
         }
 

--- a/tizen-web-vlc/js/player.js
+++ b/tizen-web-vlc/js/player.js
@@ -782,13 +782,31 @@ var Player = (function () {
     var containerSubTracks     = [];
     var lastContainerListToken = 0;
 
-    /* The SMB proxy and the transcode server both carry the real filename in
-     * a query parameter, so testing the path's extension alone misses them. */
-    function looksLikeMatroska(url) {
-        var u = String(url || '');
-        return /\.(mkv|webm)(\?|#|$)/i.test(u) ||
-               /[?&][^=&]+=[^&]*\.(mkv|webm)(&|$)/i.test(u);
+    /* Which container an embedded-subtitle extractor exists for — 'MP4',
+     * 'MKV' or null — judged from the URL's path and from every query
+     * value: the SMB proxy and the transcode server both carry the real
+     * filename in a parameter, so the path's extension alone misses them. */
+    function embeddedSubContainer(url) {
+        var u = String(url || '').split('#')[0];
+        var q = u.indexOf('?');
+        var names = [q < 0 ? u : u.slice(0, q)];
+        if (q >= 0) {
+            var params = u.slice(q + 1).split('&');
+            for (var i = 0; i < params.length; i++) {
+                var eq  = params[i].indexOf('=');
+                var val = eq < 0 ? params[i] : params[i].slice(eq + 1);
+                try { val = decodeURIComponent(val); } catch (e) {}
+                names.push(val);
+            }
+        }
+        for (var n = 0; n < names.length; n++) {
+            var lower = names[n].toLowerCase();
+            if (/\.(mp4|m4v|mov)$/.test(lower)) return 'MP4';
+            if (/\.(mkv|webm)$/.test(lower))    return 'MKV';
+        }
+        return null;
     }
+    function looksLikeMatroska(url) { return embeddedSubContainer(url) === 'MKV'; }
 
     function listContainerSubTracks(uri, file) {
         containerSubTracks = [];
@@ -1171,14 +1189,19 @@ var Player = (function () {
         return 'PROGRESSIVE';
     }
 
-    /* Extract embedded text-subtitle tracks from a local MP4 / MKV / WebM,
-     * write each one to wgt-private-tmp as SRT, and append them to
-     * playerSubtitles so they appear in the CC menu alongside any sibling
-     * SRTs.
+    /* Extract embedded text-subtitle tracks from an MP4 / MKV / WebM and
+     * append them to playerSubtitles so they appear in the CC menu alongside
+     * any sibling SRTs, painted by the same poller.
      *
      * Workaround for the firmware bug where AVPlay's setSelectTrack('TEXT')
-     * only delivers the first cue.  setExternalSubtitlePath delivers cues
-     * correctly per-frame, so we route embedded subs through that path.
+     * only delivers the first cue — a track shows in the menu, gets picked,
+     * and nothing appears on screen.  That bug does not care where the bytes
+     * come from, so the extraction runs for a URL as well as for a drive:
+     * MP4 Range-reads the moov and the subtitle samples alone, which is as
+     * cheap over HTTP as it is locally.  A remote MKV is the exception —
+     * MkvSubs.extract() pulls the whole file in, which over a network is
+     * the movie downloaded twice, so it keeps to listContainerSubTracks()
+     * plus the cue-index read of the one track that gets picked.
      *
      * Fire-and-forget — extraction runs in parallel with avOpen().  If the
      * user has a preferred subtitle language and the matching track gets
@@ -1194,14 +1217,20 @@ var Player = (function () {
         activeEmbeddedSubExtraction = null;
     }
     function extractAndAppendEmbeddedSubs(url, file) {
-        var lower = String(url || '').toLowerCase().split('?')[0];
-        var extractor, label;
-        if (/\.mp4$|\.m4v$|\.mov$/.test(lower) && typeof Mp4Subs !== 'undefined') {
-            extractor = Mp4Subs; label = 'MP4';
-        } else if (/\.mkv$|\.webm$/.test(lower) && typeof MkvSubs !== 'undefined') {
-            extractor = MkvSubs; label = 'MKV';
-        } else {
-            return;
+        var label = embeddedSubContainer(url);
+        var extractor;
+        if (label === 'MP4' && typeof Mp4Subs !== 'undefined')      extractor = Mp4Subs;
+        else if (label === 'MKV' && typeof MkvSubs !== 'undefined') extractor = MkvSubs;
+        else return;
+
+        if (!isLocalUrl(url)) {
+            if (!/^https?:/i.test(String(url || ''))) return;   // rtsp, udp, …
+            if (label === 'MKV') {
+                if (typeof Debug !== 'undefined')
+                    Debug.player('MKV over a URL: tracks come from the header, ' +
+                                 'the picked one is read through the cue index');
+                return;
+            }
         }
 
         var token = ++lastExtractToken;
@@ -1359,17 +1388,18 @@ var Player = (function () {
 
             // In parallel with avOpen: scan the file for embedded text
             // subtitle tracks (MP4 / MKV / WebM) and route them through the
-            // working external-subtitle pipeline.  No-op for unsupported
-            // containers.  Keyed off opts.sourceUri rather than url so it
-            // still fires when a local file is being *played* through the
-            // transcode server — then `url` is an HLS manifest with no
-            // container to sniff, while the bytes still come from the Tizen
-            // File handle in opts.file.
+            // working external-subtitle pipeline — for a file on a drive and
+            // for an MP4 at an http(s) URL alike (a network stream, the SMB
+            // proxy).  No-op for unsupported containers.  Keyed off
+            // opts.sourceUri rather than url so it still fires when a file
+            // is being *played* through the transcode server — then `url` is
+            // an HLS manifest with no container to sniff, while the bytes
+            // still come from the original source.
             var subsSourceUri = opts.sourceUri || url;
             /* Kept for the whole file: picking a track the TV can't select
                means going back to these bytes for that one track's text. */
             subsSource = { uri: subsSourceUri, file: opts.file || null };
-            if (isLocalUrl(subsSourceUri)) extractAndAppendEmbeddedSubs(subsSourceUri, opts.file);
+            extractAndAppendEmbeddedSubs(subsSourceUri, opts.file);
             /* Independent of extraction, and not limited to local files: the
              * header read works over the SMB proxy too, and it is the only
              * thing that sees every track in a big multi-language mux. */


### PR DESCRIPTION
Fixes #73 — a video opened through **Open Network Stream** lists its embedded subtitle track in the CC menu, but picking it puts nothing on screen.

## Why

Embedded text tracks on this firmware can't go through `setSelectTrack('TEXT')`: AVPlay delivers the first cue and then goes quiet, which is exactly "it's in the menu, I selected it, nothing renders". The app works around that by reading the track out of the container itself and painting it through the same poller as a sidecar `.srt`. That extraction only ran for **local** files — `open()` gated it on `isLocalUrl()`. A network MP4 fell through to the native path and hit the bug. The same was true for an MP4 on the SMB proxy (it's an `http://127.0.0.1:8127/...` URL) and, since the MP4 extractor couldn't open a URL at all, there was no cheap way to switch it on.

## What changes

**`Mp4Subs.openReader()` accepts an http(s) URL.** A URL has no `fileSize` to read off, so one `Range: bytes=0-0` request settles two things at once: that the server honours Range (206, not a 200 with the whole movie behind it) and, from the Content-Range total, how big the file is. The verdict is in the headers, so a 200 is aborted the moment they arrive instead of being downloaded. After that the existing XHR range reader does the moov and per-sample reads — the same bounded-read path a local file takes, so a 20 GB remote MP4 costs the moov plus the subtitle samples, nothing else.

**`Player.open()` runs the extraction for URL MP4s too.** The extracted tracks land in the CC menu in place of the native rows, as they already do for local files, and the language preference auto-applies the same way. `_nativeTextIndex` hints still line up because they come from `getTotalTrackInfo()`, not the source.

**Remote MKVs are left on the existing path on purpose.** `MkvSubs.extract()` loads the whole file (capped at 200 MB), which over a network would be the movie downloaded twice. A URL MKV already lists its tracks from the header (`listContainerSubTracks` works over HTTP) and reads the picked track through the cue index when the firmware doesn't act on the selection (#69), so it keeps that.

**Container detection reads query values.** The SMB proxy carries the real filename in `?path=...`; the old MP4 check split on `?` and lost it, while the MKV check had its own regex for exactly this case. One `embeddedSubContainer(url)` now decodes each query value and checks path and values alike; `looksLikeMatroska` is a one-liner on top of it.

## Not changed

- Local playback: same extractors, same gating, same order of operations.
- `rtsp://` / `udp://` and other non-HTTP schemes: no extraction attempt, native path as before.
- A URL whose server doesn't honour Range gets a clean error in the debug log and stays on the native rows — no worse than today.

## Tests

`node --test tests/tizen-web-vlc/*.test.js` — 75 pass (4 new). A fake `XMLHttpRequest` serves the existing MP4 fixture with real 206 + Content-Range answers:

- the URL reader sizes itself from Content-Range with a single one-byte probe
- the full incremental extraction over a URL yields both cues, and every request carried a `Range` header
- a server that answers 200 is refused at the headers and the request is aborted, not downloaded
- a `file://` source still goes to the filesystem readers and never touches the network

Not verified on a TV — I don't have one here. What to look for on a real set: open an MP4 with an embedded `tx3g`/`mov_text` track via Open Network Stream, wait a second or two for the menu to re-render, and the row should read `Embedded subtitle 1 (MP4)` rather than `(embedded) ...`; picking it should render. If the server ignores Range, the debug log will say `server does not honour Range requests` and the menu keeps the native row.