### PR TITLE
Log the whole SMB path, and read \\server\share the way Windows writes it

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,29 @@ experience, supported path.
 - Samsung Tizen TV AVPlay API docs
 - [tizen-jellyfin-avplay](https://github.com/PatrickSt1991/tizen-jellyfin-avplay) — workflow template inspiration
 
+## Reading the app's log
+
+Every debug line the app writes goes to the browser console, tagged `[vlctv]`,
+and needs nothing switched on first. To see it live:
+
+1. In Apps2Samsung, open **Installed apps → VLC TV → Debug**. This starts the
+   app in debug mode and opens `chrome://inspect` for you.
+2. Click **inspect** on the VLC TV entry. A DevTools window opens; type `vlctv`
+   in the console's filter box to hide the TV's own noise.
+3. Reproduce the problem. Warnings and errors show in red, and the Errors
+   filter picks them out.
+
+The SMB code logs under the `[SMB]` tag: what was saved (server, port, share,
+user, password length), why the share browser sent you back to Settings, the
+service launch, and the connection itself. Lines starting `svc` come from the
+background service that speaks SMB2 (its `NEGOTIATE` / `SESSION_SETUP` /
+`TREE_CONNECT` trail and socket errors); the service runs as a separate process
+and does not show up in `chrome://inspect`, so the app pulls its log and
+forwards it after each connection step.
+
+If you'd rather capture a session without DevTools attached, **Settings → Debug
+logging** POSTs the same lines to an HTTP listener on your PC. It ships off.
+
 ## Support
 
 If VLC TV is useful to you, consider supporting development:

--- a/tests/tizen-web-vlc/smb-settings.test.js
+++ b/tests/tizen-web-vlc/smb-settings.test.js
@@ -1,0 +1,105 @@
+'use strict';
+
+var assert = require('assert');
+var test   = require('node:test');
+var fs     = require('fs');
+var vm     = require('vm');
+var path   = require('path');
+
+var SRC = fs.readFileSync(
+    path.join(__dirname, '../../tizen-web-vlc/js/smb.js'), 'utf8');
+
+/* smb.js expects a browser and a Debug module; stub both so what the Save
+ * button stores and what it logs can be checked without a TV. */
+function loadSmb(fields) {
+    var store  = {};
+    var lines  = [];
+    var toasts = [];
+    var handlers = {};
+    var inputs = {};
+    ['host', 'port', 'share', 'user', 'pass', 'domain'].forEach(function (k) {
+        inputs['smb-' + k] = { value: (fields && fields[k]) || '' };
+    });
+    var buttons = {
+        'smb-save': { addEventListener: function (ev, fn) { handlers.save = fn; } },
+        'smb-anon': { addEventListener: function (ev, fn) { handlers.anon = fn; } },
+        'smb-anon-val': { textContent: '' }
+    };
+
+    var sandbox = {
+        module: { exports: {} },
+        Debug:  { send: function (tag, msg) { lines.push('[' + tag + '] ' + msg); } },
+        UI:     { toast: function (m) { toasts.push(m); } },
+        localStorage: {
+            getItem: function (k) { return Object.prototype.hasOwnProperty.call(store, k) ? store[k] : null; },
+            setItem: function (k, v) { store[k] = String(v); }
+        },
+        document: {
+            readyState: 'complete',
+            addEventListener: function () {},
+            getElementById: function (id) { return inputs[id] || buttons[id] || null; }
+        },
+        window: {},
+        XMLHttpRequest: function () {
+            this.open = function () {}; this.setRequestHeader = function () {}; this.send = function () {};
+        }
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(SRC, sandbox);
+
+    return {
+        SMB: sandbox.module.exports,
+        save: function () { handlers.save(); },
+        saved: function () { return JSON.parse(store['vlctv_smb_v1'] || '{}'); },
+        lines: lines,
+        toasts: toasts
+    };
+}
+
+test('normalizeServer accepts every spelling of a server a user is likely to type', function () {
+    var raw = loadSmb().SMB.normalizeServer;
+    // The object comes from the vm context, so copy its fields before comparing.
+    var n = function (x) { var r = raw(x); return { host: r.host, port: r.port, share: r.share }; };
+    assert.deepStrictEqual(n('192.168.1.10'),            { host: '192.168.1.10', port: 0,   share: '' });
+    assert.deepStrictEqual(n('  nas.local:4450 '),       { host: 'nas.local',    port: 4450, share: '' });
+    assert.deepStrictEqual(n('smb://nas/Media'),         { host: 'nas',          port: 0,   share: 'Media' });
+    assert.deepStrictEqual(n('//nas/Media/Films'),       { host: 'nas',          port: 0,   share: 'Media' });
+    assert.deepStrictEqual(n('\\\\nas\\Media'),          { host: 'nas',          port: 0,   share: 'Media' });
+    assert.deepStrictEqual(n('\\\\192.168.1.10:445\\Media\\'), { host: '192.168.1.10', port: 445, share: 'Media' });
+    assert.deepStrictEqual(n('[fe80::1]:445'),           { host: 'fe80::1',      port: 445, share: '' });
+});
+
+test('saving a UNC path with an empty Share field takes the share from the path', function () {
+    var t = loadSmb({ host: '\\\\nas\\Media', user: 'patrick', pass: 'secret' });
+    t.save();
+    var c = t.saved();
+    assert.strictEqual(c.host, 'nas');
+    assert.strictEqual(c.share, 'Media');
+    assert.strictEqual(c.port, 445);
+    assert.ok(t.toasts.indexOf('SMB server saved') >= 0);
+    assert.strictEqual(t.toasts.length, 1, 'no warning when host and share are both present');
+});
+
+test('an explicit Share field wins over the path typed after the host', function () {
+    var t = loadSmb({ host: 'smb://nas/Media', share: 'Backup' });
+    t.save();
+    assert.strictEqual(t.saved().share, 'Backup');
+});
+
+test('saving logs what was stored, without the password itself', function () {
+    var t = loadSmb({ host: '192.168.1.10:4450', share: 'Media', user: 'patrick', pass: 'hunter2' });
+    t.save();
+    var line = t.lines.filter(function (l) { return /settings saved/.test(l); })[0];
+    assert.ok(line, 'a settings-saved line should be logged: ' + JSON.stringify(t.lines));
+    assert.ok(/^\[SMB\]/.test(line));
+    assert.ok(/host="192\.168\.1\.10" port=4450 share="Media" user="patrick" pass=7 chars/.test(line), line);
+    assert.ok(line.indexOf('hunter2') < 0, 'the password must not be logged');
+});
+
+test('saving with the share missing says so, in the log and on screen', function () {
+    var t = loadSmb({ host: '192.168.1.10' });
+    t.save();
+    var line = t.lines.filter(function (l) { return /settings saved/.test(l); })[0];
+    assert.ok(/host and share are both required/.test(line), line);
+    assert.ok(t.toasts.indexOf('Share name is missing') >= 0, JSON.stringify(t.toasts));
+});

--- a/tizen-web-vlc/config.xml
+++ b/tizen-web-vlc/config.xml
@@ -2,7 +2,7 @@
 <widget xmlns:tizen="http://tizen.org/ns/widgets"
         xmlns="http://www.w3.org/ns/widgets"
         id="http://madebypatrick.com/vlctv"
-        version="1.4.1"
+        version="1.4.2"
         viewmodes="maximized">
     <tizen:application id="madebypatk.vlcweb"
                        package="madebypatk"

--- a/tizen-web-vlc/js/smb.js
+++ b/tizen-web-vlc/js/smb.js
@@ -17,19 +17,29 @@ var SMB = (function () {
     var BASE = 'http://127.0.0.1:8127';
     var CREDS_KEY = 'vlctv_smb_v1';
 
-    /* All SMB-side activity goes to the PC debug listener under one tag so the
-     * connection flow is actually traceable (the old code called Debug.log,
-     * which doesn't exist, so nothing was ever sent). */
+    /* All SMB-side activity goes out through Debug under one tag, so it lands
+     * in the DevTools console (and the PC listener, if one is configured) and
+     * the connection flow is traceable end to end. */
     function dbg(msg) { if (typeof Debug !== 'undefined' && Debug.send) Debug.send('SMB', msg); }
 
-    /* Pull the service's own ring-buffer log and forward the tail to the PC
-     * listener — this is how we see the NEGOTIATE / auth / socket errors that
-     * happen inside the background service, which can't reach the PC itself. */
-    function dumpServiceLogs() {
+    /* Pull the service's own ring-buffer log and forward it under the SMB tag.
+     * The service is a separate process: its console is not the one DevTools
+     * shows when the app is inspected, so this is the only way the NEGOTIATE /
+     * auth / socket trail from inside it reaches the console (or the PC
+     * listener).  Called at each step of the connection flow, not just after
+     * a failure, and only the lines that arrived since the previous pull are
+     * forwarded so the trail reads in order without repeats. */
+    var lastSvcLine = null;
+    function dumpServiceLogs(why) {
         getJson(BASE + '/smb/debug/logs', function (err, res) {
             if (err || !res || !res.logs) { dbg('service logs unavailable: ' + (err ? err.message : 'none')); return; }
-            var logs = res.logs, from = Math.max(0, logs.length - 40);
-            for (var i = from; i < logs.length; i++) dbg('svc ' + logs[i]);
+            var logs = res.logs;
+            var from = lastSvcLine === null ? -1 : logs.lastIndexOf(lastSvcLine);
+            if (from < 0) from = Math.max(0, logs.length - 40) - 1;   // first pull, or ring buffer rolled past us
+            if (from + 1 >= logs.length) { dbg('svc (no new lines' + (why ? ', ' + why : '') + ')'); return; }
+            dbg('svc --- ' + (logs.length - from - 1) + ' line(s)' + (why ? ' after ' + why : '') + ' ---');
+            for (var i = from + 1; i < logs.length; i++) dbg('svc ' + logs[i]);
+            lastSvcLine = logs[logs.length - 1];
         });
     }
 
@@ -42,19 +52,26 @@ var SMB = (function () {
         try { localStorage.setItem(CREDS_KEY, JSON.stringify(c || {})); } catch (e) {}
     }
 
-    /* Accept smb://host:port, //host/share, host:port, or a bare host. Split
-     * the port out so it can reach the proxy (SmbConnection only honours
-     * opts.port), and never leave a colon in host: net.connect treats
-     * "ip:port" as a hostname and getaddrinfo ENOTFOUNDs it. */
+    /* Accept smb://host:port, //host/share, \\host\share, host:port, or a
+     * bare host. Split the port out so it can reach the proxy (SmbConnection
+     * only honours opts.port), and never leave a colon in host: net.connect
+     * treats "ip:port" as a hostname and getaddrinfo ENOTFOUNDs it.  Windows
+     * users type the share the way Explorer shows it, backslashes included,
+     * so those count as separators too.  Whatever followed the host is
+     * returned as `share` so the form can fall back on it when the Share
+     * field was left empty. */
     function normalizeServer(raw) {
         var s = String(raw == null ? '' : raw).trim();
-        s = s.replace(/^smb:\/\//i, '').replace(/^\/+/, ''); // drop scheme + slashes
-        s = s.split('/')[0];                                 // drop any host/share tail
+        s = s.replace(/\\/g, '/');                              // \\host\share → //host/share
+        s = s.replace(/^smb:\/\//i, '').replace(/^\/+/, '');   // drop scheme + leading slashes
+        var parts = s.split('/');
+        s = parts[0];
+        var share = (parts[1] || '').trim();
         var port = 0;
         var m = s.match(/^(\[[^\]]+\]|[^:]+):(\d+)$/);        // host:port (IPv6 in [])
         if (m) { s = m[1]; port = parseInt(m[2], 10); }
         s = s.replace(/^\[|\]$/g, '');                        // unwrap bare [ipv6]
-        return { host: s, port: port };
+        return { host: s, port: port, share: share };
     }
     function haveCreds() { var c = getCreds(); return !!(c.host && c.share); }
 
@@ -184,7 +201,12 @@ var SMB = (function () {
 
         list(path, function (err, entries) {
             ul.innerHTML = '';
-            if (err) { showError(err.message); return; }
+            if (err) {
+                dbg('list ' + JSON.stringify(path || '/') + ' failed: ' + err.message);
+                dumpServiceLogs('list failure');
+                showError(err.message);
+                return;
+            }
 
             // Playable files in this folder → the playlist for next/prev/auto-play.
             var playlist = entries
@@ -258,6 +280,9 @@ var SMB = (function () {
     /* Entry point from the home tile. */
     function openBrowser() {
         if (!haveCreds()) {
+            var c0 = getCreds();
+            dbg('openBrowser: no usable server saved (host=' + JSON.stringify(c0.host || '') +
+                ' share=' + JSON.stringify(c0.share || '') + ') → sending to Settings');
             UI.toast('Add your SMB server in Settings first');
             if (window.VlcApp && window.VlcApp.openSettings) window.VlcApp.openSettings();
             return;
@@ -277,12 +302,14 @@ var SMB = (function () {
         dbg('openBrowser');
         ensureService(function (err) {
             if (err) { dbg('ensureService failed: ' + err.message); showError(err.message); return; }
+            dumpServiceLogs('service start');
             connect(function (err2) {
                 if (err2) {
                     showError('Could not connect: ' + err2.message + ' — press Back to return');
-                    dumpServiceLogs();   // surface the service-side NEGOTIATE/auth/socket trail
+                    dumpServiceLogs('connect failure');   // the service-side NEGOTIATE/auth/socket trail
                     return;
                 }
+                dumpServiceLogs('connect');
                 render('');
             });
         });
@@ -336,13 +363,26 @@ var SMB = (function () {
                 nc[k] = el ? el.value.trim() : '';
             });
             nc.anonymous = anonState;
+            var typedHost = nc.host;
             var sv = normalizeServer(nc.host);
             nc.host = sv.host;
+            // Share precedence: explicit Share field > the path typed after the
+            // host (smb://nas/Media, \\nas\Media) > nothing.
+            if (!nc.share && sv.share) nc.share = sv.share;
             // Port precedence: explicit Port field > inline host:port > default.
             var typedPort = parseInt(nc.port, 10);
             nc.port = typedPort || sv.port || 445;
             setCreds(nc);
+            dbg('settings saved: typed host=' + JSON.stringify(typedHost) +
+                ' → host=' + JSON.stringify(nc.host) + ' port=' + nc.port +
+                ' share=' + JSON.stringify(nc.share) +
+                ' user=' + (nc.anonymous ? '(guest)' : JSON.stringify(nc.user || '')) +
+                ' pass=' + (nc.pass ? nc.pass.length + ' chars' : 'none') +
+                (nc.domain ? ' domain=' + JSON.stringify(nc.domain) : '') +
+                (nc.host && nc.share ? '' : '  ** host and share are both required **'));
             UI.toast('SMB server saved');
+            if (!nc.host || !nc.share)
+                UI.toast(nc.host ? 'Share name is missing' : 'Server address is missing');
         });
     }
 
@@ -363,6 +403,10 @@ var SMB = (function () {
         applyCreds:      applyCreds,
         streamUrl:       streamUrl,
         dumpServiceLogs: dumpServiceLogs,
+        normalizeServer: normalizeServer,   // exposed for the Node tests
         isStreamUrl:     function (u) { return typeof u === 'string' && u.indexOf(BASE + '/smb/stream') === 0; }
     };
 })();
+
+// Ignored by the Tizen/browser build; lets Node tests drive the module.
+if (typeof module !== 'undefined' && module.exports) module.exports = SMB;

--- a/tizen-web-vlc/service/service.js
+++ b/tizen-web-vlc/service/service.js
@@ -786,7 +786,13 @@ function handleConnect(req, res) {
     req.on('end', function () {
         var creds;
         try { creds = JSON.parse(raw || '{}'); } catch (e) { return sendJson(res, 400, { ok: false, error: 'bad json' }); }
-        if (!creds.host || !creds.share) return sendJson(res, 400, { ok: false, error: 'host and share required' });
+        log('CONNECT_REQ', { host: creds.host, port: creds.port || 445, share: creds.share,
+                             user: creds.anonymous ? '(guest)' : (creds.user || ''),
+                             domain: creds.domain || '', pass: creds.pass ? creds.pass.length + ' chars' : 'none' });
+        if (!creds.host || !creds.share) {
+            log('CONNECT_REJECTED', 'host and share required');
+            return sendJson(res, 400, { ok: false, error: 'host and share required' });
+        }
         // Drop any stale connection for this share so creds changes take effect.
         var key = connKey(creds);
         if (conns[key]) { try { conns[key]._die('reconnect'); } catch (e) {} delete conns[key]; }
@@ -797,6 +803,7 @@ function handleConnect(req, res) {
             getConn(creds, function (err, c) {
                 if (err) { log('CONNECT_FAIL', err.message); return sendJson(res, 502, { ok: false, error: err.message }); }
                 lastCreds = creds;
+                log('CONNECT_OK', { dialect: '0x' + c.dialect.toString(16), signing: c.signing });
                 sendJson(res, 200, { ok: true, dialect: '0x' + c.dialect.toString(16), signing: c.signing });
             });
         } catch (e) {


### PR DESCRIPTION
## Why

A user reported *"it doesn't seem to pick up my SMB server, even though I saved the settings"*, and the log had nothing to say about it. Save logged nothing, the SMB tile bailed to Settings with only a toast when the stored host or share was empty, and the background service's log was only pulled after a connect had already failed. Now that Apps2Samsung → Debug gives everyone a live DevTools console (#70), the SMB path should be readable there end to end.

## What changes

**Logging (the ask)**
- Save logs what it stored: typed host → normalised host, port, share, user, password *length*. Never the password.
- Save toasts "Server address is missing" / "Share name is missing" when the result can't connect, rather than only "SMB server saved".
- The SMB tile logs why it sends someone to Settings (which of host/share was empty).
- The service log (`svc …` lines: NEGOTIATE / SESSION_SETUP / TREE_CONNECT / socket errors) is pulled after the service comes up, after connect (ok or not), and after a failed list. Only lines since the last pull are forwarded, so the trail is in order with no repeats.
- The service logs each `CONNECT_REQ` (no password) and `CONNECT_OK` / `CONNECT_FAIL`.
- README gains a "Reading the app's log" section describing the Apps2Samsung → Debug → `chrome://inspect` route.

**Parsing (a likely cause of the report)**
- `normalizeServer()` treats backslashes as separators, so `\\nas\Media` yields host `nas` instead of a hostname that ENOTFOUNDs.
- When the Share field is empty, the share typed after the host (`smb://nas/Media`, `\\nas\Media`) is used. An explicit Share field still wins.

## Impact on existing setups

- Saved credentials are untouched; nothing is migrated. Anyone whose settings already work sees no change besides more log lines.
- Anyone who typed `\\host\share` before had a host with backslashes in it. Re-saving fixes it now; until then they get the same failure as before.
- The `[SMB]` log now includes the server address, share, and username. It goes to the DevTools console and, only if enabled, the PC listener. Same exposure as the existing `connect ->` line.

## Tests

New `tests/tizen-web-vlc/smb-settings.test.js` (5 tests) loads `smb.js` in a vm sandbox and checks the parser, share fallback, save logging, and password masking.

```
node --test tests/tizen-web-vlc/*.test.js
# tests 80 / pass 80 / fail 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)