### PR TITLE
Only mark an embedded subtitle track selected when it is actually showing

### DIFF
--- a/tizen-web-vlc/config.xml
+++ b/tizen-web-vlc/config.xml
@@ -2,7 +2,7 @@
 <widget xmlns:tizen="http://tizen.org/ns/widgets"
         xmlns="http://www.w3.org/ns/widgets"
         id="http://madebypatrick.com/vlctv"
-        version="1.4.0"
+        version="1.4.1"
         viewmodes="maximized">
     <tizen:application id="madebypatk.vlcweb"
                        package="madebypatk"

--- a/tizen-web-vlc/js/app.js
+++ b/tizen-web-vlc/js/app.js
@@ -1732,8 +1732,29 @@
             applySubtitlePreference(prefSub, tracks);
         } else {
             subPrefSettled = true;
-            if (typeof Debug !== 'undefined') Debug.player('subtitle pref: auto (no preference set)');
+            adoptFileDefaultSubtitle(tracks);
         }
+    }
+
+    /* 'Auto (file default)': show the track the file itself marks default.
+     * AVPlay opens with that track current, and used to leave it there:
+     * the CC menu marked it selected, but the subtitle callback stays gated
+     * until a track is selected through Player.setSubtitleTrack, so nothing
+     * reached the screen until the user toggled it off and on (issue #73).
+     * Select it the way the CC menu does, so what the menu says and what
+     * the screen shows are the same thing. */
+    function adoptFileDefaultSubtitle(tracks) {
+        for (var j = 0; j < tracks.subtitle.length; j++) {
+            var st = tracks.subtitle[j];
+            if (st.off || st.muted || !st.avCurrent) continue;
+            var how = Player.setSubtitleTrack(st);
+            if (typeof Debug !== 'undefined')
+                Debug.player('subtitle pref: auto → file default ' + st.name + ' (' + how + ')');
+            return true;
+        }
+        if (typeof Debug !== 'undefined')
+            Debug.player('subtitle pref: auto — file has no default subtitle track');
+        return false;
     }
 
     /* Score every candidate and take the best.  External subs are reliable

--- a/tizen-web-vlc/js/player.js
+++ b/tizen-web-vlc/js/player.js
@@ -268,8 +268,12 @@ var Player = (function () {
      * the firmware's stray "first cue of the default-selected embedded TEXT
      * track" fire at file-open doesn't flash on screen when the user has
      * subs off or has picked an external sub.  Flipped to true only when
-     * the user explicitly selects an embed:N entry from the CC menu, and
-     * back to false on "off" / external / new file. */
+     * an embed:N entry goes through setSubtitleTrack — the CC menu, or the
+     * 'Auto (file default)' preference adopting the track AVPlay opened on
+     * — and back to false on "off" / external / new file.  It is also what
+     * getTracks() reports as active: AVPlay keeps naming a "current" TEXT
+     * track even while silenced, so its word alone would mark a track as
+     * showing when nothing is painted (issue #73). */
     var avNativeSubsAllowed = false;
     function subEl() { return document.getElementById('subtitle-overlay'); }
     /* `runs` is optional and only ever set by the ASS path: a list of
@@ -1801,8 +1805,13 @@ var Player = (function () {
                         mkvTrack:     ct.number,
                         extractable:  containerSubExtractable(ct),
                         beyondAvplay: !known,
+                        /* The track AVPlay opened on — the file's default.
+                         * Not the same as showing: it is only painted once
+                         * selected through setSubtitleTrack. */
+                        avCurrent:    cIdx === activeTextIdx,
                         active: got ? (currentExternalSub === got)
-                                    : (!currentExternalSub && cIdx === activeTextIdx)
+                                    : (!currentExternalSub && avNativeSubsAllowed &&
+                                       cIdx === activeTextIdx)
                     });
                 }
                 disambiguateLabels(containerRows, containerSubTracks);
@@ -1823,10 +1832,13 @@ var Player = (function () {
                         type:   'AVPLAY_EMBED',
                         mkvTrack:    cnt ? cnt.number : 0,
                         extractable: cnt ? containerSubExtractable(cnt) : false,
+                        avCurrent:   nt.index === activeTextIdx,
                         // Only count as active if it's the currently selected
-                        // TEXT track AND no external sub is overriding it.
+                        // TEXT track, we are actually painting it, AND no
+                        // external sub is overriding it.
                         active: ext ? (currentExternalSub === ext)
-                                    : (!currentExternalSub && nt.index === activeTextIdx)
+                                    : (!currentExternalSub && avNativeSubsAllowed &&
+                                       nt.index === activeTextIdx)
                     });
                 }
             }

--- a/tizen-web-vlc/js/settings.js
+++ b/tizen-web-vlc/js/settings.js
@@ -8,7 +8,7 @@ var Settings = (function () {
     var KEY = 'vlctv_settings_v1';
     var defaults = {
         audioLang:        '',          // '' = auto (use file's default), or ISO code
-        subtitleLang:     'off',       // 'off' = no subs, '' = auto-pick first, or ISO code
+        subtitleLang:     'off',       // 'off' = no subs, '' = auto (file's default track), or ISO code
         repeatMode:       'off',       // 'off' | 'one'
         autoPlay:         false,       // auto-play the next file in the folder when one finishes
         shuffle:          false,       // randomize playlist order (folder + recent) instead of alphabetical


### PR DESCRIPTION
Fixes #73 (follow-up to the MKV report in https://github.com/PatrickSt1991/vlc-tizen-tv/issues/73#issuecomment-5556996182).

## What the reporter saw

MKV over a network URL: the CC menu opens with the embedded track already marked selected, but nothing is on screen. Turning it off and on again makes the subtitles render.

## Why

AVPlay opens a file with one TEXT track already "current" and keeps reporting it through `getCurrentStreamInfo()` even after `setSilentSubtitle(true)`. `getTracks()` used that alone to decide which row is active, so the menu marked the firmware's current track as selected at file open. Nothing was painted, because the subtitle callback is gated (`avNativeSubsAllowed`) until a track is picked through `setSubtitleTrack`. The off/on toggle is what flips that gate, which is why it "fixed" it.

The default preference is `Off`, so this hit anyone who never touched the setting. The `Auto (file default)` option was also a no-op on AVPlay: it never selected anything.

## Change

- `getTracks()` marks a native embedded row active only while we are actually painting it, and exposes the track AVPlay opened on as `avCurrent`.
- `Auto (file default)` now selects that track through `Player.setSubtitleTrack`, the same path the CC menu uses, so what the menu says and what the screen shows agree in every mode:
  - **Off** shows Off, nothing rendered.
  - **Auto** renders the file's default track and marks it selected.
  - **A language** picks its match as before.
- Second commit bumps `config.xml` to **1.4.1** so the merge cuts the release with the new number.

Note for the reporter: with the setting at its default (`Off`), the menu will now correctly open on Off. Picking the track renders it, and choosing `Auto (file default)` in Settings makes it come up on its own.

## Verification

`node --check` on the three touched files, and the test suite (75 pass). Not run on a TV: `player.js` and `app.js` are DOM-bound and outside the pure-module tests.
